### PR TITLE
PLAT-100154: Link develop Enact in theme library Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - npm install
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact node_modules/.enact
-    - cd node_modules/.enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - pushd ../enact
     - npm install
     - npm run bootstrap -- --ignore enact-sampler
     - npm run link-all
-    - cd ../..
+    - popd
+    - npm install
     - enact link
 script:
     - echo -e "\x1b\x5b35;1m*** Starting tests...\x1b\x5b0m"


### PR DESCRIPTION
Adds setup steps to clone `develop` of Enact, bootstrap Enact, and use it linked into sandstone.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>