### PR TITLE
PLAT-113453: Fixed spacing between Header's title and subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` to read out each number value with space when input button focused
 - `sandstone/FixedPopupPanels`, `sandstone/Panels`, and `sandstone/PopupTabLayout` to avoid skipping panel animations when under system load
 - `sandstone/MediaControls` to start animation after more components are rendered
+- `sandstone/Panels.Header` spacing between title and subtitle
 - `sandstone/Popup` to correctly emit the `onClose` event when focus attempts to leave the popup
 - `sandstone/PopupTabLayout` and `sandstone/TabLayout` to not lose focus from tabs with 5-way
 - `sandstone/Scroller` to not losing focus on scrollbar when re-render

--- a/samples/sampler/stories/default/Header.js
+++ b/samples/sampler/stories/default/Header.js
@@ -5,6 +5,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import {Panel, Header, HeaderBase} from '@enact/sandstone/Panels';
+import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Steps from '@enact/sandstone/Steps';
 
@@ -63,6 +64,7 @@ storiesOf('Sandstone', module)
 				>
 					{children}
 				</Header>
+				<BodyText>Example body text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam malesuada felis egestas elit laoreet, at egestas justo ornare. Fusce vel diam porttitor, dapibus nisi in, lobortis ante. Sed quis gravida sapien, id convallis dui.</BodyText>
 			</Panel>);
 
 			return story;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -63,10 +63,14 @@
 		standard-padding: 108px 150px 73px 150px;
 		standard-title-font-size: 108px;
 		standard-title-line-height: 127px;
+		standard-titles-gap: 18px;
+		standard-subtitle-font-size: 60px;
+		standard-subtitle-line-height: 70px;
 
 		wizard-padding: 108px 150px 66px 150px;
 		wizard-title-font-size: 144px;
 		wizard-title-line-height: 169px;
+		wizard-titles-gap: 12px;
 	}
 
 	.panel() {
@@ -118,7 +122,7 @@
 @sand-heading-medium-font-size:     66px;
 @sand-heading-small-font-size:      54px;
 @sand-heading-tiny-font-size:       48px;
-@sand-heading-subtitle-font-size:   60px;
+@sand-heading-subtitle-font-size:   #guide.header[standard-subtitle-font-size];
 @sand-heading-title-font-size:      #guide.header[standard-title-font-size];
 @sand-imageitem-caption-font-size:  60px;
 @sand-imageitem-label-font-size:    48px;
@@ -426,7 +430,7 @@
 // Header
 // ---------------------------------------
 @sand-header-slotabove-margin: 0 -@sand-component-spacing 30px -@sand-component-spacing; // Negative margins accomodate the component-spacing
-@sand-header-slotbelow-margin: 84px -@sand-component-spacing 0 -@sand-component-spacing; // Negative margins accomodate the component-spacing
+@sand-header-slotbelow-margin: 18px -@sand-component-spacing 0 -@sand-component-spacing; // Negative margins accomodate the component-spacing
 @sand-header-subtitle-height: (@sand-heading-subtitle-font-size * @sand-heading-subtitle-line-height);
 // STOP! READ THE FOLLOWING BEFORE EDITING.
 //
@@ -451,7 +455,21 @@
 	.extract(#guide.header[standard-padding], bottom)[]
 	.extract(#guide.header[standard-padding], left)[];
 @sand-header-standard-title-padding: 0;
-@sand-header-standard-subtitle-margin: -24px 0 0 0;
+@sand-header-standard-subtitle-margin:
+	(
+		.extract(#guide.header[standard-titles-gap], top)[]
+		- #guide.get-edge-size-difference(
+			#guide.header[standard-title-line-height],
+			@sand-heading-title-font-size,
+			@sand-heading-title-line-height
+		)[@result]
+		- #guide.get-edge-size-difference(
+			#guide.header[standard-subtitle-line-height],
+			@sand-heading-subtitle-font-size,
+			@sand-heading-subtitle-line-height
+		)[@result]
+	)
+	0 0 0;
 @sand-header-compact-margin: 0;
 @sand-header-compact-padding:
 	(


### PR DESCRIPTION
The spacing was previously set to a fixed value, which was out of sync with the guide.

The new approach calculates the correct value based on the guide reference variables and the locale-safe line heights of the titles.

The Header sample now also includes body text to help illustrate where the header stops and the content starts.