### PR TITLE
Fixed the TabLayout height and the collapsed tab width

### DIFF
--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -85,7 +85,7 @@ const TabLayoutBase = kind({
 		 * @type {{tabs: {collapsed: Number, normal: Number}, content: {expanded: number, normal: number}}}
 		 * @default {
 		 * 	tabs: {
-		 * 		collapsed: 450,
+		 * 		collapsed: 240,
 		 * 		normal: 855
 		 * 	},
 		 * 	content: {
@@ -154,7 +154,7 @@ const TabLayoutBase = kind({
 	defaultProps: {
 		dimensions: {
 			tabs: {
-				collapsed: 450,
+				collapsed: 240,
 				normal: 855
 			},
 			content: {

--- a/TabLayout/TabLayout.module.less
+++ b/TabLayout/TabLayout.module.less
@@ -3,6 +3,8 @@
 @import "../styles/variables.less";
 
 .tabLayout {
+	height: 100%;
+
 	.content {
 		margin-top: @sand-tablayout-content-margin-top;
 	}


### PR DESCRIPTION
The component height was not respecting the dimensions of the parent, and the legacy collapsed tab width needed to be updated.