### PR TITLE
PLAT-109419: Fix ContextualMenu not to read as alert when rendered on the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Popup` to always remove scrim on close
 - `sandstone/TabLayout` button sizes to match the latest design
 - `sandstone/WizardPanels` to respect using `spotlight/SpotlightContainerDecorator.spotlightDefaultClass` to determine the default focus
+- `sandstone/ContextualMenuDecorator` to not read as alert when rendered on the screen
 
 ## [1.0.0-beta.5] - 2020-06-01
 

--- a/ContextualMenuDecorator/ContextualMenuDecorator.js
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.js
@@ -158,7 +158,7 @@ const ContextualMenuDecoratorBase = hoc(defaultConfig, (config, Wrapped) => {
 				'container',
 				popupClassName
 			),
-			popupProps: ({menuItems, popupProps}) => ({children: menuItems, childComponent: Item, component: 'div', ...popupProps})
+			popupProps: ({menuItems, popupProps}) => ({'aria-live': null, children: menuItems, childComponent: Item, component: 'div', role: null, ...popupProps})
 		},
 
 		render: ({onOpen, popupProps, ...rest}) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Fixed not to read all Contextual content when ContextualMenu is displayed with regard to new a11y UX

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Prevent alert behavior by modifying the aria-live attribute and role to be removed.
(Sandstone a11y scenario: read only the focused item when ContextualPopup is opened.)

### Links
[//]: # (Related issues, references)
PLAT-109419

### Comments
Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)