### PR TITLE
PLAT-102872: Fix video player to seek using left, right key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/VideoPlayer` to seek playing time using left, right key
 - `sandstone/Panels.Header` to always vertically center the input field
 - `sandstone/ImageItem` not to have truncated label in RTL
 - `sandstone/VirtualList.VirtualGridList` to make item stick to the bottom when scroll via down key
@@ -65,7 +66,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Scroller` to show the focused item fully when scrolling with 5way directional keys
 - `sandstone/TabLayout` to select tabs when focusing them in 5-way mode
 - `sandstone/ThemeDecorator` global focus+disabled rules to not double-apply opacity values
-- `sandstone/VideoPlayer` to seek playing time using left, right key
 
 ## [1.0.0-alpha.4] - 2020-03-17
 

--- a/VideoPlayer/MediaControls.js
+++ b/VideoPlayer/MediaControls.js
@@ -670,9 +670,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 				visible
 			} = this.props;
 
-			const current = Spotlight.getCurrent();
-
-			if ((!no5WayJump || !current) &&
+			if (!no5WayJump &&
 					!visible &&
 					!mediaDisabled &&
 					(is('left', ev.keyCode) || is('right', ev.keyCode))) {

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -740,6 +740,14 @@ const VideoPlayerBase = class extends React.Component {
 		if (!this.state.mediaControlsVisible && prevState.mediaControlsVisible) {
 			forwardControlsAvailable({available: false}, this.props);
 			this.stopAutoCloseTimeout();
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState(({no5WayJump}) => {
+				const current = Spotlight.getCurrent();
+				if (!no5WayJump || current) {
+					return null;
+				}
+				return {no5WayJump: false};
+			});
 
 			if (!this.props.spotlightDisabled) {
 				// If last focused item were in the media controls or slider, we need to explicitly
@@ -1717,8 +1725,8 @@ const VideoPlayerBase = class extends React.Component {
 	}
 
 	handleControlsHandleAboveBlur = () => {
-		this.setState(({no5WayJump}) => {
-			if (no5WayJump) {
+		this.setState(({no5WayJump, mediaControlsVisible}) => {
+			if (no5WayJump || !mediaControlsVisible) {
 				return null;
 			}
 			return {no5WayJump: true};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I separated the style of `MediaControls` from `VideoPlayer.module.less` (ref #64).
This made it impossible to reference the `VideoPlayer.module.less` style anymore.
The reason for the separation is that there is real case where only `MediaControls` is used alone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`VideoPlayer` pass `no5WayJump` prop to `MediaControls`.
`MediaControls` is not refer to `VideoPlayer.module.less`.
I think that It is better to control 5way jump using `props` instead of referencing css as condition.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-102872

### Comments