### PR TITLE
PLAT-101126: Replace VirtualListBase, ScrollerBase, and Scrollable with VirtualListBasic, ScrollerBasic, and useScroll

### DIFF
--- a/Scrollable/ScrollThumb.js
+++ b/Scrollable/ScrollThumb.js
@@ -1,4 +1,4 @@
-import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
+import {ScrollThumb as UiScrollThumb} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import React, {forwardRef, useEffect} from 'react';
 

--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -12,11 +12,11 @@ import Spotlight from '@enact/spotlight';
 import {spottableClass} from '@enact/spotlight/Spottable';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {getRect, intersects} from '@enact/spotlight/src/utils';
-import {useScrollBase} from '@enact/ui/Scrollable';
-import {useChildAdapter as useUiChildAdapter} from '@enact/ui/Scrollable/useChild';
-import {utilDecorateChildProps} from '@enact/ui/Scrollable';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import {useScrollBase} from '@enact/ui/useScroll';
+import {useChildAdapter as useUiChildAdapter} from '@enact/ui/useScroll/useChild';
+import {utilDecorateChildProps} from '@enact/ui/useScroll';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import PropTypes from 'prop-types';
 import React, {Component, useContext, useRef} from 'react';
 

--- a/Scrollable/Scrollbar.js
+++ b/Scrollable/Scrollbar.js
@@ -1,5 +1,5 @@
 // import ApiDecorator from '@enact/core/internal/ApiDecorator';
-import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
+import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import React, {forwardRef, memo, useImperativeHandle, useRef} from 'react';
 

