### PR TITLE
PLAT-102833: Fix CheckboxItem QA Sample by removing knobs with undefined prop

### DIFF
--- a/samples/sampler/stories/qa/CheckboxItem.js
+++ b/samples/sampler/stories/qa/CheckboxItem.js
@@ -24,7 +24,6 @@ storiesOf('CheckboxItem', module)
 		() => (
 			<CheckboxItem
 				disabled={boolean('disabled', Config, false)}
-				iconPosition={select('iconPosition', ['before', 'after'], Config)}
 				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>
@@ -37,7 +36,6 @@ storiesOf('CheckboxItem', module)
 		() => (
 			<CheckboxItem
 				disabled={boolean('disabled', Config, false)}
-				iconPosition={select('iconPosition', ['before', 'after'], Config)}
 				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>
@@ -62,7 +60,6 @@ storiesOf('CheckboxItem', module)
 		() => (
 			<CheckboxItem
 				disabled={boolean('disabled', Config, false)}
-				iconPosition={select('iconPosition', ['before', 'after'], Config)}
 				inline={boolean('inline', Config)}
 				onToggle={action('onToggle')}
 			>


### PR DESCRIPTION
Signed-off-by: Jeongran Jang <jeongran.jang@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
React does not recognize the `iconPosition` prop on a DOM element when loading CheckboxItem QA Sample

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove knobs for 'iconPosition' which is undefined prop in CheckboxItem

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-102833

### Comments