### PR TITLE
PLAT-113636: Update tooltipProps for A11y in TooltipDecorator sampler

### DIFF
--- a/samples/sampler/stories/default/TooltipDecorator.js
+++ b/samples/sampler/stories/default/TooltipDecorator.js
@@ -37,9 +37,7 @@ const prop = {
 		'transparent'
 	],
 	ariaObject: {
-		'aria-hidden': false,
-		'aria-label': 'Tooltip Label',
-		'role': 'alert'
+		'aria-hidden': true
 	}
 };
 


### PR DESCRIPTION
The `tooltipProps` in the `TooltipButton` wrapped with `TooltipDecorator` is different from our A11y guideline. So the `tooltipProps` is updated properly.

Our guideline for the `TooltipDecorator`.
```
const TooltipButton = TooltipDecorator(Button);
<TooltipButton
    aria-label="This is Text"
    tooltipProps={{'aria-hidden': true}}
    tooltipText="Text"
>Text 1</TooltipButton>
```

Read out: `This is Text` + `button`

```
If you want to use a Button wrapped with TooltipDecorator,
you should use `aria-label` and tooltipProps={{'aria-hidden': true}}.
If not, the screen reader tries to read out the Tooltip's content while reading out the Button content because the Tooltip has the `alert` role by default.
```



Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)