### PR TITLE
PLAT-106655: Add close button to popup sample

### DIFF
--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -239,7 +239,12 @@ class PopupFocusTest extends React.Component {
 					scrimType={scrimType}
 					spotlightRestrict={spotlightRestrict}
 				>
-					<div>This is a Popup</div>
+					<Row>
+						<Cell align="center">This is a Popup</Cell>
+						<Cell shrink>
+							<Button icon="closex" onClick={this.handleClosePopup} size="small" />
+						</Cell>
+					</Row>
 				</Popup>
 			</div>
 		);


### PR DESCRIPTION
Since `Popup` components no longer support a built-in close button, we need to add a close button to the QA spotlight > popup sample in order to verify focus behavior when a focusable control triggers a panel open/close change.