### PR TITLE
PLAT-115130: Fixed TooltipDecorator to marquee when tooltipRelative is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/TooltipDecorator` to marquee when `tooltipReleative` prop is true
+
 ## [1.3.2] - 2020-09-25
 
 ### Changed

--- a/TooltipDecorator/TooltipDecorator.js
+++ b/TooltipDecorator/TooltipDecorator.js
@@ -454,7 +454,6 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const {children, tooltipMarquee, tooltipRelative, tooltipProps, tooltipText, tooltipWidth, tooltipType} = this.props;
 			const {top, left} = this.state.position;
 			const tooltipStyle = {
-				display: ((tooltipRelative && !this.state.showing) ? 'none' : null),
 				// Moving the position to CSS variables where there are additional offset calculations
 				'--tooltip-position-top': tooltipRelative ? null : ri.unit(top, 'rem'),
 				'--tooltip-position-left': tooltipRelative ? null : ri.unit(left, 'rem')
@@ -486,6 +485,8 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 							{renderedTooltip}
 						</FloatingLayerBase>
 					);
+				} else if (!this.state.showing) {
+					renderedTooltip = null;
 				}
 
 				if (tooltipDestinationProp === 'children') {


### PR DESCRIPTION
This PR fixes `Tooltip` which has a long text does not marquee when `tooltipRelative` is set to true.
When `tooltipRelative` set to true, the tooltip DOM is rendered with `display: none`, and the Marquee couldn't calculate its size properly at the rendered time.
Even the Marquee re-renders when the tooltip showing but there is no logic for restarting marquee in this case.
I've removed the `display: none` style so the lifecycle of the tooltip could be the same as the floating layer one.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)