### PR TITLE
PLAT-99113: Support stretched vertical scrollbar 

### DIFF
--- a/Scrollable/Scrollbar.js
+++ b/Scrollable/Scrollbar.js
@@ -1,12 +1,13 @@
 // import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {forwardRef, memo, useImperativeHandle, useRef} from 'react';
 
 import ScrollThumb from './ScrollThumb';
 // import Skinnable from '../Skinnable';
 
-import componentCss from './Scrollbar.module.less';
+import css from './Scrollbar.module.less';
 
 /**
  * A Sandstone-styled scroller base component.
@@ -27,6 +28,17 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 	delete rest.focusableScrollbar;
 	delete rest.rtl;
 
+	const syncHeight = (initialHiddenHeight, scrollPosition) => {
+		if (scrollbarRef.current && typeof window !== 'undefined') {
+			const
+				node = scrollbarRef.current.getContainerRef().current,
+				height = parseInt(window.getComputedStyle(node).getPropertyValue('height'));
+
+			// To scale the scrollbar height depending on the VirtualList position
+			node.style.transform = 'scale3d(1, ' + (height - initialHiddenHeight + scrollPosition) / (height) + ', 1)';
+		}
+	};
+
 	useImperativeHandle(ref, () => {
 		const {getContainerRef, showThumb, startHidingThumb, update: uiUpdate} = scrollbarRef.current;
 
@@ -36,6 +48,7 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 			},
 			showThumb,
 			startHidingThumb,
+			syncHeight,
 			uiUpdate,
 			update: (bounds) => {
 				uiUpdate(bounds);
@@ -46,8 +59,8 @@ const ScrollbarBase = memo(forwardRef((props, ref) => {
 	return (
 		<UiScrollbarBase
 			clientSize={clientSize}
-			className={className}
-			css={componentCss}
+			className={classNames(className, css.initialHiddenHeight)}
+			css={css}
 			ref={scrollbarRef}
 			vertical={vertical}
 			childRenderer={({thumbRef}) => { // eslint-disable-line react/jsx-no-bind

--- a/Scrollable/Scrollbar.module.less
+++ b/Scrollable/Scrollbar.module.less
@@ -42,3 +42,8 @@
 		}
 	}
 });
+
+.initialHiddenHeight {
+	transform-origin: center top;
+	will-change: transform;
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If the Header shrinks in a Panel, the list or the scroller is lifted up. While doing it, its vertical scrollbar height should also be stretched. 

### Resolution

The `initialHiddenHeight` prop is added to the `VirtualList` and the `Scroller` and is the gap between the reduced scroller height and the enlarged scroller height.
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-99113

### Comments

The UX team confirmed that there was no real case for the stretched horizontal scrollbar.

The design for the horizontal tab panel using the stretched vertical scrollbar in the PR, is not defined yet. So I could not create any sample for it. To verify my PR, please add the `initialHiddenHeight` in any list or scroller samples temporary.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)