### PR TITLE
PLAT-109067: Fowarding accessibility props to Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/MediaPlayer.MediaControls` props `rateChangeDisabled` to prevent playback rate control via rewind and fast forward keys
+- `sandstone/Input` forwarding accessibility props to `Popup`
 
 ### Fixed
 

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -8,6 +8,7 @@ import Layout, {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import React from 'react';
+import {extractAriaProps} from '@enact/core/util';
 
 import Button from '../Button';
 import Popup from '../Popup';
@@ -292,8 +293,8 @@ const InputPopupBase = kind({
 		value,
 		...rest
 	}) => {
-
 		const inputProps = extractInputFieldProps(rest);
+		const ariaProps = extractAriaProps(rest);
 		const numberMode = (numberInputField !== 'field') && (type === 'number' || type === 'passwordnumber');
 
 		delete rest.length;
@@ -308,6 +309,7 @@ const InputPopupBase = kind({
 				className={popupClassName}
 				noAnimation
 				open={!disabled && open}
+				{...ariaProps}
 			>
 				<Layout orientation="vertical" align={`center ${numberMode ? 'space-between' : ''}`} className={css.body}>
 					<Cell shrink className={css.titles}>

--- a/Input/Keypad.js
+++ b/Input/Keypad.js
@@ -80,6 +80,7 @@ const Keypad = kind({
 							component={Key}
 							key={`key${rowIndex}-${keyText}`}
 							onKeyButtonClick={keyText === 'backspace' ? onRemove : onAdd}
+							aria-label={keyText}
 						>
 							{keyText}
 						</Cell>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Accessibility props has to forwarding to Popup in Input

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Delegate props using extractAriaProps

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-109067

### Comments
Enact-DCO-1.0-Signed-off-by: Changgi Lee changgi.lee@lge.com