### PR TITLE
PLAT-101414: [VirtualList and Scroller] Fix sluggish scroll when key holding on scrollthumb 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller.Scroller` to scroll not sluggish when holding directional keys on scroll thumb.
+- `sandstone/Scroller.Scroller` to scroll not sluggish when holding keys on scroll thumb.
 - `sandstone/VirtualList.VirtualList` and `sandstone/VirtualList.VirtualGridList` not to suddenly jump when pressing directional keys after wheeling.
 - `sandstone/Scroller.Scroller` to wheel normally when `focusableScrollbar` prop is `byEnter`.
 

--- a/useScroll/ScrollThumb.js
+++ b/useScroll/ScrollThumb.js
@@ -36,8 +36,11 @@ let ScrollThumb = forwardRef((props, ref) => {
 		cbAlertThumb();
 	});
 
-	useEffect (()=> {
+	useEffect (() => {
 		SpotlightAccelerator.reset();
+		return () => {
+			SpotlightAccelerator.reset();
+		};
 	}, []);
 
 	const consumeEventWithScroll = useCallback((scrollParam, ev) => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was sluggish scroll bug when user holding down key on `scrollThumb`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The sluggish issue is because of too many keydown event.
So, I  apply SpotlightAccelerator for event sampling.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-101414

### Comments