### PR TITLE
PLAT-109024: Switched to "tallglyph" locale support

### DIFF
--- a/styles/mixins.less
+++ b/styles/mixins.less
@@ -174,14 +174,10 @@
 
 // Generic Non-Latin Font Rule generator
 .sand-locale-non-latin(@nlrules; @target) when (isruleset(@nlrules)) and (@target = self) {
-	&:global(.enact-locale-non-latin) {
-		@nlrules();
-	}
+	.enact-locale(non-latin, @nlrules);
 }
 .sand-locale-non-latin(@nlrules; @target: normal) when (isruleset(@nlrules)) {
-	:global(.enact-locale-non-latin) & {
-		@nlrules();
-	}
+	.enact-locale(non-latin, @nlrules);
 }
 
 //
@@ -258,16 +254,17 @@
 }
 
 .sand-body-text() {
+	font-weight: @sand-body-font-weight;
+	font-size: @sand-body-font-size;
+	font-style: @sand-body-font-style;
 	.sand-font(@sand-body-font-family; @sand-non-latin-font-family-light; {
 		font-weight: @sand-non-latin-body-font-weight;
 		font-size: @sand-non-latin-body-font-size;
 		font-style: @sand-non-latin-body-font-style;
-		line-height: @sand-non-latin-body-line-height;
 	});
-	font-weight: @sand-body-font-weight;
-	font-size: @sand-body-font-size;
-	font-style: @sand-body-font-style;
-	line-height: @sand-body-line-height;
+
+	.enact-locale-line-height(@sand-body-line-height; @sand-non-latin-body-line-height);
+
 	a:link {color: inherit; text-decoration:none;}
 	a:visited {color: inherit; text-decoration:none;}
 	a:hover {color: inherit; text-decoration:none;}
@@ -306,9 +303,13 @@
 	-webkit-box-orient: vertical;
 }
 
-// Assign rules specifically to RTL locales
-.enact-locale-rtl(@rtlrules) when (isruleset(@rtlrules)) {
-	:global(.enact-locale-right-to-left) & {
-		@rtlrules();
-	}
+// Add an extension to the .enact-locale-line-height mixin defined in ~@ui which has defaults specific to sandstone.
+//
+// Set line-height for normal and tallglyphs with 0, 1 or 2 arguments
+// Ex:
+//   .enact-locale-line-height();              ->  normal: default; tallglyphs: default;
+//   .enact-locale-line-height(1.4em);         ->  normal: 1.4em; tallglyphs: default;
+//   .enact-locale-line-height(1.4em; 1.6em);  ->  normal: 1.4em; tallglyphs: 1.6em;
+.enact-locale-line-height(@normal: @sand-common-line-height; @tallglyph: @sand-tallglyph-line-height) when (default()) {
+	.enact-locale-tallglyph(line-height, @normal, @tallglyph);
 }

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -90,6 +90,10 @@
 @sand-translate-center: translate(-50%, -50%);
 @sand-common-circular-corners: 9000px; // A value large enough that when applied to any node via border-radius produces a completely round corner
 
+// Locale
+// ---------------------------------------
+@locale-tallglyph-languages: th, si, ar;
+
 // Spotlight
 // ---------------------------------------
 @sand-spotlight-font-weight: 600;
@@ -183,6 +187,8 @@
 @sand-non-latin-font-weight: 400;
 @sand-non-latin-font-weight-light: 300;
 @sand-non-latin-font-weight-bold: 700;
+@sand-common-line-height: 1.3em;
+@sand-tallglyph-line-height: 1.5em;
 
 // Alert
 @sand-alert-font-family: @sand-font-family;
@@ -216,7 +222,7 @@
 @sand-timepicker-colon-margin: 0 6px;
 
 // Heading
-@sand-heading-line-height: 1.3em;
+@sand-heading-line-height: @sand-common-line-height;
 @sand-heading-font-style: normal;
 @sand-heading-title-font-family: @sand-alt-font-family;
 @sand-heading-title-font-weight: normal;
@@ -253,10 +259,10 @@
 @sand-input-number-font-family: @sand-body-font-family;
 
 // Item
-@sand-item-line-height: 1.3em;
+@sand-item-line-height: @sand-common-line-height;
 @sand-item-line-height-large: @sand-item-line-height;
 @sand-item-label-line-height: @sand-item-line-height;
-@sand-item-small-line-height: 1.3em;
+@sand-item-small-line-height: @sand-common-line-height;
 @sand-item-small-line-height-large: @sand-item-small-line-height;
 @sand-item-small-label-line-height: @sand-item-small-line-height;
 


### PR DESCRIPTION
This PR is a Sandstone version of the https://github.com/enactjs/enact/pull/2834 PR (dependency) which prepares Sandstone for the conversion to the more granular `.enact-locale()` mixin format of applying localization styling rules.

This simplifies and standardizes the code's ability to target specific locale features.

### Additional Considerations
Like the base PR, an additional PR can be created for the conversion of all existing references of the global class name to the new mixin format. This could additionally be bundled with this PR, but was left out to keep the focus of the review on the "work" parts of the change, rather than the conversion.