### PR TITLE
PLAT-111224: Refactor focus shadow to use box-shadow

### DIFF
--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -293,7 +293,6 @@
 			color: @sand-button-transparent-text-color;
 
 			.bg {
-				.sand-button-selected-colors();
 				opacity: @sand-button-transparent-bg-opacity;
 			}
 		}
@@ -344,22 +343,22 @@
 
 				&.focusExpand {
 					.bg {
-						transform: @sand-button-focusexpand-focus-bg-transform;
+						&::after { transform: @sand-button-focusexpand-focus-bg-transform; }
 					}
 
 					&.small .bg {
-						transform: @sand-button-small-focusexpand-focus-bg-transform;
+						&::after { transform: @sand-button-small-focusexpand-focus-bg-transform; }
 					}
 
 					&.pressed,
 					&:active {
 						.bg {
-							transform: @sand-button-focusexpand-pressed-bg-transform;
+							&::after { transform: @sand-button-focusexpand-pressed-bg-transform; }
 						}
 
 						&.small {
 							.bg {
-								transform: @sand-button-small-focusexpand-pressed-bg-transform;
+								&::after { transform: @sand-button-small-focusexpand-pressed-bg-transform; }
 							}
 						}
 					}
@@ -369,12 +368,12 @@
 					&.pressed,
 					&:active {
 						.bg {
-							transform: @sand-button-pressed-bg-transform;
+							&::after { transform: @sand-button-pressed-bg-transform; }
 						}
 
 						&.small {
 							.bg {
-								transform: @sand-button-small-pressed-bg-transform;
+								&::after { transform: @sand-button-small-pressed-bg-transform; }
 							}
 						}
 					}

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -343,22 +343,30 @@
 
 				&.focusExpand {
 					.bg {
-						&::after { transform: @sand-button-focusexpand-focus-bg-transform; }
+						.sand-bg-colors({
+							transform: @sand-button-focusexpand-focus-bg-transform;
+						});
 					}
 
 					&.small .bg {
-						&::after { transform: @sand-button-small-focusexpand-focus-bg-transform; }
+						.sand-bg-colors({
+							transform: @sand-button-small-focusexpand-focus-bg-transform;
+						});
 					}
 
 					&.pressed,
 					&:active {
 						.bg {
-							&::after { transform: @sand-button-focusexpand-pressed-bg-transform; }
+							.sand-bg-colors({
+								transform: @sand-button-focusexpand-pressed-bg-transform;
+							});
 						}
 
 						&.small {
 							.bg {
-								&::after { transform: @sand-button-small-focusexpand-pressed-bg-transform; }
+								.sand-bg-colors({
+									transform: @sand-button-small-focusexpand-pressed-bg-transform;
+								});
 							}
 						}
 					}
@@ -368,12 +376,16 @@
 					&.pressed,
 					&:active {
 						.bg {
-							&::after { transform: @sand-button-pressed-bg-transform; }
+							.sand-bg-colors({
+								transform: @sand-button-pressed-bg-transform;
+							});
 						}
 
 						&.small {
 							.bg {
-								&::after { transform: @sand-button-small-pressed-bg-transform; }
+								.sand-bg-colors({
+									transform: @sand-button-small-pressed-bg-transform;
+								});
 							}
 						}
 					}

--- a/styles/color-mixins.less
+++ b/styles/color-mixins.less
@@ -11,26 +11,63 @@
 // ---------------------------------------
 
 // Establish rules assignment for before focus has happened
-.sand-spotlight-resting-bg-colors (@opacity: 0) {
-	background-color: @sand-spotlight-bg-color;
+.sand-spotlight-resting-bg-colors (@opacity: 0, @bg: {}, @shadow: {}) {
+	// These lines are really long, and occasionally repeated. Defining here as shorthand.
+	@transition-opacity: opacity @sand-spotlight-focus-animation-duration ease-out;
+	@transition-transform: transform @sand-spotlight-focus-animation-duration ease-out;
+	@transition-filter: filter @sand-spotlight-focus-animation-duration ease-out;
+
 	opacity: @opacity;
-	filter+_: drop-shadow(@sand-spotlight-resting-shadow);
-	transition+:
-		filter @sand-spotlight-focus-animation-duration ease-out,
-		opacity @sand-spotlight-focus-animation-duration ease-out;
-	will-change+: filter, opacity;
+	transition+: @transition-opacity;
+	will-change+: opacity;
+
+	// Prep common aspects
+	@shared: {
+		content: "";
+		position: absolute;
+		.position(0);
+		border-radius: inherit;
+		--spotlight-resting-bg-colors: 1;
+	};
+
+	// Shadow
+	&::before {
+		@shared();
+		background-color: @sand-spotlight-bg-color;
+		box-shadow: @sand-spotlight-focus-shadow;
+		transform+_: scale(0.9, 0.5); // Hard-coded values, not part of the design. This transform is responsible for tucking the shadow up inside the background so it can transition out.
+		opacity: 0;
+		transition+: @transition-opacity, @transition-transform;
+		will-change+: opacity, transition;
+		@shadow();
+	}
+	// Background coloration
+	&::after {
+		@shared();
+		background-color: @sand-spotlight-bg-color;
+		transition+: @transition-filter;
+		will-change+: filter;
+		@bg();
+	}
 }
 
 // Establish rules assignment for after focus has happened
-.sand-spotlight-focus-bg-colors () {
-	background-color: @sand-spotlight-bg-color;
+.sand-spotlight-focus-bg-colors (@bg: {}, @shadow: {}) {
 	opacity: 1;
-	.sand-spotlight-focus-shadow-colors();
+	&::after {
+		background-color: @sand-spotlight-bg-color;
+		@bg();
+	}
+	.sand-spotlight-focus-shadow-colors(@shadow);
 }
 
 // Just the spotlight shadow (merge-safe)
-.sand-spotlight-focus-shadow-colors () {
-	filter+_: drop-shadow(@sand-spotlight-focus-shadow);
+.sand-spotlight-focus-shadow-colors (@shadow: {}) {
+	&::before {
+		transform: scale(1);
+		opacity: 1;
+		@shadow();
+	}
 }
 
 .sand-spotlight-focus-text-colors () {
@@ -81,20 +118,25 @@
 }
 
 // Button state mixins
-.sand-button-resting-bg-colors () {
-	.sand-spotlight-resting-bg-colors();
-	.sand-button-resting-bg-color();
-	will-change+: transform;
-	transition+: transform @sand-button-focus-duration ease-out;
+.sand-button-resting-bg-colors (@bg: {}, @shadow: {}) {
+	.sand-spotlight-resting-bg-colors(@opacity: 0, @bg: {
+		.sand-button-resting-bg-color();
+		will-change+: transform;
+		transition+: transform @sand-button-focus-duration ease-out;
+		@bg();
+	}, @shadow);
 }
 
-.sand-button-selected-colors () {
-	.sand-button-resting-bg-colors();
-	.sand-button-selected-bg-color();
+.sand-button-selected-colors (@bg: {}, @shadow: {}) {
+	&::after {
+		.sand-button-selected-bg-color();
+		@bg();
+	}
 }
 
-.sand-button-focus-bg-colors () {
-	.sand-spotlight-focus-shadow-colors();
-	.sand-button-focus-bg-color();
-	opacity: 1;
+.sand-button-focus-bg-colors (@bg: {}, @shadow: {}) {
+	.sand-spotlight-focus-bg-colors(@bg: {
+		.sand-button-focus-bg-color();
+		@bg();
+	}, @shadow);
 }

--- a/styles/color-mixins.less
+++ b/styles/color-mixins.less
@@ -9,6 +9,17 @@
 // ---------------------------------------
 // Focus Shadow and background setup
 // ---------------------------------------
+.sand-bg-colors (@bg) {
+	//// Relocate the bg styling to a pseudo-element
+	// &::after {
+		@bg();
+	// }
+}
+.sand-shadow-colors (@shadow) {
+	&::before {
+		@shadow();
+	}
+}
 
 // Establish rules assignment for before focus has happened
 .sand-spotlight-resting-bg-colors (@opacity: 0, @bg: {}, @shadow: {}) {
@@ -22,52 +33,63 @@
 	will-change+: opacity;
 
 	// Prep common aspects
-	@shared: {
+	@pseudo-element-setup: {
 		content: "";
 		position: absolute;
 		.position(0);
 		border-radius: inherit;
-		--spotlight-resting-bg-colors: 1;
 	};
 
 	// Shadow
-	&::before {
-		@shared();
+	.sand-shadow-colors({
+		@pseudo-element-setup();
 		background-color: @sand-spotlight-bg-color;
-		box-shadow: @sand-spotlight-focus-shadow;
-		transform+_: scale(0.9, 0.5); // Hard-coded values, not part of the design. This transform is responsible for tucking the shadow up inside the background so it can transition out.
 		opacity: 0;
-		transition+: @transition-opacity, @transition-transform;
-		will-change+: opacity, transition;
+
+		// filter+: drop-shadow(@sand-spotlight-focus-shadow);
+		box-shadow: @sand-spotlight-focus-shadow;
+
+		//// Include a transform on the shadow for a better effect
+		// transform+_: scale(0.9, 0.5); // Hard-coded values, not part of the design. This transform is responsible for tucking the shadow up inside the background so it can transition out.
+		// transition+: @transition-opacity, @transition-transform;
+		// will-change+: opacity, transition;
+
+		//// Simple opacity change to the shadow (fade-in)
+		transition+: @transition-opacity;
+		will-change+: opacity;
+
 		@shadow();
-	}
+	});
+
 	// Background coloration
-	&::after {
-		@shared();
+	.sand-bg-colors({
+		// @pseudo-element-setup();
+
 		background-color: @sand-spotlight-bg-color;
 		transition+: @transition-filter;
 		will-change+: filter;
+
 		@bg();
-	}
+	});
 }
 
 // Establish rules assignment for after focus has happened
 .sand-spotlight-focus-bg-colors (@bg: {}, @shadow: {}) {
 	opacity: 1;
-	&::after {
+	.sand-bg-colors({
 		background-color: @sand-spotlight-bg-color;
 		@bg();
-	}
+	});
 	.sand-spotlight-focus-shadow-colors(@shadow);
 }
 
 // Just the spotlight shadow (merge-safe)
 .sand-spotlight-focus-shadow-colors (@shadow: {}) {
-	&::before {
+	.sand-shadow-colors({
 		transform: scale(1);
 		opacity: 1;
 		@shadow();
-	}
+	});
 }
 
 .sand-spotlight-focus-text-colors () {
@@ -128,10 +150,10 @@
 }
 
 .sand-button-selected-colors (@bg: {}, @shadow: {}) {
-	&::after {
+	.sand-bg-colors({
 		.sand-button-selected-bg-color();
 		@bg();
-	}
+	});
 }
 
 .sand-button-focus-bg-colors (@bg: {}, @shadow: {}) {


### PR DESCRIPTION
As part of performance optimization, an alternate approach to supporting the shadow is to use `box-shadow` instead of `filter: drop-shadow()`. This migrates all of the focus mixins to use this alternate approach, as well as the Button state mixins.

### Where is this?
This can be seen on the following components:
* Button
  * All types
* Item
  * All derivatives

### Known Issues
_These will be resolved before final merge._
* [ ] Joined Picker focus
  * A pending ticket (#480) for Picker implements a major refactor, which changes the location where these effects will be added. _I may decide to rebase this PR on that ticket if the dependent work doesn't land soon, to get this portion of the work and testing out of the way._
* [ ] ImageItem focus
  * ImageItem uses UI image item as the base, but doesn't support the ability to add or inject a `.bg` node, necessary for attaching the styles to.
