### PR TITLE
PLAT-100708: Fix JSDoc parse errors

### DIFF
--- a/RadioItem/RadioItem.js
+++ b/RadioItem/RadioItem.js
@@ -54,7 +54,7 @@ const RadioItemBase = kind({
 		 *
 		 * @type {String}
 		 * @default 'circle'
-		 * @see {@link agate/Icon.Icon}
+		 * @see {@link sandstone/Icon.Icon}
 		 */
 		icon: PropTypes.string
 	},

--- a/VirtualList/VirtualListBase.js
+++ b/VirtualList/VirtualListBase.js
@@ -345,9 +345,6 @@ const useSpottable = (props, instances, context) => {
 		}
 	}
 
-	/**
-	 * Focus on the Node of the VirtualList item
-	 */
 	function focusOnNode (node) {
 		if (node) {
 			Spotlight.focus(node);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There are the following JSDoc parse errors.
```
Too many doclets (2):
sandstone/VirtualList in /Users/yb.sung/Documents/_Work/docs/raw/sandstone/VirtualList/VirtualList.js:10
focusOnNode in /Users/yb.sung/Documents/_Work/docs/raw/sandstone/VirtualList/VirtualListBase.js:353

Invalid link: agate/Icon.Icon:
    Used in: sandstone/RadioItem

```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Remove the  /* */ comment in VirtualListBase
- Rename agate/Icon as sandstone/Icon

### Links
[//]: # (Related issues, references)

PLAT-100708

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)