### PR TITLE
Use CLI's package-lock for installation rather than just package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - npm --no-audit link
     - popd
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
-    - pushd ../enact-cli
+    - pushd ../enact
     - npm install
     - npm run bootstrap -- --ignore enact-sampler
     - npm run link-all


### PR DESCRIPTION
A child dependency is causing trouble somewhere in the current `develop` CLI stack.  Current causing issues with Sandstone exclusively (no repeatable moonstone or agate Travis errors as far as I can see), so probably related to a specific technique or coding scenario exclusive to Sandstone.

This PR modifies our Travis setup to clone CLI repo on `develop` branch and `npm ci`/`npm link` it. Unlike a generic git url install, this specifically uses the validated-as-working package-lock.json on the repo. Similar to a shrinkwrap install.

The only other alternative is to use the latest published release of CLI on NPM (`npm install -g @enact/cli`) instead, as all our NPM releases are shrinkwrapped. However since we desired `develop` for a multitude of reasons, this PR's solution was chose.

Ideally this is a temporary bug and the faulty child depedency gets an update soon, however will want to create a followup investigation ticket.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>