### PR TITLE
PLAT-100708: Fix VirtualList and Scroller JSDoc parse error

### DIFF
--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -41,7 +41,6 @@ import useThemeScroller from './useThemeScroller';
  *
  * @class Scroller
  * @memberof sandstone/Scroller
- * @extends sandstone/Scroller.ScrollerBasic
  * @ui
  * @public
  */

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -27,7 +27,6 @@ import {VirtualListBasic} from './VirtualListBasic';
  *
  * @class VirtualList
  * @memberof sandstone/VirtualList
- * @extends sandstone/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
@@ -225,7 +224,6 @@ VirtualList = Skinnable(
  *
  * @class VirtualGridList
  * @memberof sandstone/VirtualList
- * @extends sandstone/VirtualList.VirtualListBasic
  * @ui
  * @public
  */


### PR DESCRIPTION
Fix VirtualList and Scroller JSDoc parse error
```
Invalid reference: sandstone/VirtualList.VirtualListBasic:
    type: extends - VirtualList in docs/raw/sandstone/VirtualList/VirtualList.js:34
    type: extends - VirtualGridList in docs/raw/sandstone/VirtualList/VirtualList.js:232
Invalid reference: sandstone/Scroller.ScrollerBasic:
    type: extends - Scroller in docs/raw/sandstone/Scroller/Scroller.js:48
```

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)