### PR TITLE
PLAT-117003: Updated sandstone to use new helper method from ui-test-utils

### DIFF
--- a/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
+++ b/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
@@ -12,7 +12,7 @@ describe('FixedPopupPanels', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.item1);
+			Page.waitForFocused(Interface.item1);
 
 			Interface.waitForEnter(2, () => {
 				Page.spotlightSelect();
@@ -34,7 +34,7 @@ describe('FixedPopupPanels', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.item1);
+			Page.waitForFocused(Interface.item1);
 
 			// focus the right picker button
 			Page.spotlightDown();
@@ -61,7 +61,7 @@ describe('FixedPopupPanels', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.item1);
+			Page.waitForFocused(Interface.item1);
 
 			Page.spotlightLeft();
 
@@ -75,7 +75,7 @@ describe('FixedPopupPanels', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.item1);
+			Page.waitForFocused(Interface.item1);
 
 			Page.spotlightLeft();
 

--- a/tests/ui/specs/FixedPopupPanels/FixedPopupPanelsPage.js
+++ b/tests/ui/specs/FixedPopupPanels/FixedPopupPanelsPage.js
@@ -94,10 +94,6 @@ class FixedPopupPanelsPage extends Page {
 	open (urlExtra) {
 		super.open('FixedPopupPanels-View', urlExtra);
 	}
-
-	waitForFocus (target, {targetName = 'item', timeoutMsg = `timed out waiting for ${targetName} focused`, timeout = 1200, interval = 200} = {}) {
-		browser.waitUntil(() => target.isExisting() && target.isFocused(), {timeout, timeoutMsg, interval});
-	}
 }
 
 module.exports = new FixedPopupPanelsPage();

--- a/tests/ui/specs/FixedPopupPanels/WithoutPanel/FixedPopupPanelsWithoutPanel-specs.js
+++ b/tests/ui/specs/FixedPopupPanels/WithoutPanel/FixedPopupPanelsWithoutPanel-specs.js
@@ -15,11 +15,11 @@ describe('FixedPopupPanelsWithoutPanel', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.item1);
+			Page.waitForFocused(Interface.item1);
 
 			Page.backKey();
 
-			Page.waitForFocus(Interface.openButton, {targetName: 'open button'});
+			Page.waitForFocused(Interface.openButton, {targetName: 'open button'});
 		});
 	});
 });

--- a/tests/ui/specs/FixedPopupPanels/WithoutPanel/FixedPopupPanelsWithoutPanelPage.js
+++ b/tests/ui/specs/FixedPopupPanels/WithoutPanel/FixedPopupPanelsWithoutPanelPage.js
@@ -34,10 +34,6 @@ class FixedPopupPanelsPage extends Page {
 	open () {
 		super.open('FixedPopupPanelsWithoutPanel-View');
 	}
-
-	waitForFocus (target, {targetName = 'item', timeoutMsg = `timed out waiting for ${targetName} focused`, timeout = 1200, interval = 200} = {}) {
-		browser.waitUntil(() => target.isExisting() && target.isFocused(), {timeout, timeoutMsg, interval});
-	}
 }
 
 module.exports = new FixedPopupPanelsPage();

--- a/tests/ui/specs/FlexiblePopupPanels/FlexiblePopupPanels-specs.js
+++ b/tests/ui/specs/FlexiblePopupPanels/FlexiblePopupPanels-specs.js
@@ -13,28 +13,28 @@ describe('FlexiblePopupPanels', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.singleItem);
+			Page.waitForFocused(Interface.singleItem);
 
 			// verifies that focus enters the panel body by default
 			Page.spotlightRight();
 
-			Page.waitForFocus(Interface.nextButton, {targetName: 'next button'});
+			Page.waitForFocused(Interface.nextButton, {targetName: 'next button'});
 
 			Page.spotlightSelect();
 			Interface.waitForPanelBody(2);
 
 			// should retain focus on navigation buttons - [GT-32184]
-			Page.waitForFocus(Interface.nextButton, {targetName: 'next button 2'});
+			Page.waitForFocused(Interface.nextButton, {targetName: 'next button 2'});
 
 			Page.spotlightLeft();
 			Page.spotlightLeft();
-			Page.waitForFocus(Interface.prevButton, {targetName: 'prev button'});
+			Page.waitForFocused(Interface.prevButton, {targetName: 'prev button'});
 
 			Page.spotlightSelect();
 			Interface.waitForPanelBody(1);
 
 			// should retain focus on navigation buttons - [GT-32184]
-			Page.waitForFocus(Interface.prevButton, {targetName: 'prev button 2'});
+			Page.waitForFocused(Interface.prevButton, {targetName: 'prev button 2'});
 		});
 
 		// [GT-32185]
@@ -43,13 +43,13 @@ describe('FlexiblePopupPanels', function () {
 
 			Page.spotlightSelect();
 
-			Page.waitForFocus(Interface.singleItem);
+			Page.waitForFocused(Interface.singleItem);
 
 			Page.spotlightLeft();
 			Page.spotlightSelect();
 			Interface.waitForPanelBody(7);
 
-			Page.waitForFocus($('#item2'), {targetName: 'item 2'});
+			Page.waitForFocused($('#item2'), {targetName: 'item 2'});
 		});
 	});
 

--- a/tests/ui/specs/FlexiblePopupPanels/FlexiblePopupPanelsPage.js
+++ b/tests/ui/specs/FlexiblePopupPanels/FlexiblePopupPanelsPage.js
@@ -103,9 +103,6 @@ class FlexiblePopupPanelsPage extends Page {
 		super.open('FlexiblePopupPanels-View', urlExtra);
 	}
 
-	waitForFocus (target, {targetName = 'item', timeoutMsg = `timed out waiting for ${targetName} focused`, timeout = 1200, interval = 200} = {}) {
-		browser.waitUntil(() => target.isExisting() && target.isFocused(), {timeout, timeoutMsg, interval});
-	}
 }
 
 module.exports = new FlexiblePopupPanelsPage();


### PR DESCRIPTION
- Update Sandstone UI tests to use the new waitForFocused helper method from ui-test-utils.