### PR TITLE
PLAT-125201: Ignore pointer events on scroll thumb when touching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Changed
 
 - `sandstone/Panels.Header` to always show back button
-- `sandstone/Scroller` scrollbar thumb to not get focus with touch when `focusableScrollbar`
+- `sandstone/Scroller` scrollbar thumb to not get focus with touch when `focusableScrollbar` is `true` or `byEnter`
 
 ## [1.4.3] - 2020-10-30
 

--- a/useScroll/ScrollbarTrack.module.less
+++ b/useScroll/ScrollbarTrack.module.less
@@ -103,7 +103,7 @@
 					right: calc(@sand-scrollbar-thumb-focus-direction-indicator-top - @sand-scrollbar-thumb-focus-direction-indicator-height);
 					top: calc(@sand-scrollbar-thumb-focus-direction-indicator-left/2);
 				}
-			})
+			});
 		}
 	}
 }


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- In touch mode, the focus indication is displayed only the moment of touch down.
The focusableScroll thumb expand the size and changes color to white, but this momentary change causes a bug.
- There is four types of behaviors when tapping a scroll thumb when focusableScrollbar=true
case 1) No action
case 2) Getting brighter and bigger, then back to normal (a normal focus effect)
case 3) Getting brighter and bigger, then only color is back to normal (a bigger thumb left)
case 4) Just getting brighter and back to normal

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
-  Changed  `sandstone/Scroller` scrollbar thumb to not get focus with touch when `focusableScrollbar`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-125201

### Comments