### PR TITLE
PLAT-115241: Fix VirtualList to avoid focusing first item when not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Tooltip` arrow shape
+- `sandstone/VirtualList` to avoid focusing first item when not required
 - `sandstone/WizardPanels` to render `Panel` contents within the usual render flow allowing more predictable use of lifecycle methods
 
 ### Added

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -391,7 +391,7 @@ function placeholderRenderer ({
 }) {
 	return (primary ? null : (
 		<SpotlightPlaceholder
-			data-index={0}
+			data-index={-1}
 			data-vl-placeholder
 			key="placeholder"
 			// a zero width/height element can't be focused by spotlight so we're giving


### PR DESCRIPTION
## Issue

Opening `Dropdown` with a selected item would result in focusing the first item in the `VirtualList` before focusing the selected item. This wasn't generally visible to users but did produce unexpected accessibility read out behavior.

## Analysis

`VirtualList` uses a spotlight placeholder to capture spotlight when the item that should be focused is not yet available. The placeholder was defaulting to a valid index, `0`, which caused `VirtualList` to focus that index when the component was updated.

See https://replay.io/view?id=7c5e602c-17ea-4273-aed9-d7db8e45452c for a walkthrough via comments

## Resolution

Change the placeholder to default to an invalid index so it doesn't attempt to restore to it when it isn't required.