### PR TITLE
PLAT-119722: Fixed TabLayout to not handle key events from other popup components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/TabLayout` to not handle key events from other popup components
+
 ## [1.3.0] - 2020-09-14
 
 ### Added

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -228,7 +228,7 @@ const TabLayoutBase = kind({
 			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
 			const direction = getDirection(keyCode);
 
-			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical') {
+			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
 				Spotlight.setPointerMode(false);
 				ev.preventDefault();
 


### PR DESCRIPTION
Currently, TabLayout in popup handles key events from other popup components.
So I added a guard to prevent handling these keys.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)