### PR TITLE
PLAT-103432: Checkbox: remove green color for neutral state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [Unreleased]
+
+### Fixed
+
+- `sandstone/Checkbox` styling
+
 ## [1.0.0-alpha.5] - 2020-03-23
 
 ### Removed

--- a/Checkbox/Checkbox.js
+++ b/Checkbox/Checkbox.js
@@ -84,7 +84,10 @@ const CheckboxBase = kind({
 	},
 
 	computed: {
-		className: ({selected, styler}) => styler.append({selected})
+		className: ({children, selected, styler}) => styler.append({
+			check: children === 'check',
+			selected
+		})
 	},
 
 	render: ({children, css, ...rest}) => {

--- a/Checkbox/Checkbox.module.less
+++ b/Checkbox/Checkbox.module.less
@@ -29,6 +29,14 @@
 				@sand-checkbox-selected-bg-color,
 				@sand-checkbox-selected-border-color
 			);
+
+			&:not(.check) {
+				.checkboxColors(
+					@sand-checkbox-selected-no-check-color,
+					@sand-checkbox-selected-no-check-bg-color,
+					@sand-checkbox-selected-no-check-border-color
+				);
+			}
 		}
 
 		.focus({
@@ -44,6 +52,14 @@
 					@sand-checkbox-selected-focus-bg-color,
 					@sand-checkbox-selected-focus-border-color
 				);
+
+				&:not(.check) {
+					.checkboxColors(
+						@sand-checkbox-selected-no-check-focus-color,
+						@sand-checkbox-selected-no-check-focus-bg-color,
+						@sand-checkbox-selected-no-check-focus-border-color
+					);
+				}
 			}
 		});
 	});
@@ -65,6 +81,14 @@
 					@sand-checkbox-selected-focus-bg-color,
 					@sand-checkbox-selected-focus-border-color
 				);
+
+				&:not(.check) {
+					.checkboxColors(
+						@sand-checkbox-selected-no-check-focus-color,
+						@sand-checkbox-selected-no-check-focus-bg-color,
+						@sand-checkbox-selected-no-check-focus-border-color
+					);
+				}
 			}
 		});
 	}

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -78,6 +78,13 @@
 @sand-checkbox-selected-focus-color: @sand-checkbox-selected-color;
 @sand-checkbox-selected-focus-bg-color: @sand-checkbox-selected-bg-color;
 @sand-checkbox-selected-focus-border-color: @sand-checkbox-selected-border-color;
+@sand-checkbox-selected-no-check-color: @sand-checkbox-border-color;
+@sand-checkbox-selected-no-check-bg-color: @sand-checkbox-bg-color;
+@sand-checkbox-selected-no-check-border-color: @sand-checkbox-border-color;
+@sand-checkbox-selected-no-check-focus-color: @sand-checkbox-focus-border-color;
+@sand-checkbox-selected-no-check-focus-bg-color: @sand-checkbox-focus-bg-color;
+@sand-checkbox-selected-no-check-focus-border-color: @sand-checkbox-focus-border-color;
+
 
 // ContextualPopup
 // ---------------------------------------


### PR DESCRIPTION
Fixed colors for neutral state in `Checkbox`.
The latest GUI guide addressed that `Checkbox` doesn't use green feature color when no use `check` icon.
I attached screenshot in Jira ticket.