### PR TITLE
PLAT-112392: Fix failing Dropdown UI test

### DIFF
--- a/tests/ui/specs/Dropdown/Dropdown-specs.js
+++ b/tests/ui/specs/Dropdown/Dropdown-specs.js
@@ -2,7 +2,7 @@ const Page = require('./DropdownPage');
 
 function waitForFocusedText (dropdown, text, timeout, timeoutMsg = `timed out waiting for ${text}`, interval = 250) {
 	browser.waitUntil(function () {
-		return dropdown.focusedItemText === text;
+		return dropdown.focusedItemText.indexOf(text) === 0;
 	}, {timeout, timeoutMsg, interval});
 }
 
@@ -14,7 +14,7 @@ describe('Dropdown', function () {
 			Page.open();
 		});
 
-		it.skip('should focus the first item when `selected` changes to `null` - [GT-30183]', function () {
+		it('should focus the first item when `selected` changes to `null` - [GT-30183]', function () {
 			const dropdown = Page.components.dropdownChangeSelected;
 
 			Page.openDropdown(dropdown);


### PR DESCRIPTION
We have a `Dropdown` UI test that repeatedly fails each release that we should skip for now.

After taking a brief look at it, I have a hunch that the addition of the selection/checkmark to the dropdown items may be interfering with grabbing and matching the text content of the dom, since now the selected dom will report to have a `"four↵✓"` text content instead of `"four"`. However, any newline stripping I tried (albeit quickly) still didn't match the expected string and/or checkmark. That being said, I'm still not confident that's the problem with the test.