--- a/Scrollable/useEvent.js
+++ b/Scrollable/useEvent.js
@@ -5,9 +5,9 @@ import {clamp} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getRect} from '@enact/spotlight/src/utils';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
-import {constants} from '@enact/ui/Scrollable';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
+import {constants} from '@enact/ui/useScroll';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
 const {animationDuration, epsilon, isPageDown, isPageUp, overscrollTypeOnce, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;

--- a/Scrollable/useOverscrollEffect.js
+++ b/Scrollable/useOverscrollEffect.js
@@ -1,5 +1,5 @@
 import {Job} from '@enact/core/util';
-import {constants} from '@enact/ui/Scrollable';
+import {constants} from '@enact/ui/useScroll';
 import {useCallback, useEffect, useRef} from 'react';
 
 const

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -13,7 +13,7 @@
  *
  * @module sandstone/Scroller
  * @exports Scroller
- * @exports ScrollerBase
+ * @exports ScrollerBasic
  */
 
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
@@ -22,8 +22,8 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import {getRect} from '@enact/spotlight/src/utils';
 import {ResizeContext} from '@enact/ui/Resizable';
 import ri from '@enact/ui/resolution';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
-import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
+import {ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
 import React, {Component, useCallback, useEffect} from 'react';
 
@@ -42,16 +42,16 @@ const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
  * [SpotlightContainerDecorator]{@link spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator}
  * and the Scrollable version, [Scroller]{@link sandstone/Scroller.Scroller}.
  *
- * @class ScrollerBase
+ * @class ScrollerBasic
  * @memberof sandstone/Scroller
- * @extends ui/Scroller.ScrollerBase
+ * @extends ui/Scroller.ScrollerBasic
  * @ui
  * @public
  */
-class ScrollerBase extends Component {
-	static displayName = 'ScrollerBase'
+class ScrollerBasic extends Component {
+	static displayName = 'ScrollerBasic'
 
-	static propTypes = /** @lends sandstone/Scroller.ScrollerBase.prototype */ {
+	static propTypes = /** @lends sandstone/Scroller.ScrollerBasic.prototype */ {
 		/**
 		 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.
 		 *
@@ -369,7 +369,7 @@ const useSpottableScroller = (props) => {
  * not move focus to the scrollbar controls.
  *
  * @name focusableScrollbar
- * @memberof sandstone/Scroller.ScrollerBase.prototype
+ * @memberof sandstone/Scroller.ScrollerBasic.prototype
  * @type {Boolean}
  * @default false
  * @public
@@ -383,7 +383,7 @@ const useSpottableScroller = (props) => {
  * `Panel`.
  *
  * @name id
- * @memberof sandstone/Scroller.ScrollerBase.prototype
+ * @memberof sandstone/Scroller.ScrollerBasic.prototype
  * @type {String}
  * @public
  */
@@ -398,7 +398,7 @@ const useSpottableScroller = (props) => {
  *
  * @class Scroller
  * @memberof sandstone/Scroller
- * @extends sandstone/Scroller.ScrollerBase
+ * @extends sandstone/Scroller.ScrollerBasic
  * @ui
  * @public
  */
@@ -428,7 +428,7 @@ let Scroller = (props) => {
 			<div {...scrollContainerProps}>
 				<div {...innerScrollContainerProps}>
 					<ChildWrapper {...childWrapperProps}>
-						<UiScrollerBase {...uiChildProps} />
+						<UiScrollerBasic {...uiChildProps} />
 					</ChildWrapper>
 				</div>
 				{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
@@ -502,5 +502,5 @@ Scroller = Skinnable(
 export default Scroller;
 export {
 	Scroller,
-	ScrollerBase
+	ScrollerBasic
 };

--- a/Scroller/useEvent.js
+++ b/Scroller/useEvent.js
@@ -1,4 +1,4 @@
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import {useRef} from 'react';
 
 const useEventKey = () => {

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -4,13 +4,13 @@
  * @module sandstone/VirtualList
  * @exports VirtualGridList
  * @exports VirtualList
- * @exports VirtualListBase
+ * @exports VirtualListBasic
  */
 
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
-import {gridListItemSizeShape, itemSizesShape, VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
+import {gridListItemSizeShape, itemSizesShape, VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
@@ -19,14 +19,14 @@ import useScroll from '../Scrollable';
 import Scrollbar from '../Scrollable/Scrollbar';
 import Skinnable from '../Skinnable';
 
-import {useSpottableVirtualList, VirtualListBase} from './VirtualListBase';
+import {useSpottableVirtualList, VirtualListBasic} from './VirtualListBasic';
 
 /**
  * A Sandstone-styled scrollable and spottable virtual list component.
  *
  * @class VirtualList
  * @memberof sandstone/VirtualList
- * @extends sandstone/VirtualList.VirtualListBase
+ * @extends sandstone/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
@@ -74,7 +74,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...innerScrollContainerProps}>
 					<ChildWrapper {...childWrapperProps}>
-						<UiVirtualListBase {...uiChildProps} />
+						<UiVirtualListBasic {...uiChildProps} />
 					</ChildWrapper>
 				</div>
 				{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
@@ -225,7 +225,7 @@ VirtualList = Skinnable(
  *
  * @class VirtualGridList
  * @memberof sandstone/VirtualList
- * @extends sandstone/VirtualList.VirtualListBase
+ * @extends sandstone/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
@@ -257,7 +257,7 @@ let VirtualGridList = ({role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...innerScrollContainerProps}>
 					<ChildWrapper {...childWrapperProps}>
-						<UiVirtualListBase {...uiChildProps} />
+						<UiVirtualListBasic {...uiChildProps} />
 					</ChildWrapper>
 				</div>
 				{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
@@ -407,5 +407,5 @@ export default VirtualList;
 export {
 	VirtualGridList,
 	VirtualList,
-	VirtualListBase
+	VirtualListBasic
 };

--- a/VirtualList/VirtualListBasic.js
+++ b/VirtualList/VirtualListBasic.js
@@ -5,7 +5,7 @@ import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import PropTypes from 'prop-types';
 import React, {Component, useCallback, useEffect, useRef} from 'react';
 
-import {dataIndexAttribute} from '../Scrollable';
+import {dataIndexAttribute} from '../Scrollable/Scrollable';
 
 import {useEventKey} from './useEvent';
 import usePreventScroll from './usePreventScroll';
@@ -17,9 +17,9 @@ const SpotlightPlaceholder = Spottable('div');
 const nop = () => {};
 
 class VirtualListCore extends Component {
-	displayName = 'VirtualListBase'
+	displayName = 'VirtualListBasic'
 
-	static propTypes = /** @lends sandstone/VirtualList.VirtualListBase.prototype */ {
+	static propTypes = /** @lends sandstone/VirtualList.VirtualListBasic.prototype */ {
 		/**
 		 * The `render` function called for each item in the list.
 		 *
@@ -202,7 +202,7 @@ const useSpottable = (props, instances, context) => {
 		isWrappedBy5way: false,
 		lastFocusedIndex: null,
 		nodeIndexToBeFocused: false,
-		pause: new Pause('VirtualListBase')
+		pause: new Pause('VirtualListBasic')
 	});
 
 	const {pause} = mutableRef.current;
@@ -560,20 +560,20 @@ const useSpottableVirtualList = (props) => {
  * A Sandstone-styled base component for [VirtualList]{@link sandstone/VirtualList.VirtualList} and
  * [VirtualGridList]{@link sandstone/VirtualList.VirtualGridList}.
  *
- * @class VirtualListBase
+ * @class VirtualListBasic
  * @memberof sandstone/VirtualList
- * @extends ui/VirtualList.VirtualListBase
+ * @extends ui/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
-const VirtualListBase = VirtualListCore;
+const VirtualListBasic = VirtualListCore;
 
 /**
  * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
  * not move focus to the scrollbar controls.
  *
  * @name focusableScrollbar
- * @memberof sandstone/VirtualList.VirtualListBase.prototype
+ * @memberof sandstone/VirtualList.VirtualListBasic.prototype
  * @type {Boolean}
  * @default false
  * @public
@@ -587,7 +587,7 @@ const VirtualListBase = VirtualListCore;
  * the `Panel`.
  *
  * @name id
- * @memberof sandstone/VirtualList.VirtualListBase.prototype
+ * @memberof sandstone/VirtualList.VirtualListBasic.prototype
  * @type {String}
  * @public
  */
@@ -630,5 +630,5 @@ function listItemsRenderer (props) {
 export default useSpottableVirtualList;
 export {
 	useSpottableVirtualList,
-	VirtualListBase
+	VirtualListBasic
 };

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -1,8 +1,8 @@
 import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import clamp from 'ramda/src/clamp';
 import {useCallback, useEffect, useRef} from 'react';
 

--- a/VirtualList/usePreventScroll.js
+++ b/VirtualList/usePreventScroll.js
@@ -1,4 +1,4 @@
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import {useEffect} from 'react';
 
 const usePreventScroll = (props, instances, context) => {

--- a/VirtualList/useSpotlight.js
+++ b/VirtualList/useSpotlight.js
@@ -1,5 +1,5 @@
 import Spotlight from '@enact/spotlight';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
 const useSpotlightConfig = (props, instances) => {

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -5,10 +5,10 @@ import ri from '@enact/ui/resolution';
 import React from 'react';
 import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 import {storiesOf} from '@storybook/react';
-import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
+import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
 import {GridListImageItem} from '@enact/sandstone/GridListImageItem';
-import {VirtualGridList, VirtualListBase} from '@enact/sandstone/VirtualList';
+import {VirtualGridList, VirtualListBasic} from '@enact/sandstone/VirtualList';
 
 const
 	wrapOption = {
@@ -63,7 +63,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const VirtualGridListConfig = mergeComponentMetadata('VirtualGridList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const VirtualGridListConfig = mergeComponentMetadata('VirtualGridList', UiVirtualListBasic, UiScrollableBase, VirtualListBasic);
 
 storiesOf('Sandstone', module)
 	.add(

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -5,10 +5,10 @@ import React from 'react';
 import ri from '@enact/ui/resolution';
 import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
 import {storiesOf} from '@storybook/react';
-import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
+import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
 import Item from '@enact/sandstone/Item';
-import VirtualList, {VirtualListBase} from '@enact/sandstone/VirtualList';
+import VirtualList, {VirtualListBasic} from '@enact/sandstone/VirtualList';
 
 const
 	wrapOption = {
@@ -52,7 +52,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBasic, UiScrollableBase, VirtualListBasic);
 
 storiesOf('Sandstone', module)
 	.add(

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -3,18 +3,18 @@ import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import ri from '@enact/ui/resolution';
 import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
-import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList/VirtualListBase';
+import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList/VirtualListBasic';
 import React from 'react';
 
 import Button from '@enact/sandstone/Button';
 import ContexturePopupDecorator from '@enact/sandstone/ContextualPopupDecorator';
 import GridListImageItem from '@enact/sandstone/GridListImageItem';
 import Item from '@enact/sandstone/Item';
-import {VirtualGridList, VirtualListBase} from '@enact/sandstone/VirtualList';
+import {VirtualGridList, VirtualListBasic} from '@enact/sandstone/VirtualList';
 
 import {storiesOf} from '@storybook/react';
 
-const Config = mergeComponentMetadata('VirtualGridList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const Config = mergeComponentMetadata('VirtualGridList', UiVirtualListBasic, UiScrollableBase, VirtualListBasic);
 
 const
 	defaultDataSize = 1000,

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -3,7 +3,7 @@ import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import ri from '@enact/ui/resolution';
 import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable';
-import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
+import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 
@@ -11,11 +11,11 @@ import Item from '@enact/sandstone/Item';
 import {ActivityPanels, Panel, Header} from '@enact/sandstone/Panels';
 import Scroller from '@enact/sandstone/Scroller';
 import SwitchItem from '@enact/sandstone/SwitchItem';
-import VirtualList, {VirtualListBase} from '@enact/sandstone/VirtualList';
+import VirtualList, {VirtualListBasic} from '@enact/sandstone/VirtualList';
 
 import {storiesOf} from '@storybook/react';
 
-const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const Config = mergeComponentMetadata('VirtualList', UiVirtualListBasic, UiScrollableBase, VirtualListBasic);
 
 const
 	itemStyle = {

--- a/samples/sampler/stories/qa/VirtualListNative.js
+++ b/samples/sampler/stories/qa/VirtualListNative.js
@@ -4,15 +4,15 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {Column, Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import {ScrollableBase as UiScrollableBase} from '@enact/ui/Scrollable/Scrollable';
-import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList/VirtualListBase';
+import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList/VirtualListBasic';
 import React from 'react';
 
 import Item from '@enact/sandstone/Item';
-import {VirtualList, VirtualListBase} from '@enact/sandstone/VirtualList';
+import {VirtualList, VirtualListBasic} from '@enact/sandstone/VirtualList';
 
 import {storiesOf} from '@storybook/react';
 
-const Config = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const Config = mergeComponentMetadata('VirtualList', UiVirtualListBasic, UiScrollableBase, VirtualListBasic);
 
 const
 	items = [],


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

All modules from ui/Scrollable were moved to ui/useScroll.
VirtualListBase from ui/VirtualList.js was replaced with VirtualListBasic
ScrollerBase from ui/Scroller.js was replaced with ScrollerBasic
So some modules should be imported from proper modules.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Import
- not ui/Scrollable but ui/useScroll
- not VirtualBase but VirtualListBasic from ui/VirtualList
- not ScrollerBase but ScrollerBasic from ui/Scroller

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

* [x] lint (strict mode, npm run lint -s)
* [x] unit test (npm run test)
* [ ] UI test (npm run test-ui)
* [ ] screenshot test (npm run test-ss)
* [x] sampler (npm run serve)
* [x] qa-sampler (npm run serve-qa)
* [x] JSDoc parse (npm run parse)

### Links
[//]: # (Related issues, references)

PLAT-101126

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)