### PR TITLE
Fixed Storybook's Viewport sizing after update

### DIFF
--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.less
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.less
@@ -41,7 +41,7 @@
 	// storybook's structure to update that goofy rule to a rational one.
 	// The :not() bit targets only non-enact elements, so if a story doesn't use withInfo, and a
 	// `div` isn't added, the components aren't being told to be a different size/position.
-	.storyCell > div:not([class]):not([style]):first-child {
+	.storyCell > div:not([class]):first-child {
 		position: relative;
 		width: 100%;
 		height: 100%;


### PR DESCRIPTION
The recent Storybook update changed around the DOM a little, breaking our hack to get the viewport to fill the screen, rather than shrink.

This change relaxes the selector just enough to let it attach properly to the Storybook story wrapper and apply our sizing rules.