### PR TITLE
PLAT-105136: Fix Spotlight lands on the X Closing button 

### DIFF
--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -139,7 +139,7 @@ const InPanels = ({className, title, ...rest}) => {
 	return (
 		<Panels className={className} index={index}>
 			<Panel>
-				<Header type="compact" title={`${title} Panel 0`} key="header" noCloseButton />
+				<Header type="compact" title={`${title} Panel 0`} key="header" />
 				<VirtualList
 					id="spotlight-list"
 					// eslint-disable-next-line enact/prop-types
@@ -149,7 +149,7 @@ const InPanels = ({className, title, ...rest}) => {
 				/>
 			</Panel>
 			<Panel title={`${title} Panel 1`}>
-				<Header type="compact" title={`${title} Panel 1`} key="header" noCloseButton />
+				<Header type="compact" title={`${title} Panel 1`} key="header" />
 				<Item onClick={handleSelectItem}>Go Back</Item>
 			</Panel>
 		</Panels>
@@ -265,8 +265,7 @@ storiesOf('VirtualList', module)
 	)
 	.add(
 		'in Panels',
-		context => {
-			context.noPanels = true;
+		(context) => {
 			const title = `${context.kind} ${context.story}`.trim();
 			return (
 				<InPanels
@@ -286,6 +285,11 @@ storiesOf('VirtualList', module)
 					wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 				/>
 			);
+		},
+		{
+			props: {
+				noPanels: true
+			}
 		}
 	)
 	.add(


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
QA Sampler VirtualList>inPanels: Spotlight lands on the X Closing button instead of the 'Go Back' button
 
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In alpha 8, a close button was added to the header(#211).  so, duplicated panel and x buttons were shown from alpha 8.
In this patch, I removed the outer panels.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-105136

### Comments
