### PR TITLE
PLAT-104567: First internal-theme $L always fails

### DIFF
--- a/internal/$L/$L.js
+++ b/internal/$L/$L.js
@@ -83,6 +83,7 @@ function toIString (str) {
 
 	if (!rb) {
 		createResBundle({sync: true, onLoad: setResBundle});
+		rb = getResBundle();
 	}
 
 	return getIStringFromBundle(str, rb);


### PR DESCRIPTION
* The original `rb` variable was not being updated after first creation of the internal theme ResBundle, and as a result, the first `<theme>/internal/$L` would always fail and return the original string (afterwards would be fine since the ResBundle would exist at time of `$L`).
* Appears to be a carry-over from when the internal `@enact/i18n/$L` and `@enact/i18n/src/resBundle` were mashed together into `@enact/moonstone/internal/$L`.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>