### PR TITLE
PLAT-87184: Remove the iLib <14.4.0 ResBundle cache workaround

### DIFF
--- a/internal/$L/$L.js
+++ b/internal/$L/$L.js
@@ -2,7 +2,6 @@
 
 import {getIStringFromBundle} from '@enact/i18n/src/resBundle';
 import ResBundle from 'ilib/lib/ResBundle';
-import ilib from 'ilib';
 
 // The ilib.ResBundle for the active locale used by $L
 let resBundle;


### PR DESCRIPTION
* Removes the `ilib.data` hot swapping, since it's no longer needed as long as `basePath` is specified and iLib >=14.4.0 is used.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>