### PR TITLE
PLAT-110340: Added a Lorem test for fullscreen and removed subtitle test

### DIFF
--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -7,14 +7,14 @@ import img from '../../images/300x300.png';
 import {withConfig, withProps, LoremString} from './utils';
 
 
-// Only type: 'fullscreen' supports title and subtitle props
+// Only type: 'fullscreen' supports title prop
 const fullscreenTests = [
 	<Alert open title="Title" />,
 	<Alert open>Alert!</Alert>,
 	<Alert open>{LoremString}</Alert>
 ];
 
-// Only type: 'overlay; supports children
+// Only type: 'overlay' supports children
 const overlayTests = [
 	<Alert open>Alert!</Alert>,
 	<Alert open>{LoremString}</Alert>


### PR DESCRIPTION
- Added a long string test for children in fullscreen type.
- Subtitle has been replaced by Bodytext so removed the test calling for subtitle.