### PR TITLE
PLAT-100538: Fix focus disappeared when jumping from the first to the end item by 'up' key in VirtualList

### DIFF
--- a/Item/Item.js
+++ b/Item/Item.js
@@ -229,6 +229,7 @@ const ItemBase = kind({
  * @class ItemDecorator
  * @hoc
  * @memberof sandstone/Item
+ * @mixes ui/Item.ItemDecorator
  * @mixes ui/Slottable.Slottable
  * @mixes spotlight/Spottable.Spottable
  * @mixes sandstone/Marquee.MarqueeController


### PR DESCRIPTION
**Issue Resolved / Feature Added**
Focus disappeared when jumping from the first to the end item by 'up' key when `wrap` prop is `true` in VirtualList.

**Resolution**
VirtualList focuses on an item that currently not yet exists but will create later via ref. So setting `ref` to the right component is important.
`Item` is widely used for rendering items for VirtualList. So we need to make sure `ref` is passing to the right spot.
This issue is caused by the current `Item` component's structure. In the current definition of `ItemDecorator`, it has `ForwardRef` at the outermost but after `Pure`, there is another `ForwardRef` hoc used by `ui/Item.ItemDecorator`. If we applied `ForwardRef` at the outermost point, `ref` could safely travel through the stack but in this case, it doesn't.

```javascript
// sandstone
const ItemDecorator = compose(
	ForwardRef({prop: 'componentRef'}),
	Slottable({slots: ['label', 'slotAfter', 'slotBefore']}),
	Pure,
	UiItemDecorator,
	Spottable,
	MarqueeController({marqueeOnFocus: true, invalidateProps: ['inline', 'autoHide']}),
	Skinnable
);

// ui
const ItemDecorator = compose(
	ForwardRef({prop: 'componentRef'}), // -> This one should be omitted.
	Touchable
);
```
So in this PR, I've changed using `ui/Item.ItemDecorator` to `Touchable` which one that left after omitting `ForwardRef` from `ui/Item.ItemDecorator`.

