### PR TITLE
PLAT-121331: Rename qa-a11y Section's vertical prop as horizontal

### DIFF
--- a/samples/qa-a11y/src/components/Section.js
+++ b/samples/qa-a11y/src/components/Section.js
@@ -22,8 +22,8 @@ const SectionBase = kind({
 	name: 'Section',
 
 	propTypes: {
-		title: PropTypes.string,
-		vertical: PropTypes.bool
+		horizontal: PropTypes.bool,
+		title: PropTypes.string
 	},
 
 	styles: {
@@ -31,8 +31,8 @@ const SectionBase = kind({
 		className: 'section'
 	},
 
-	render: ({children, title, vertical, ...rest}) => (
-		vertical ?
+	render: ({children, horizontal, title, ...rest}) => (
+		horizontal ?
 			<Cell size={1500} {...rest}>
 				<Heading showLine>{title}</Heading>
 				<Row className={css.componentDemo}>

--- a/samples/qa-a11y/src/views/Picker.js
+++ b/samples/qa-a11y/src/views/Picker.js
@@ -84,7 +84,7 @@ const PickerView = () => (
 			</Picker>
 		</Section>
 
-		<SpotlightContainerSection className={appCss.marginTop} title="Vertical" vertical>
+		<SpotlightContainerSection className={appCss.marginTop} horizontal title="Vertical">
 			<Picker
 				alt="Vertical"
 				orientation="vertical"
@@ -172,7 +172,7 @@ const PickerView = () => (
 			</Picker>
 		</Section>
 
-		<SpotlightContainerSection className={appCss.marginTop} title="Vertical" vertical>
+		<SpotlightContainerSection className={appCss.marginTop} horizontal title="Vertical">
 			<Picker
 				alt="Vertical"
 				decrementAriaLabel="Decrement"
@@ -264,7 +264,7 @@ const PickerView = () => (
 			</Picker>
 		</Section>
 
-		<SpotlightContainerSection className={appCss.marginTop} title="Vertical" vertical>
+		<SpotlightContainerSection className={appCss.marginTop} horizontal title="Vertical">
 			<Picker
 				alt="Vertical"
 				aria-label="This is a Label 4."

--- a/samples/qa-a11y/src/views/RangePicker.js
+++ b/samples/qa-a11y/src/views/RangePicker.js
@@ -59,7 +59,7 @@ const RangePickerView = () => (
 			/>
 		</Section>
 
-		<SpotlightContainerSection className={appCss.marginTop} title="Vertical" vertical>
+		<SpotlightContainerSection className={appCss.marginTop} horizontal title="Vertical">
 			<RangePicker
 				alt="Vertical"
 				defaultValue={0}
@@ -162,7 +162,7 @@ const RangePickerView = () => (
 			/>
 		</Section>
 
-		<SpotlightContainerSection className={appCss.marginTop} title="Vertical" vertical>
+		<SpotlightContainerSection className={appCss.marginTop} horizontal title="Vertical">
 			<RangePicker
 				alt="Vertical"
 				decrementAriaLabel="This is a Label 9."
@@ -270,7 +270,7 @@ const RangePickerView = () => (
 			/>
 		</Section>
 
-		<SpotlightContainerSection className={appCss.marginTop} title="Vertical" vertical>
+		<SpotlightContainerSection className={appCss.marginTop} horizontal title="Vertical">
 			<RangePicker
 				alt="Vertical"
 				aria-label="This is a Label 21."


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

If giving `vertical` to qa-a11y Section, them the content in the Section display horizontally.
So I might be better to rename it as `horizontal.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`vertical` prop in qa-a11y Section is renamed as `horizontal`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments

PLAT-121331