### PR TITLE
PLAT-124936: Fixes to Button and Marquee

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -159,7 +159,6 @@ const ButtonBase = kind({
 		 * Boolean controlling whether this component should enforce the "minimum width" rules.
 		 *
 		 * @type {Boolean}
-		 * @default true
 		 * @public
 		 */
 		minWidth: PropTypes.bool,
@@ -180,6 +179,7 @@ const ButtonBase = kind({
 		collapsed: false,
 		focusEffect: 'expand',
 		iconComponent: Icon,
+		iconOnly: false,
 		iconPosition: 'before',
 		size: 'large'
 	},
@@ -236,9 +236,11 @@ const ButtonBase = kind({
 const IconButtonDecorator = hoc((config, Wrapped) => {
 	return kind({
 		name: 'IconButtonDecorator',
+
 		computed: {
 			iconOnly: ({children}) => (React.Children.toArray(children).filter(Boolean).length === 0)
 		},
+
 		render: (props) => {
 			return (
 				<Wrapped {...props} />

--- a/Marquee/Marquee.js
+++ b/Marquee/Marquee.js
@@ -38,7 +38,7 @@ const Marquee = MarqueeDecorator('div');
 export default Marquee;
 export {
 	/**
-	 * A block element which will marquee its contents
+	 * A block element which will marquee its contents.
 	 *
 	 * @see {@link ui/Marquee.Marquee}
 	 * @class Marquee
@@ -50,7 +50,7 @@ export {
 	Marquee,
 
 	/**
-	 * Internal component to provide marquee markup
+	 * Internal component to provide marquee markup.
 	 *
 	 * @see {@link ui/Marquee.Marquee}
 	 * @class MarqueeBase
@@ -62,7 +62,7 @@ export {
 	MarqueeBase,
 
 	/**
-	 * Adds ability to control descendant marquee instances to a component
+	 * Adds ability to control descendant marquee instances to a component.
 	 *
 	 * @see {@link ui/Marquee.MarqueeController}
 	 * @hoc
@@ -74,7 +74,7 @@ export {
 	MarqueeController,
 
 	/**
-	 * Adds marquee behavior to a component
+	 * Adds marquee behavior to a component.
 	 *
 	 * @see {@link ui/Marquee.MarqueeDecorator}
 	 * @hoc


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
- iconOnly Button prop doesn't have a default value;
- need one empty lines between name and computed as well as between computed and render at IconButtonDecorator;
- minWidth Button prop has an unnecessary @default is true;
- there are some . missing at the end of the sentence in Marquee.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- set false to iconOnly Button prop default value;
- added one empty lines between name and computed as well as between computed and render at IconButtonDecorator;
- removed @default true from minWidth Button prop;
- added missing . at the end of the sentence in Marquee.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
PLAT-124936 https://github.com/enactjs/agate/pull/400

### Comments