### PR TITLE
PLAT-103487: Sandstone Travis failing with develop Enact APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ install:
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
-    - npm run bootstrap -- --ignore enact-sampler
-    - npm run link-all
+    - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link
+    - npm run lerna link -- --ignore enact-sampler
     - popd
     - rm -fr node_modules/@enact
     - npm install


### PR DESCRIPTION
Previous we setup Enact dependencies for `develop` by running `npm run bootstrap` and `npm run link-all`, however this results in each package having their symlinked interdependencies overwritten by NPM releases (eg, in UI, @enact/core symlink is replaced with a copy of `master` @enact/core from NPM).  This results is some `develop` APIs not always be available.

This change modifies Travis setup to be similar to Jenkins. It now instead usea Lerna to run `npm link` on each Enact package, then uses `lerna link` to symlink all together afterwards.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>