### PR TITLE
ENYO-6425: WindowEventable breaking isomorphic tests

### DIFF
--- a/Input/WindowEventable.js
+++ b/Input/WindowEventable.js
@@ -35,7 +35,7 @@ const WindowEventable = hoc(defaultConfig, ({globalNode, ...events}, Wrapped) =>
 		constructor (props) {
 			super(props);
 
-			if (globalNode == null) globalNode = window;
+			if (globalNode == null && typeof window !== 'undefined') globalNode = window;
 
 			this.events = {};
 			for (let [evName, fn] of Object.entries(events)) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added / Resolution

Updates `WindowEventable` to add a safeguard on `globalNode`  fallback for `window` usage, when `window` might not exist (prerendering).

### Links
ENYO-6425

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>