### PR TITLE
PLAT-113149: Fix timing of calling setThemeScrollContentHandle

### DIFF
--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -347,13 +347,11 @@ const useThemeScroller = (props, scrollContentProps, isHorizontalScrollbarVisibl
 	const {calculatePositionOnFocus, focusOnNode, setContainerDisabled} = useSpottable(scrollContentProps, {scrollContainerRef, scrollContentHandle, scrollContentRef});
 	const focusableBodyProps = (props.focusableScrollbar === 'byEnter') ? getFocusableBodyProps(scrollContainerRef) : {};
 
-	useEffect(() => {
-		scrollContentProps.setThemeScrollContentHandle({
-			calculatePositionOnFocus,
-			focusOnNode,
-			setContainerDisabled
-		});
-	}, [calculatePositionOnFocus, focusOnNode, scrollContentProps, setContainerDisabled]);
+	scrollContentProps.setThemeScrollContentHandle({
+		calculatePositionOnFocus,
+		focusOnNode,
+		setContainerDisabled
+	});
 
 	// Render
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -337,9 +337,8 @@ const useThemeVirtualList = (props) => {
 		shouldPreventOverscrollEffect,
 		shouldPreventScrollByFocus
 	};
-	useEffect(() => {
-		props.setThemeScrollContentHandle(handle);
-	}, [handle, props]);
+
+	props.setThemeScrollContentHandle(handle);
 
 	// Render
 


### PR DESCRIPTION
This PR fixes not focusing item by `scrollTo` from App with special condition "vertical/horizontalScrollbar prop is visible".
Currently `setThemeScrollContentHandle` is called in `useEffect` so the functions in themeScrollContentHandle may have the old props when the App calls `scrollTo` in `componentDidUpdate` phase.
We had it in `useEffect` since we have been using `ref` in moonstone, but after migration with hooks, we changed it to use `useRef` so I think we are safe to call it out of `useEffect`.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)