### PR TITLE
PLAT-100998: Use updated CLI commands for bootstrap and clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Large-screen/TV support library for Enact, containing a variety of UI components.",
   "main": "index.js",
   "scripts": {
-    "bootstrap": "npm link && enact link && cd samples && cd sampler && npm run bootstrap",
+    "bootstrap": "enact bootstrap",
     "clean": "enact clean",
+    "cleanall": "enact clean --all",
     "lint": "enact lint --local",
     "sampler": "npm run --prefix samples/sampler serve",
     "sampler-qa": "npm run --prefix samples/sampler serve-qa",

--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "bootstrap": "npm i && enact link",
+    "bootstrap": "enact bootstrap",
+    "clean": "enact clean",
+    "cleanall": "enact clean --all",
     "lint": "enact lint --strict",
     "test": "echo \"No test suite\" && exit 0",
     "pack": "build-storybook -c .storybook -o dist",


### PR DESCRIPTION
Requires https://github.com/enactjs/cli/pull/208 for `enact clean --all` support

Ensures root `package.json` and sampler package.json` get up-to-date bootstrap, clean, cleanall run scripts.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>