### PR TITLE
Automatic Header Type (OptionPanels)

### DIFF
--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -3,6 +3,7 @@ import kind from '@enact/core/kind';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator, {spotlightDefaultClass} from '@enact/spotlight/SpotlightContainerDecorator';
 import Slottable from '@enact/ui/Slottable';
+import ComponentOverride from '@enact/ui/ComponentOverride';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -167,6 +168,15 @@ const PanelBase = kind({
 			noHeader: !header,
 			visible: !hideChildren
 		}),
+		header: ({header}, type) => (
+			// If this is a OptionPanels Panel, automatically add the "compact" type to the incoming Header component.
+			type === 'option' ?
+				<ComponentOverride
+					component={header}
+					type="compact"
+				/> :
+				header
+		),
 		// nulling headerId prevents the aria-labelledby relationship which is necessary to allow
 		// aria-label to take precedence
 		// (see https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby)


### PR DESCRIPTION
Automatically assign the prescribed type of header for the given `Panels` scenario.

This could easily be updated to also automatically apply other Header attributes for other types of Panels, like `Wizard`, `List`, `Browse`, or `Settings`.

Usage:
When a `Header` is used in a `Panel` which is inside an `OptionPanels` instance, the `type` prop is automatically chosen ("compact"). When in any other scenario, no additional props are added to Header. It could be expanded upon to feed a map of Panel(s) types -> correlated header types, so the selection is always correct.

Ex: 
* panel type === 'option' -> compact header
* panel type === 'mini' -> mini header
* panel type === 'wizard' -> wizard header
* other -> do nothing, pass header through unaltered

This saves developers time and improves consistency.