### PR TITLE
PLAT-114488: Fix VirtualList Scrollbar thumb to not clipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Scroller` and `sandstone/VirtualList` scrollbar thumb shape to not clipped
 - `sandstone/Scroller` not to read out thumb audio guidance when focusing on the body
 - `sandstone/Checkbox` and `sandstone/Switch` to support `aria-disabled`
 - `sandstone/ProgressButton` icon size

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -767,8 +767,8 @@
 @sand-scrollbar-track-margin: 12px;
 @sand-scrollbar-track-focusable-margin: 24px;
 @sand-scrollbar-track-width: 12px;
-@sand-scrollbar-track-border-radius: 6px;
-@sand-scrollbar-thumb-border-radius: 6px;
+@sand-scrollbar-track-border-radius: 12px;
+@sand-scrollbar-thumb-border-radius: 12px;
 @sand-scrollbar-thumb-focus-width: 30px;
 @sand-scrollbar-thumb-focus-left: -9px;
 @sand-scrollbar-thumb-focus-border-radius: 12px;


### PR DESCRIPTION
Due to `border-radius` value is too small, the scrollbar thumb is clipped some times.
I increased the value to 12px.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)