### PR TITLE
PLAT-106459: Update VirtualGridList sample to fix knobs in Other tab

### DIFF
--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -81,8 +81,8 @@ storiesOf('Sandstone', module)
 				horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualGridListConfig)}
 				itemRenderer={renderItem}
 				itemSize={{
-					minWidth: ri.scale(number('minWidth', VirtualGridListConfig, 688)),
-					minHeight: ri.scale(number('minHeight', VirtualGridListConfig, 570))
+					minWidth: ri.scale(number('itemSize.minWidth', VirtualGridListConfig, 688)),
+					minHeight: ri.scale(number('itemSize.minHeight', VirtualGridListConfig, 570))
 				}}
 				key={select('scrollMode', prop.scrollModeOption, VirtualGridListConfig)}
 				noScrollByWheel={boolean('noScrollByWheel', VirtualGridListConfig)}


### PR DESCRIPTION
…s props added to VirtualGridList knob.

* Includes VirtualGridListConfig in the knob function for `minWidth`, `minHeight`, and `spacing`, such that they correctly register under the "VirtualGridList" category and don't default to "Other"

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>