### PR TITLE
PLAT-100417: Update Button size default docs

### DIFF
--- a/samples/sampler/stories/default/LabeledIcon.js
+++ b/samples/sampler/stories/default/LabeledIcon.js
@@ -11,7 +11,7 @@ import Icon, {IconBase} from '@enact/sandstone/Icon';
 import iconNames from './icons';
 
 LabeledIcon.displayName = 'LabeledIcon';
-const Config = mergeComponentMetadata('LabeledIcon', UiIcon, IconBase, Icon, UiLabeledIconBase, UiLabeledIcon);
+const Config = mergeComponentMetadata('LabeledIcon', UiLabeledIconBase, UiLabeledIcon, UiIcon, IconBase, Icon, LabeledIcon);
 
 storiesOf('Sandstone', module)
 	.add(
@@ -23,7 +23,7 @@ storiesOf('Sandstone', module)
 				inline={boolean('inline', Config)}
 				labelPosition={select('labelPosition', ['above', 'after', 'before', 'below', 'left', 'right'], Config)}
 				flip={select('flip', ['', 'both', 'horizontal', 'vertical'], Config, '')}
-				size={select('size', ['small', 'large'], Config, 'large')}
+				size={select('size', ['small', 'large'], Config)}
 			>
 				{text('children', Config, 'Hello LabeledIcon')}
 			</LabeledIcon>


### PR DESCRIPTION
I changed order of components that to merge metadata of each because `defaultProps` of `LabeledIcon` override.
![Screenshot085](https://user-images.githubusercontent.com/11263018/75953660-2b9e1400-5ef5-11ea-8f2f-ffa588d91c67.png)
