### PR TITLE
PLAT-101116: Updated the Header stories with a knob to show the input

### DIFF
--- a/samples/sampler/stories/default/Header.js
+++ b/samples/sampler/stories/default/Header.js
@@ -40,7 +40,8 @@ storiesOf('Sandstone', module)
 	.add(
 		'Header',
 		() => {
-			const headerInput = boolean('headerInput', Config) ? <Input placeholder="placeholder text" /> : null;
+			const headerInput = boolean('headerInput', Config, true) ? <Input placeholder="placeholder text" /> : null;
+			const showInput = boolean('showInput', Config);
 			const slotAboveSelection = select('slotAbove', ['none', 'steps'], Config);
 			const slotAbove = prop.above[slotAboveSelection];
 			const slotBeforeSelection = select('slotBefore', prop.buttonsSelection, Config);
@@ -57,6 +58,7 @@ storiesOf('Sandstone', module)
 					type={select('type', prop.type, Config)}
 					centered={boolean('centered', Config)}
 					headerInput={headerInput}
+					showInput={showInput}
 					marqueeOn={select('marqueeOn', prop.marqueeOn, Config)}
 					slotAbove={slotAbove}
 					slotBefore={slotBefore}

--- a/samples/sampler/stories/qa/Header.js
+++ b/samples/sampler/stories/qa/Header.js
@@ -227,12 +227,14 @@ storiesOf('Header.Input', module)
 		() => {
 			const addHeaderComponents = boolean('add headerComponents', Config);
 			const input = boolean('Input Mode', Config, true) ? <Input placeholder={text('placeholder', Config, inputData.longTitle)} dismissOnEnter={boolean('Input dismissOnEnter', Config, true)} /> : null;
+			const showInput = boolean('showInput', Config, true);
 			return (
 				<Header
 					title={text('title', Config, inputData.tallText)}
 					headerInput={input}
 					subtitle={text('subtitle', Config, inputData.longSubtitle)}
 					marqueeOn={select('marqueeOn', prop.marqueeOn, Config)}
+					showInput={showInput}
 				>
 					{addHeaderComponents ? headerComponents : null}
 				</Header>
@@ -244,12 +246,14 @@ storiesOf('Header.Input', module)
 		() => {
 			const addHeaderComponents = boolean('add headerComponents', Config);
 			const input = boolean('Input Mode', Config, true) ? <Input placeholder={text('placeholder', Config, inputData.longTitle)} dismissOnEnter={boolean('Input dismissOnEnter', Config, true)} /> : null;
+			const showInput = boolean('showInput', Config, true);
 			return (
 				<Header
 					headerInput={input}
 					title={text('title', Config, inputData.longTitle)}
 					subtitle={text('subtitle', Config, inputData.longSubtitle)}
 					marqueeOn={select('marqueeOn', prop.marqueeOn, Config)}
+					showInput={showInput}
 				>
 					{addHeaderComponents ? headerComponents : null}
 				</Header>


### PR DESCRIPTION
This adds a knob to both default and qa stories for Header to `showInput`. Some of the defaults changed so usage is more intuitive, but each boolean can still be turned off, to demonstrate the effects.