### PR TITLE
PLAT-101405: Fix UI test fails in standstone VirtualList specs

### DIFF
--- a/tests/ui/specs/VirtualList/VirtualList-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList-specs.js
@@ -137,7 +137,7 @@ describe('VirtualList', function () {
 			// Wheeling will not be implemented - see ENYO-6178
 			for (let i = 0; i < 100; ++i) {
 				Page.spotlightDown();
-				Page.delay(70); // TODO: This is an arbitrary value to help provide expected behavior between rapidly repeating keydown events
+				Page.delay(100); // TODO: This is an arbitrary value to help provide expected behavior between rapidly repeating keydown events
 			}
 			// Step 7: 2. Click the last item.
 			Page.spotlightSelect();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

There were 2 UI test fails
```
1) VirtualList LTR locale should focus and Scroll with Up/Down and 5-way [GT-24451]:
step 4 focus: expected 'item9' to equal 'item8'
running chrome
AssertionError: step 4 focus: expected 'item9' to equal 'item8'
    at expectFocusedItem (/Users/yb.sung/Documents/_Work/sandstone/tests/ui/specs/VirtualList/VirtualList-utils.js:4:32)
    at Context.<anonymous> (/Users/yb.sung/Documents/_Work/sandstone/tests/ui/specs/VirtualList/VirtualList-specs.js:34:4)
    at new Promise (<anonymous>)
    at new F (/Users/yb.sung/Documents/_Work/sandstone/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js:36:28)

2) VirtualList LTR locale should not scroll when leaving list with 5-way up/down [GT-25987]:
step 7 focus: expected 'item85' to equal 'item99'
running chrome
AssertionError: step 7 focus: expected 'item85' to equal 'item99'
    at expectFocusedItem (/Users/yb.sung/Documents/_Work/sandstone/tests/ui/specs/VirtualList/VirtualList-utils.js:4:32)
    at Context.<anonymous> (/Users/yb.sung/Documents/_Work/sandstone/tests/ui/specs/VirtualList/VirtualList-specs.js:146:4)
    at new Promise (<anonymous>)
    at new F (/Users/yb.sung/Documents/_Work/sandstone/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js:36:28)
```


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Fix UI test fails in standstone VirtualList specs

1) VirtualList LTR locale should focus and Scroll with Up/Down and 5-way [GT-24451]:
step 4 focus: expected 'item9' to equal 'item8'
: The top padding in the VirtualList was removed recently and the number of the visible items were increased. So the test cases should be updated before. Now I updated it.

2) VirtualList LTR locale should not scroll when leaving list with 5-way up/down [GT-25987]:
step 7 focus: expected 'item85' to equal 'item99'
: It seemed that some 5-way down keys were ignored because those keys were generated so quickly. So I increased the delay to ~70~ 100ms between keys.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-101405

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)