### PR TITLE
PLAT-105369: Sampler - SwitchItem:  Switch Circle has uneven space between the circle and the oval - with 'large text' selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` and `sandstone/VirtualList` to handle a keydown event without an error
+- `sandstone/Switch` style to align circle icon vertically
 - `sandstone/Panels` to not fire transition events when initially rendered
 - `sandstone/Tooltip` style to match latest designs
 - `sandstone/VirtualList` to support navigation with spottable children inside an item

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -607,12 +607,12 @@
 @sand-switch-height: 60px;
 @sand-switch-width: 114px;
 @sand-switch-icon-height: @sand-switch-height;
-@sand-switch-icon-line-height: 63px;
+@sand-switch-icon-line-height: @sand-switch-icon-height;
 @sand-switch-height-large: @sand-icon-small-size-large;
 @sand-switch-width-large: 162px;
 @sand-switch-icon-height-large: @sand-icon-small-size-large;
 @sand-switch-icon-width-large: @sand-icon-small-size-large;
-@sand-switch-icon-line-height-large: 96px;
+@sand-switch-icon-line-height-large: @sand-switch-icon-height-large;
 @sand-switch-spottable-margin: 18px (@sand-component-spacing + 30px);
 @sand-switch-spottable-border-radius: @sand-item-border-radius;
 @sand-switch-spottable-position-top-bottom: -18px; // These correlate with the numbers from 'margin" above


### PR DESCRIPTION
Fixed `line-height` to use same value to height of `icon`.
*Before*
![Screenshot208](https://user-images.githubusercontent.com/11263018/82617620-9238f100-9c0b-11ea-9000-df0bda3d7494.png)
*After*
![Screenshot209](https://user-images.githubusercontent.com/11263018/82617622-9402b480-9c0b-11ea-93be-b174074ba75e.png)
