### PR TITLE
PLAT-99721: Apply Fadeout effect to Scroller

### DIFF
--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -543,8 +543,8 @@ const useScroll = (props) => {
 
 	decorateChildProps('childProps', {
 		className: [
-			!isHorizontalScrollbarVisible && isVerticalScrollbarVisible ? css.verticalOnly : null,
-			isHorizontalScrollbarVisible && !isVerticalScrollbarVisible ? css.horizontalOnly : null,
+			!isHorizontalScrollbarVisible && isVerticalScrollbarVisible ? css.verticalFadeout : null,
+			isHorizontalScrollbarVisible && !isVerticalScrollbarVisible ? css.horizontalFadeout : null,
 			css.contentWrapper
 		],
 		onUpdate: handleScrollerUpdate,

--- a/Scrollable/Scrollable.module.less
+++ b/Scrollable/Scrollable.module.less
@@ -11,14 +11,14 @@
 		box-sizing: border-box;
 		padding: var(--scroll-fadeout-size);
 
-		&.verticalOnly {
+		&.verticalFadeout {
 			-webkit-mask-image: -webkit-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,1) 48px, rgba(0,0,0,1) calc(100% - 48px), rgba(0,0,0,0));
-			-webkit-mask-image: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,1) 48px, rgba(0,0,0,1) calc(100% - 48px), rgba(0,0,0,0));
+			mask-image: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,1) 48px, rgba(0,0,0,1) calc(100% - 48px), rgba(0,0,0,0));
 		}
 
-		&.horizontalOnly {
+		&.horizontalFadeout {
 			-webkit-mask-image: -webkit-linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,1) 48px, rgba(0,0,0,1) calc(100% - 48px), rgba(0,0,0,0));
-			-webkit-mask-image: linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,1) 48px, rgba(0,0,0,1) calc(100% - 48px), rgba(0,0,0,0));
+			mask-image: linear-gradient(left, rgba(0,0,0,0), rgba(0,0,0,1) 48px, rgba(0,0,0,1) calc(100% - 48px), rgba(0,0,0,0));
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

According to the new GUI, it is needed to apply fade out effect on the items sticking to the VirtualList and Scroller boundaries. This effect is available when only vertical scrollbar or only horizontal scrollbar shows.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

- The `decorateChildProps` were called twice for props.  It would be better to be call it once for each prop.

- If hovering the clipped item, then the item will be not over but under the fadeout effect.
![image](https://user-images.githubusercontent.com/4239873/74707911-76196280-525e-11ea-9459-606e07b93c9f.png)

### Links
[//]: # (Related issues, references)

PLAT-99721

### Comments
