### PR TITLE
ENYO-6434: Sandstone SlotItem using old icon margin variable name

### DIFF
--- a/SlotItem/SlotItem.module.less
+++ b/SlotItem/SlotItem.module.less
@@ -39,7 +39,7 @@
 		// run into the Item's content.
 		&.after {
 			> :first-child {
-				-webkit-margin-start: @sand-icon-large-margin;
+				-webkit-margin-start: @sand-icon-margin;
 			}
 
 			> :last-child {
@@ -53,7 +53,7 @@
 			}
 
 			> :last-child {
-				-webkit-margin-end: @sand-icon-large-margin;
+				-webkit-margin-end: @sand-icon-margin;
 			}
 		}
 	}


### PR DESCRIPTION
The LESS variable for icon margin changed in https://github.com/enyojs/sandstone/pull/94 however SlotItem is still using the old `@sand-icon-large-margin`. As a result, it fails to build.

This change updates to use the current variable name for the icon margin, `@sand-icon-margin`.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>
