### PR TITLE
PLAT-101271: Remove redundant padding based on scroll direction

### DIFF
--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -389,8 +389,8 @@ const useScroll = (props) => {
 			css.scroll,
 			scrollContainerHandle.current.rtl ? css.rtl : null,
 			overscrollCss.scroll,
-			(props.direction === 'horizontal' || props.direction === 'both') && (props.horizontalScrollbar !== 'hidden') ? css.horizontal : null,
-			(props.direction === 'vertical' || props.direction === 'both') && (props.verticalScrollbar !== 'hidden') ? css.vertical : null
+			(props.direction === 'horizontal' || props.direction === 'both') && (props.horizontalScrollbar !== 'hidden') ? css.horizontalPadding : null,
+			(props.direction === 'vertical' || props.direction === 'both') && (props.verticalScrollbar !== 'hidden') ? css.verticalPadding : null
 		],
 		'data-spotlight-container': spotlightContainer,
 		'data-spotlight-container-disabled': spotlightContainerDisabled,

--- a/useScroll/useScroll.module.less
+++ b/useScroll/useScroll.module.less
@@ -6,11 +6,12 @@
 	box-sizing: border-box;
 	overflow: hidden;
 
-	&.vertical {
-		padding: 0 var(--scroll-scrollbar-size);
+	&.verticalPadding {
+		padding-left: var(--scroll-scrollbar-size);
+		padding-right: var(--scroll-scrollbar-size);
 	}
 
-	&.horizontal {
+	&.horizontalPadding {
 		padding-bottom: var(--scroll-scrollbar-size);
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

By default, there were top, bottom, left, right paddings in the VirtualList and the Scroller.
So the content became more smaller.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Remove redundant padding based on scroll direction.
By default, the top padding in the scroller is removed.
If scrolling vertically, the right and the left paddings are removed.
If scrolling horizontally, the bottom paddings is removed.
Even though scrolling vertically or horizontally, if using `horizontalScrollbar` or `verticalScrollbar` with `hidden` value, then the paddings are removed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-101271

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)