### PR TITLE
PLAT-116312: Add WizardPanels UI test to validate horizontal body-to-…

### DIFF
--- a/tests/ui/specs/WizardPanels/WizardPanels-specs.js
+++ b/tests/ui/specs/WizardPanels/WizardPanels-specs.js
@@ -78,6 +78,8 @@ describe('WizardPanels', function () {
 		});
 
 		it('should focus an eligible navigation button when leaving the contents or footer via 5-way left or right', function () {
+			expect('OK').to.be.equal(browser.execute(getFocusedTextContent));
+
 			Page.spotlightRight();
 			Page.spotlightRight();
 


### PR DESCRIPTION
…header 5-way focus

Note: This relies on the enact fix: https://github.com/enactjs/enact/pull/2848

### Issue
When navigating via 5-way *left or right* within the body/footer of `WizardPanels`, you cannot focus on the navigation buttons - even when they're the next expected target.

### Fix
There is a related enact fix (which this PR depends) that resolves an issue where you are unable to set focus from an element if the next eligible element resides in a container that does not also meet the eligibility requirements based on the 5-way direction pressed. https://github.com/enactjs/enact/pull/2848