### PR TITLE
PLAT-113638: Fix Checkbox and Switch to support `aria-disabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Checkbox` and `sandstone/Switch` to support `aria-disabled`
 - `sandstone/TabGroup` to read out contents without button `role`
 
 ## [1.0.1] - 2020-07-20

--- a/Checkbox/Checkbox.js
+++ b/Checkbox/Checkbox.js
@@ -75,6 +75,15 @@ const CheckboxBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Disables Checkbox and becomes non-interactive.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		disabled: PropTypes.bool,
+
+		/**
 		 * Enables the "indeterminate" state.
 		 *
 		 * An indeterminate, mixed, or half-selected state is typically used in a hierarchy or group
@@ -141,7 +150,7 @@ const CheckboxBase = kind({
 		children: ({indeterminate, indeterminateIcon, children}) => (indeterminate ? indeterminateIcon : children) // This controls which icon to use, an not that icon's visual presence.
 	},
 
-	render: ({children, css, selected, ...rest}) => {
+	render: ({children, css, disabled, selected, ...rest}) => {
 		delete rest.indeterminate;
 		delete rest.indeterminateIcon;
 		delete rest.standalone;
@@ -150,6 +159,8 @@ const CheckboxBase = kind({
 			<div
 				{...rest}
 				aria-checked={selected}
+				aria-disabled={disabled}
+				disabled={disabled}
 				role="checkbox"
 			>
 				<div className={css.bg} />

--- a/Switch/Switch.js
+++ b/Switch/Switch.js
@@ -41,6 +41,15 @@ const SwitchBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Disables Switch and becomes non-interactive.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		disabled: PropTypes.bool,
+
+		/**
 		 * Disables animation.
 		 *
 		 * @type {Boolean}
@@ -78,13 +87,15 @@ const SwitchBase = kind({
 		})
 	},
 
-	render: ({children, css, selected, ...rest}) => {
+	render: ({children, css, disabled, selected, ...rest}) => {
 		delete rest.noAnimation;
 
 		return (
 			<div
 				{...rest}
 				aria-pressed={selected}
+				aria-disabled={disabled}
+				disabled={disabled}
 				role="button"
 			>
 				<div className={css.bg} />


### PR DESCRIPTION
Sandstone does not readout ".. deactivated" when Checkbox and Switch focused. Because the focusable element does not have an `aria-disabled` prop. Therefore, modified to put `aria-disabled` as in the state of the `disabled` prop.

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)