### PR TITLE
PLAT-116121: Allow key events to bubble after Panels is unmounted whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Button` focus style to match latest designs
 - `sandstone/Panels.Panel` to return to last focused element when reentering the `Panel`
+- `sandstone/Panels` to allow key events after being unmounted
 - `sandstone/TabLayout` to correctly restore focus to the selected tab after expanding
 - `sandstone/VideoPlayer.Video` to reuse video DOM node when changing `source`
 

--- a/internal/Panels/Viewport.js
+++ b/internal/Panels/Viewport.js
@@ -202,7 +202,7 @@ const ViewportBase = class extends React.Component {
 	}
 
 	componentWillUnmount () {
-		this.paused.resume();
+		this.resume();
 	}
 
 	addTransitioningClass = () => {


### PR DESCRIPTION
…n capturing

In #658 we introduced a feature where we stop key events in `Panels` during transitions. We failed to properly allow key events to bubble/resume when panels are unmounted.

When unmounting, we can call `this.resume()` which is a convenience method to resume the spotlight paused state and also stop capturing and preventing key events.