### PR TITLE
PLAT-109073: Add #guide LESS reference library

### DIFF
--- a/styles/variables.less
+++ b/styles/variables.less
@@ -64,7 +64,7 @@
 		standard-title-font-size: 108px;
 		standard-title-line-height: 127px;
 
-		wizard-padding: 108px 210px 66px 210px;
+		wizard-padding: 108px 150px 66px 150px;
 		wizard-title-font-size: 144px;
 		wizard-title-line-height: 169px;
 	}


### PR DESCRIPTION
Adds a LESS `#guide` library for storing values that come directly from the GUI guide to help keep definitions safely and cleanly defined while the computation is done in the more familiar variables section.

Usage:
`#guide.header[standard-padding]` returns `108px 150px 73px 150px`

Also in the `#guide` library, is a mixin for calculating the difference between the GUI guide's line-height/box-size and a framework locale-safe line-height. (Documentation and examples included in PR).
This allows the guide values to be directly referenced, unaltered, and visually produce exactly the correct sizing values regardless of what the GUI guide defines or our internationalization locale rules dictate.