### PR TITLE
PLAT-113967: Added an ImageItem qa-sampler to verify `children` renders properly when `data-index` prop changed

### DIFF
--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -35,6 +35,8 @@ storiesOf('ImageItem', module)
 					key={!!dataIndex + ''}
 					label={text('label', Config, 'ImageItem label')}
 					orientation={select('orientation', prop.orientation, Config)}
+					selected={boolean('selected', Config)}
+					showSelection={boolean('showSelection', Config)}
 					src={object('src', Config, src)}
 					style={{
 						width: ri.scale(select('orientation', prop.orientation, Config) === 'vertical' ? 768 : 1020),


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When passing a `data-index` prop to an `ImageItem`, the `children` prop should be rendered properly when being changed. For now there is no sampler to verify it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The ImageItem qa sampler is created.
The `data-index` knob is added as a boolean knob in the qa sampler
If the knob is true, then `data-index = 0` is passed as a prop.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-113967

### Comments
