### PR TITLE
PLAT-105068: Prevent overlap of dropdowns

### DIFF
--- a/samples/sampler/stories/qa/Dropdown.js
+++ b/samples/sampler/stories/qa/Dropdown.js
@@ -8,7 +8,6 @@ import {storiesOf} from '@storybook/react';
 import Button, {ButtonBase} from '@enact/sandstone/Button';
 import Dropdown, {DropdownBase} from '@enact/sandstone/Dropdown';
 import Heading from '@enact/sandstone/Heading';
-import ri from '@enact/ui/resolution';
 
 const Config = mergeComponentMetadata('Dropdown', UIButtonBase, UIButton, ButtonBase, Button, DropdownBase, Dropdown);
 const items = (itemCount, optionText = 'Option') => (new Array(itemCount)).fill().map((i, index) => `${optionText} ${index + 1}`);


### PR DESCRIPTION
There's no real need for them to be stacked vertically, is there?  We could just make them inline and it'd work at any resolution.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com