### PR TITLE
Refactors the color change into Button's required structure

### DIFF
--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -4,6 +4,13 @@
 @import "../styles/variables.less";
 @import "../styles/skin.less";
 
+// Add button-specific rules to the shared resting-colors mixin
+.sand-button-spotlight-resting-colors() {
+	.sand-spotlight-resting-colors();
+	will-change+: transform;
+	transition+: transform @sand-button-focus-duration ease-out;
+}
+
 .button {
 	// default is size="large"
 	.sand-large-button-text();
@@ -241,9 +248,7 @@
 
 		.bg {
 			border-color: transparent;
-			.sand-spotlight-resting-colors();
-			will-change+: transform;
-			transition+: transform @sand-button-focus-duration ease-out;
+			.sand-button-spotlight-resting-colors();
 		}
 
 		&.opaque {
@@ -277,6 +282,27 @@
 			background-color: @sand-remote-button-blue-color;
 		}
 
+		&.selected {
+			.bg {
+				.sand-button-spotlight-resting-colors();
+				filter+_: saturate(1.5) brightness(0.5); // Simulates #3e454d, the spec color
+			}
+
+			&.opaque {
+				.bg {
+					background-color: @sand-button-bg-color;
+					opacity: @sand-button-bg-opacity;
+				}
+			}
+
+			&.transparent {
+				.bg {
+					background-color: @sand-button-bg-color;
+					opacity: @sand-button-transparent-selected-bg-opacity;
+				}
+			}
+		}
+
 		.focus({
 			color: @sand-button-focus-text-color;
 
@@ -292,7 +318,8 @@
 			// adjusting it to become the focus-bg-color. If either color value changes, these
 			// adjustments must be recalculated. This is not automatic. It may be possible to
 			// autonomously calculate this in the future...
-			&.opaque {
+			&.opaque,
+			&.selected.transparent {
 				.bg {
 					.sand-spotlight-focus-colors();
 					background-color: @sand-button-bg-color; // We use the resting colors here and augment the color using a filter so it can be animated smoothly
@@ -300,17 +327,6 @@
 				}
 			}
 		});
-
-		&.selected {
-			.bg {
-				background-color: @sand-button-selected-bg-color;
-			}
-			&.transparent {
-				.bg {
-					opacity: @sand-button-transparent-selected-bg-opacity;
-				}
-			}
-		}
 
 		// Button-non-disabled rules
 		&:not([disabled]) {

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -36,7 +36,7 @@ const threeWayBoolean = (value) => {
 storiesOf('Sandstone', module)
 	.add(
 		'Button',
-		() => (
+		() => (<React.Fragment>
 			<Button
 				onClick={action('onClick')}
 				backgroundOpacity={select('backgroundOpacity', prop.backgroundOpacity, Config)}
@@ -50,7 +50,7 @@ storiesOf('Sandstone', module)
 			>
 				{text('children', Config, 'click me')}
 			</Button>
-		),
+		</React.Fragment>),
 		{
 			info: {
 				text: 'The basic Button'

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -65,7 +65,6 @@
 @sand-button-bg-color: #7d848c;
 @sand-button-transparent-bg-color: @sand-spotlight-bg-color; // This must match the focus color to avoid visual "jumps" when focused. We control the translucency through the opacity variable.
 @sand-button-focus-text-color: @sand-spotlight-text-color;
-@sand-button-selected-bg-color: #3e454d;
 
 // Checkbox
 // ---------------------------------------


### PR DESCRIPTION
Due to the new styling and animation requirements for Button (any many other components), we no longer have the luxury of simply changing the background colors for many states.

This PR refactors Button to use the updated styling technique to apply the `selected` colors safely, without causing visual "jumps" or "skips" during the focus animation.

This is a slow-motion capture of what the original PR #217 was doing:
![Button-selected-focus-jump](https://user-images.githubusercontent.com/386529/79384239-57141580-7f1b-11ea-9f02-3c4be699039c.gif)

This is a slow-motion capture of this PR:
![Button-selected-focus-smooth](https://user-images.githubusercontent.com/386529/79384322-7e6ae280-7f1b-11ea-9851-42189951f2ec.gif)

Note the difference between the two. The first video shows a rapid swap in colors, followed by the remainder of the animation. The second video shows a smooth transition between the resting and focused states.

It's more work to achieve this smooth transition, but it's worth it for the performance gain (no paints at all!) and for the smooth visual animation effect. Chrome has an Animation tab in the inspector tools; there you can set the animation speed down to 10% so you can more easily watch the transitions and verify they're doing what you expect.