### PR TITLE
PLAT-118004: Fix FlexiblePopupPanels sampler's custom button properly

### DIFF
--- a/samples/sampler/stories/default/FlexiblePopupPanels.js
+++ b/samples/sampler/stories/default/FlexiblePopupPanels.js
@@ -69,7 +69,7 @@ storiesOf('Sandstone', module)
 				>
 					<Panel
 						size={size}
-						prevButton={boolean('custom first Panel prevButton', PanelConfig) ?  <Button icon="arrowhookright" aria-label="go to last" /> : void 0}
+						prevButton={boolean('custom first Panel prevButton', PanelConfig) ?  <Button icon="jumpbackward" aria-label="go to last" /> : void 0}
 					>
 						<Header title="First List" />
 						<Scroller style={{width: (size === 'auto' ? ri.scaleToRem(900) : null)}}>
@@ -87,7 +87,7 @@ storiesOf('Sandstone', module)
 					</Panel>
 					<Panel
 						size={size}
-						nextButton={boolean('custom last Panel nextButton', PanelConfig) ? <Button icon="arrowhookleft" aria-label="go back to first" /> : void 0}
+						nextButton={boolean('custom last Panel nextButton', PanelConfig) ? <Button icon="jumpforward" aria-label="go back to first" /> : void 0}
 					>
 						<Header title="Third panel" />
 						<Scroller style={{width: (size === 'auto' ? ri.scaleToRem(900) : null)}}>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed customized last `Panel` nextButton on `Panel` 2 of 3 in sampler of `FlexiblePopupPanels`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Move custom nextButton' prop to the third `Panel` from the second `Panel`.
- Change `Icon` and aria-label properly.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-118004

### Comments