### PR TITLE
PLAT-113144: Fix Input preventDefault test failure

### DIFF
--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -271,7 +271,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		onKeyDown (ev) {
-			const {currentTarget, keyCode, preventDefault, target} = ev;
+			const {currentTarget, keyCode, target} = ev;
 
 			// cache the target if this is the first keyDown event to ensure the component had focus
 			// when the key interaction started
@@ -299,7 +299,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				// prevent modifying the value via 5-way for numeric fields
 				if ((isUp || isDown) && target.type === 'number') {
-					preventDefault();
+					ev.preventDefault();
 				}
 
 				if (shouldSpotlightMove) {
@@ -330,7 +330,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		onKeyUp = (ev) => {
 			const {dismissOnEnter} = this.props;
-			const {currentTarget, keyCode, preventDefault, target} = ev;
+			const {currentTarget, keyCode, target} = ev;
 
 			// verify that we have a matching pair of key down/up events to avoid adjusting focus
 			// when the component received focus mid-press
@@ -341,7 +341,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					if (this.state.focused === 'input' && dismissOnEnter && is('enter', keyCode)) {
 						this.focusDecorator(currentTarget);
 						// prevent Enter onKeyPress which triggers an onMouseDown via Spotlight
-						preventDefault();
+						ev.preventDefault();
 					} else if (this.state.focused !== 'input' && is('enter', keyCode)) {
 						this.focusInput(currentTarget);
 					}


### PR DESCRIPTION
This became necessary because of changes with how the event is forwarded from enactjs/enact#2809.  It may be caused by an error in React TestUtils implementation of `simulate` but I did not investigate that fully.

That said, I changed the source because destructuring instance methods seems sketchy to begin with.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com