### PR TITLE
PLAT-119130: FeedbackContent must always be updated to current playing time

### DIFF
--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -867,7 +867,6 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopDelayedMiniFeedbackHide();
 		this.announceJob.stop();
 		this.renderBottomControl.stop();
-		this.sliderTooltipTimeJob.stop();
 		this.slider5WayPressJob.stop();
 		if (this.floatingLayerController) {
 			this.floatingLayerController.unregister();
@@ -1255,7 +1254,7 @@ const VideoPlayerBase = class extends React.Component {
 			loading: el.loading,
 			proportionLoaded: el.proportionLoaded,
 			proportionPlayed: el.proportionPlayed || 0,
-			sliderTooltipTime: this.sliderScrubbing ? (this.sliderKnobProportion * el.duration) : el.currentTime,
+			sliderTooltipTime: el.currentTime,
 			// note: `el.loading && this.state.sourceUnavailable == false` is equivalent to `oncanplaythrough`
 			sourceUnavailable: el.loading && this.state.sourceUnavailable || el.error
 		};
@@ -1694,8 +1693,6 @@ const VideoPlayerBase = class extends React.Component {
 		this.sliderScrubbing = false;
 	};
 
-	sliderTooltipTimeJob = new Job((time) => this.setState({sliderTooltipTime: time}), 20);
-
 	handleKnobMove = (ev) => {
 		this.sliderScrubbing = true;
 
@@ -1706,7 +1703,6 @@ const VideoPlayerBase = class extends React.Component {
 			const seconds = Math.floor(this.sliderKnobProportion * this.video.duration);
 
 			if (!isNaN(seconds)) {
-				this.sliderTooltipTimeJob.throttle(seconds);
 				const knobTime = secondsToTime(seconds, getDurFmt(this.props.locale), {includeHour: true});
 
 				forward('onScrub', {...ev, seconds}, this.props);
@@ -1727,7 +1723,6 @@ const VideoPlayerBase = class extends React.Component {
 		this.stopDelayedFeedbackHide();
 
 		if (!isNaN(seconds)) {
-			this.sliderTooltipTimeJob.throttle(seconds);
 			const knobTime = secondsToTime(seconds, getDurFmt(this.props.locale), {includeHour: true});
 
 			forward('onScrub', {
@@ -1743,10 +1738,9 @@ const VideoPlayerBase = class extends React.Component {
 	handleSliderBlur = () => {
 		this.sliderScrubbing = false;
 		this.startDelayedFeedbackHide();
-		this.setState(({currentTime}) => ({
+		this.setState(() => ({
 			feedbackAction: 'blur',
-			feedbackVisible: true,
-			sliderTooltipTime: currentTime
+			feedbackVisible: true
 		}));
 	};
 


### PR DESCRIPTION
`FeedbackContent` is not updated to current playing time when slider is scrubbing.
But `FeedbackContent` must always be updated to current playing time.

This problem can't occur in the UX scenario.
However, since it is unnecessary logic, it needs to be fixed and there is related Q issue.
I want to delete the suspicious code.

Enact-DCO-1.0-Signed-off-by: Hyeok Jo (hyeok.jo@lge.com)