### PR TITLE
Hotfix: Refactor FixedPopupPanels QA story

### DIFF
--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -1,11 +1,15 @@
+/* eslint-disable react/jsx-no-bind */
+
 import {action} from '@enact/storybook-utils/addons/actions';
-import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
+import {boolean, select} from '@enact/storybook-utils/addons/knobs';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import React from 'react';
+import compose from 'ramda/src/compose';
 import {storiesOf} from '@storybook/react';
 import {Column, Cell} from '@enact/ui/Layout';
 
 import BodyText from '@enact/sandstone/BodyText';
+import Button from '@enact/sandstone/Button';
 import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels';
 import Item from '@enact/sandstone/Item';
 import {VirtualList} from '@enact/sandstone/VirtualList';
@@ -29,18 +33,33 @@ const itemRenderer = ({index, ...rest}) => {
 storiesOf('FixedPopupPanels', module)
 	.add(
 		'with VirtualList',
-		() => (
-			<div>
+		() => {
+			const defaultOpen = false;
+			const [open, setOpenState] = React.useState(defaultOpen);
+			const toggleOpen = () => setOpenState(!open);
+			const handleClose = compose(toggleOpen, action('onClose'));
+
+			const defaultIndex = 0;
+			const [index, setPanelIndexState] = React.useState(defaultIndex);
+
+			const nextPanel = () => setPanelIndexState(Math.min(index + 1, 3));
+			const prevPanel = () => setPanelIndexState(Math.max(index - 1, 0));
+			const handleBack = compose(prevPanel, action('onBack'));
+
+			const itemHeight = 156;
+			const itemSize = ri.scale(itemHeight);
+
+			return (<div>
 				<FixedPopupPanels
-					index={number('index', Config, {range: true, min: 0, max: 1}, 0)}
-					open={boolean('open', Config, true)}
+					index={index}
+					open={open}
 					position={select('position', ['left', 'right'], Config)}
 					fullHeight={boolean('fullHeight', Config)}
 					width={select('width', ['narrow', 'half'], Config)}
 					noAnimation={boolean('noAnimation', Config)}
 					noAutoDismiss={boolean('noAutoDismiss', Config)}
-					onBack={action('onBack')}
-					onClose={action('onClose')}
+					onBack={handleBack}
+					onClose={handleClose}
 					onHide={action('onHide')}
 					onShow={action('onShow')}
 					scrimType={select('scrimType', ['none', 'translucent', 'transparent'], Config)}
@@ -49,44 +68,94 @@ storiesOf('FixedPopupPanels', module)
 					<Panel>
 						<Header>
 							<title>
-								FixedPopupPanels Title
+								Panel 1
 							</title>
 							<subtitle>
-								A panel type for options views
+								20-Item VirtualList in a `Layout`
 							</subtitle>
+							<slotAfter>
+								<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
+							</slotAfter>
 						</Header>
 						<Column>
-							<Cell shrink>
-								<BodyText>Example text inside an FixedPopupPanels Panel</BodyText>
-							</Cell>
-							<Cell>
-								<VirtualList
-									itemSize={ri.scale(156)}
-									itemRenderer={itemRenderer}
-									dataSize={20}
-								/>
-							</Cell>
+							<Cell shrink component={BodyText}>A 3-Cell Layout with 4 visible items in a VirtualList</Cell>
+							<Cell
+								size={itemHeight * 4}
+								component={VirtualList}
+								childProps={{onClick: nextPanel}}
+								itemSize={itemSize}
+								itemRenderer={itemRenderer}
+								dataSize={20}
+							/>
+							<Cell shrink component={BodyText}>This text should be visible.</Cell>
 						</Column>
 					</Panel>
 					<Panel>
 						<Header>
 							<title>
-								Another Panel
+								Panel 2
 							</title>
 							<subtitle>
-								This is the second page
+								3-Item VirtualList in a `Layout`
 							</subtitle>
+							<slotAfter>
+								<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
+							</slotAfter>
+						</Header>
+						<Column>
+							<Cell shrink>
+								<BodyText>A 3-Cell Layout with fixed height VirtualList</BodyText>
+							</Cell>
+							<Cell size={itemHeight * 3}>
+								<VirtualList
+									childProps={{onClick: nextPanel}}
+									itemSize={itemSize}
+									itemRenderer={itemRenderer}
+									dataSize={3}
+								/>
+							</Cell>
+							<Cell shrink component={BodyText}>This text should be visible.</Cell>
+						</Column>
+					</Panel>
+					<Panel>
+						<Header>
+							<title>
+								Panel 3
+							</title>
+							<subtitle>
+								VirtualList filling the height of the panel
+							</subtitle>
+							<slotAfter>
+								<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
+							</slotAfter>
 						</Header>
 						<VirtualList
-							itemSize={ri.scale(156)}
+							childProps={{onClick: nextPanel}}
+							itemSize={itemSize}
 							itemRenderer={itemRenderer}
 							dataSize={20}
 						/>
 					</Panel>
+					<Panel>
+						<Header>
+							<title>
+								Panel 4
+							</title>
+							<subtitle>
+								2-Item VirtualList filling just the space it needs
+							</subtitle>
+						</Header>
+						<VirtualList
+							itemSize={itemSize}
+							itemRenderer={itemRenderer}
+							dataSize={2}
+						/>
+					</Panel>
 				</FixedPopupPanels>
-				<BodyText centered>Use KNOBS to interact with FixedPopupPanels.</BodyText>
+				<Button onClick={toggleOpen}>Open FixedPopupPanels</Button>
 			</div>
-		),
+			);
+		},
 		{
 			info: {
 				text: 'QA -  Basic usage of FixedPopupPanels'


### PR DESCRIPTION
FixedPopupPanels now has a usage rule. If a Layout is used (flex-box), a `size`/`height` must be set on any auto-sizing content so the container doesn't collapse to `0` height.

This PR updates the QA story with the necessary code, as well as refactoring it to be more "natural" to interact with. Built-in state rather than knobs. It also adds several additional cases to validate things are working as expected, as well as including better descriptive text.