### PR TITLE
PLAT-106629: Add public classNames to ImageItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/ImageItem` public class names `horizontal` and `vertical`
+
 ### Fixed
 
 - `sandstone/Panels` to not fire transition events when initially rendered

--- a/ImageItem/ImageItem.js
+++ b/ImageItem/ImageItem.js
@@ -198,7 +198,7 @@ const ImageItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['imageItem', 'caption', 'image', 'label', 'selected', 'selectionIcon']
+		publicClassNames: ['imageItem', 'caption', 'horizontal', 'image', 'label', 'selected', 'selectionIcon', 'vertical']
 	},
 
 	computed: {


### PR DESCRIPTION
Additional public classnames are needed for `ImageItem`, in order to specify styles based on orientation.