### PR TITLE
PLAT-112490: Remove case that do not require testing on qa-a11y

### DIFF
--- a/samples/qa-a11y/src/views/Region.js
+++ b/samples/qa-a11y/src/views/Region.js
@@ -88,16 +88,16 @@ const RegionView = kind({
 
 			<Region className={css.region} title="Outside region">
 				<Region title="Inside region">
-					<p>Focusing Button 13 should read "Outside region, Inside region, Button 13, button"</p>
+					<p>Focusing Button 12 should read "Outside region, Inside region, Button 12, button"</p>
 					<Button>Button 12</Button>
 				</Region>
 			</Region>
 
 			<Region className={css.region} title="Outside region">
-				<p>Focusing Button 13 should read "Outside region, Button 14, button"</p>
+				<p>Focusing Button 13 should read "Outside region, Button 13, button"</p>
 				<Button>Button 13</Button>
 				<Region title="Inside region">
-					<p>Focusing Button 14 should read "Inside region, Button 15, button"</p>
+					<p>Focusing Button 14 should read "Inside region, Button 14, button"</p>
 					<Button>Button 14</Button>
 				</Region>
 			</Region>


### PR DESCRIPTION
The sample that I'm removing from this PR is a composite test of `region` role and `dialog` role.
It is unnecessary to test that the sandstone is not used for the purpose, so it is removed.

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)