### PR TITLE
PLAT-110483: Add mixins for safer value extraction from LESS variables

### DIFF
--- a/styles/mixins.less
+++ b/styles/mixins.less
@@ -15,6 +15,9 @@
 // .normalize-shorthand(11px 21px 31px)[]       -->  11px 21px 31px 21px
 // .normalize-shorthand(11px 21px)[]            -->  11px 21px 11px 21px
 // .normalize-shorthand(11px)[]                 -->  11px 11px 11px 11px
+//
+// NOTE: The [] is required at the end of the method call, which instructs LESS to return a value.
+// For details see: http://lesscss.org/features/#mixins-feature-unnamed-lookups
 .normalize-shorthand(@trbl) when ((length(@trbl) >= 1) and (length(@trbl) <= 4)) {
 	@result:
 		extract(@trbl, 1)
@@ -31,6 +34,9 @@
 // padding-left: .extract(11px 21px, left)[]            -->  21px
 // padding-left: .extract(11px, left)[]                 -->  11px
 // padding: .extract(11px 21px 31px 41px)[]             -->  11px 21px 31px 41px
+//
+// NOTE: The [] is required at the end of the method call, which instructs LESS to return a value.
+// For details see: http://lesscss.org/features/#mixins-feature-unnamed-lookups
 .extract(@trbl; @position) when (@position = top) {
 	@result: extract(.normalize-shorthand(@trbl)[], 1);
 }
@@ -54,6 +60,9 @@
 // padding-left: .extract(11px 21px 31px, 4)[]       -->  21px
 // padding-left: .extract(11px 21px, 4)[]            -->  21px
 // padding-left: .extract(11px, 4)[]                 -->  11px
+//
+// NOTE: The [] is required at the end of the method call, which instructs LESS to return a value.
+// For details see: http://lesscss.org/features/#mixins-feature-unnamed-lookups
 .extract(@trbl; @position) when ((@position >= 1) and (@position <= 4)) {
 	@result: extract(.normalize-shorthand(@trbl)[], @position);
 }


### PR DESCRIPTION
In LESS, the `extract` method is very literal in what it supports extraction from. It, rightly, has no concept of short-hand used by several CSS properties, in favor of being highly predictable in any situation; even if that predictability includes a predictable crash. While this is great for strict programming, it's not so great for convenience in the 99% usage case.

The new `.extract()` mixin solves this by first normalizing the input (anywhere between 1 and 4 values) and offering human-readable access to any of those arguments, even if they don't exist in the input list, using the standard short-hand logic to fill in any unknowns.

This PR  introduces 2 new mixins: `.normalize-shorthand()` and `.extract()`. `.extract()` has two modes that it supports: one-argument mode, which may be called with a named side; and two-argument mode which is called with its second argument being the numeric position of the desired list element, just like the built-in `extract`. Both approaches are included because one may be desirable over the other.

Examples and usage are included in the docs of these methods. 