### PR TITLE
PLAT-115882: VideoPlayer sampler to set default value of muted prop

### DIFF
--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -156,7 +156,7 @@ storiesOf('Sandstone', module)
 						jumpDelay={number('jumpDelay', Config, 200)}
 						loop={boolean('loop', Config, true)}
 						miniFeedbackHideDelay={number('miniFeedbackHideDelay', Config, 2000)}
-						muted={boolean('muted', Config, true)}
+						muted={boolean('muted', Config)}
 						no5WayJump={boolean('no5WayJump', Config)}
 						noAutoPlay={boolean('noAutoPlay', Config)}
 						noAutoShowMediaControls={boolean('noAutoShowMediaControls', Config)}


### PR DESCRIPTION
VideoPlayer sampler set `muted` prop value `true` and it causes confusion like - Sandstone VideoPlayer has a sound problem. I've got several same questions
I don't know why this sampler set this prop true but I would like to remove and follow the default value if there's no issue.

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>