### PR TITLE
PLAT-124922: Changed Panels.Header to always show back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/Panels.Header` to always show back button
+
 ## [1.4.3] - 2020-10-30
 
 ### Changed

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -421,11 +421,11 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({backButtonAvailable, hover, noBackButton, entering, centered, children, type, styler}) => styler.append(
+		className: ({backButtonAvailable, noBackButton, centered, children, type, styler}) => styler.append(
 			{
 				centered,
 				// This likely doesn't need to be as verbose as it is, with the first 2 conditionals
-				showBack: (backButtonAvailable && !noBackButton && (hover || entering)),
+				showBack: (backButtonAvailable && !noBackButton),
 				withChildren: hasChildren(children)
 			},
 			type
@@ -492,7 +492,6 @@ const HeaderBase = kind({
 		closeButtonAriaLabel,
 		closeButtonBackgroundOpacity,
 		css,
-		hover,
 		noBackButton,
 		noCloseButton,
 		onBack,
@@ -508,6 +507,7 @@ const HeaderBase = kind({
 	}) => {
 		delete rest.arranger;
 		delete rest.entering;
+		delete rest.hover;
 		delete rest.marqueeOn;
 		delete rest.onHideBack;
 		delete rest.onShowBack;
@@ -528,7 +528,6 @@ const HeaderBase = kind({
 					iconFlip="auto"
 					onClick={onBack}
 					size="small"
-					spotlightDisabled={!(backButtonAvailable && !noBackButton && hover)}
 				/>
 			</div>
 		) : null);


### PR DESCRIPTION
On touchable device, UX wants to always show the back button from Panels.Header.
This PR changes the behavior.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)