### PR TITLE
PLAT-122228: Add data-webos-voice-labels when label is used in Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Item` to `data-webos-voice-labels` when `label` is used
+- `sandstone/Item` prop `data-webos-voice-labels` when `label` is used
 
 ### Fixed
 

--- a/Item/Item.js
+++ b/Item/Item.js
@@ -225,15 +225,8 @@ const ItemBase = kind({
 	render: ({centered, children, componentRef, css, inline, label, labelPosition, marqueeOn, slotAfter, slotBefore, ...rest}) => {
 		delete rest.size;
 
-		const voiceProps = {};
-		if (label) {
-			const keys = Object.keys(rest);
-			if (keys.indexOf('data-webos-voice-label') === -1 && keys.indexOf('data-webos-voice-labels') === -1) {
-				if (typeof label === 'string' && (children[0] && typeof children[0] === 'string')) {
-					voiceProps['data-webos-voice-labels'] = JSON.stringify([label, children[0]]);
-				}
-			}
-		}
+		const keys = Object.keys(rest);
+		const voiceProps = (!keys.includes('data-webos-voice-label') && !keys.includes('data-webos-voice-labels') && label && typeof label === 'string' && children && children[0] && typeof children[0] === 'string') ? {'data-webos-voice-labels': JSON.stringify([label, children[0]])} : {};
 
 		return (
 			<UiItemBase


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When label is used in Item, voice label has to separated for recognized by NLP server

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add data-webos-voice-labels attribute when label is used in Item

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
https://jira2.lgsvl.com/browse/PLAT-122228

### Comments
N/A