### PR TITLE
PLAT-117972: Scroller: Focus should not leave scrollbar with 5-way directional keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Changed
 
+- `sandstone/Scroller` scrollbar thumb to prevent losing focus with 5-way directional keys when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` and `sandstone/VirtualList` scrollbar color and transparency
 
 ### Fixed

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -24,10 +24,15 @@ const getFocusableBodyProps = (scrollContainerRef, contentId) => {
 
 	const setNavigableFilter = ({filterTarget}) => {
 		if (spotlightId && filterTarget) {
-			const targetClassName = (filterTarget === 'body') ? css.focusableBody : scrollbarTrackCss.thumb;
+			const bodyFiltered = (filterTarget === 'body');
+			const targetClassName = bodyFiltered ? css.focusableBody : scrollbarTrackCss.thumb;
+
 			Spotlight.set(spotlightId, {
-				navigableFilter: (elem) => (typeof elem === 'string' || !elem.classList.contains(targetClassName))
+				navigableFilter: (elem) => (typeof elem === 'string' || !elem.classList.contains(targetClassName)),
+				// Focus should not leave scrollbar with directional keys
+				restrict: bodyFiltered ? 'self-only' : 'self-first'
 			});
+
 			return true;
 		}
 	};

--- a/tests/ui/specs/Scroller/Scroller-specs.js
+++ b/tests/ui/specs/Scroller/Scroller-specs.js
@@ -58,6 +58,53 @@ describe('Scroller', function () {
 			expect(ScrollerPage.buttonTop.isFocused()).to.be.true();
 		});
 
+		it('should not move its focus from scrollbar with directional keys when focusableScrollbar is `byEnter`[GT-33977]', function () {
+			// Step 3: Knobs > Scroller > focusableScrollbar > byEnter
+			ScrollerPage.dropdownFocusableScrollbar.moveTo();
+			ScrollerPage.spotlightSelect();
+			ScrollerPage.spotlightDown();
+			ScrollerPage.spotlightDown();
+			ScrollerPage.spotlightSelect();
+
+			// Step 3: Knobs > Scroller > direction > vertical
+			ScrollerPage.spotlightRight();
+			ScrollerPage.spotlightSelect();
+			ScrollerPage.spotlightDown();
+			ScrollerPage.spotlightDown();
+			ScrollerPage.spotlightSelect();
+
+			// Step 4: Hover on the (x) button. This case replaced 'X' button to 'Top' button.
+			ScrollerPage.buttonTop.moveTo();
+			// Step 4 Verify: Spotlight is on the (x) button.
+			expect(ScrollerPage.buttonTop.isFocused(), 'focus').to.be.true();
+			// Step 5: Press 5-Way Down.
+			ScrollerPage.spotlightDown();
+			// Step 5 Verify: Spotlight is on the box surrounding the item and scrollbars.
+			expect(ScrollerPage.focusableBody.isFocused()).to.be.true();
+			// Step 6: Press 5-Way Select.
+			ScrollerPage.spotlightSelect();
+			// Step 6 Verify: Spotlight is on the Scroll thumb in vertical scrollbar track.
+			expect(ScrollerPage.verticalScrollThumb.isFocused()).to.be.true();
+			// Step 7: Press any 5-Way direction key.
+			// Step 7 Verify: Spotlight is on the Scroll thumb in vertical scrollbar track.
+			ScrollerPage.spotlightLeft();
+			expect(ScrollerPage.verticalScrollThumb.isFocused()).to.be.true();
+			ScrollerPage.spotlightRight();
+			expect(ScrollerPage.verticalScrollThumb.isFocused()).to.be.true();
+			ScrollerPage.spotlightUp();
+			expect(ScrollerPage.verticalScrollThumb.isFocused()).to.be.true();
+			ScrollerPage.spotlightDown();
+			expect(ScrollerPage.verticalScrollThumb.isFocused()).to.be.true();
+			// Step 8: Press Back key (or 'esc' with Chrome) or 5-way Select.
+			ScrollerPage.backKey();
+			// Step 8 Verify: Spolight is on the box surrounding the item and scrollbars.
+			expect(ScrollerPage.focusableBody.isFocused()).to.be.true();
+			// Step 9: Press 5-Way Up.
+			ScrollerPage.spotlightUp();
+			// Step 9 Verify: Spotlight is on the (x) button.
+			expect(ScrollerPage.buttonTop.isFocused()).to.be.true();
+		});
+
 		it('should focus on scrollthumb with 5-way key and focusableScrollbar `true`[GT-28534]', function () {
 			// Step 3: Knobs > Scroller > focusableScrollbar > true
 			ScrollerPage.dropdownFocusableScrollbar.moveTo();


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
TV UX is changed. Scroller: Focus should not leave scrollbar with direction key.
Leave focus from scrollbar only allows back or ok key in byEnter mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set restrict  'self-only' to the scroller container when the scrolbar get focus.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-117972
Jenkins ui-test result : enact-ui-tests/575/

### Comments