### PR TITLE
PLAT-100369: Fixed default prop value for lists

### DIFF
--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -188,7 +188,7 @@ VirtualList.defaultProps = {
 		scrollbarButton: false,
 		wheel: true
 	},
-	preventBubblingOnKeyDown: 'none',
+	preventBubblingOnKeyDown: 'programmatic',
 	role: 'list',
 	type: 'JS',
 	verticalScrollbar: 'auto'
@@ -359,7 +359,7 @@ VirtualGridList.defaultProps = {
 		scrollbarButton: false,
 		wheel: true
 	},
-	preventBubblingOnKeyDown: 'none',
+	preventBubblingOnKeyDown: 'programmatic',
 	role: 'list',
 	type: 'JS',
 	verticalScrollbar: 'auto'


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When spot moves between scroll buttons, `onKeyDown` occurs on apps due to wrong default prop value of lists.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed the default prop value

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This change is to fix UI test failure for future works on `develop` branch until we remove buttons.

### Links
[//]: # (Related issues, references)
PLAT-100369
