### PR TITLE
Remove unused eslint directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
     - codecov
     - echo -e "\x1b\x5b35;1m*** Tests complete\x1b\x5b0m"
     - echo -e "\x1b\x5b35;1m*** Starting eslint...\x1b\x5b0m"
-    - npm run lint -- -- --max-warnings 0 .
+    - npm run lint -- -- --max-warnings 0 --report-unused-disable-directives .
     - echo -e "\x1b\x5b35;1m*** eslint complete\x1b\x5b0m"

--- a/Image/Image.js
+++ b/Image/Image.js
@@ -76,7 +76,7 @@ const ImageBase = kind({
 //
 // This is ripe for refactoring, and could probably move into UI to be generalized, but that's for
 // another time. -B 2018-05-01
-const ResponsiveImageDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'ResponsiveImageDecorator'
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -403,7 +403,7 @@ const MediaControlsBase = kind({
  * @hoc
  * @private
  */
-const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+const MediaControlsDecorator = hoc((config, Wrapped) => {
 	class MediaControlsDecoratorHOC extends React.Component {
 		static displayName = 'MediaControlsDecorator'
 

--- a/MediaPlayer/MediaSliderDecorator.js
+++ b/MediaPlayer/MediaSliderDecorator.js
@@ -70,7 +70,7 @@ const handleKeyUp = handle(
  * @hoc
  * @private
  */
-const MediaSliderDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+const MediaSliderDecorator = hoc((config, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'MediaSliderDecorator'
 

--- a/ThemeDecorator/AccessibilityDecorator.js
+++ b/ThemeDecorator/AccessibilityDecorator.js
@@ -12,7 +12,7 @@ import React from 'react';
  * @hoc
  * @public
  */
-const AccessibilityDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+const AccessibilityDecorator = hoc((config, Wrapped) => {
 	return class extends React.Component {
 		static contextType = ResizeContext;
 

--- a/ThemeDecorator/I18nFontDecorator.js
+++ b/ThemeDecorator/I18nFontDecorator.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import {fontOverrideGenerator} from './fontGenerator';
 
-const I18nFontDecorator = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+const I18nFontDecorator = hoc((config, Wrapped) => {
 	return class I18nDecorator extends React.Component {
 		static displayName = 'I18nFontDecorator'
 

--- a/VirtualList/tests/VirtualList-specs.js
+++ b/VirtualList/tests/VirtualList-specs.js
@@ -277,7 +277,7 @@ describe('VirtualList', () => {
 			'should render an added item named \'Password 0\' as the first item',
 			(done) => {
 				const itemArray = [{name: 'A'}, {name: 'B'}, {name: 'C'}];
-				const renderItemArray = ({index, ...rest}) => { // eslint-disable-line enact/display-name, enact/prop-types, react/jsx-no-bind
+				const renderItemArray = ({index, ...rest}) => { // eslint-disable-line enact/prop-types
 					return (
 						<div {...rest} id={'item' + index}>
 							{itemArray[index].name}

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -103,8 +103,7 @@ const useSpottable = (props, instances) => {
 
 	useEffect(() => {
 		return () => {
-			// TODO: Fix eslint
-			pause.resume(); // eslint-disable-line react-hooks/exhaustive
+			pause.resume();
 			SpotlightAccelerator.reset();
 
 			setContainerDisabled(false);
@@ -392,7 +391,6 @@ const useThemeVirtualList = (props) => {
 	};
 };
 
-/* eslint-disable enact/prop-types */
 function listItemsRenderer (props) {
 	const {
 		cc,

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -10,7 +10,7 @@ import css from './VirtualGridList.module.less';
 
 const
 	items = [],
-	// eslint-disable-next-line enact/prop-types, enact/display-name
+	// eslint-disable-next-line enact/prop-types
 	renderItem = ({index, ...rest}) => {
 		const
 			{caption, label, src} = items[index],

--- a/samples/sampler/stories/qa/Marquee.js
+++ b/samples/sampler/stories/qa/Marquee.js
@@ -56,7 +56,6 @@ const MarqueeI18nSamples = I18nContextDecorator({updateLocaleProp: 'updateLocale
 	)
 }));
 
-// eslint-disable-next-line enact/prop-types
 const CustomItemBase = ({children, ...rest}) => (
 	<div {...rest} style={{display: 'flex', width: 300, alignItems: 'center'}}>
 		<Icon>flag</Icon>

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -35,7 +35,7 @@ const
 		true: true,
 		'&quot;noAnimation&quot;': 'noAnimation'
 	},
-	// eslint-disable-next-line enact/prop-types, enact/display-name
+	// eslint-disable-next-line enact/prop-types
 	renderItem = (ItemComponent, size, vertical, onClick) => ({index, ...rest}) => {
 		const style = vertical ?
 			{margin: 0} :
@@ -137,7 +137,6 @@ const InPanels = ({className, title, ...rest}) => {
 	);
 };
 
-// eslint-disable-next-line enact/prop-types
 class VirtualListWithCBScrollTo extends React.Component {
 	static propTypes = {
 		dataSize: PropTypes.number


### PR DESCRIPTION
Also adds an error to Travis if they creep in again.  Not necessary, but nice?

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com