### PR TITLE
PLAT-125327: Fix FlexiblePopupPanel screenshot test fails

### DIFF
--- a/Popup/Popup.module.less
+++ b/Popup/Popup.module.less
@@ -12,7 +12,7 @@
 
 	.body {
 		.sand-text-base();
-		.padding-start-end(@sand-popup-padding);
+		.padding-start-end(.extract(@sand-popup-padding, left)[], .extract(@sand-popup-padding, right)[]);
 		box-sizing: border-box;
 		pointer-events: auto;
 		.locale-japanese-line-break();


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

After releasing Sandstone 1.4.4, FlexiblePopupPanel screenshot tests were broken. There were several fails with it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Due to the https://github.com/enactjs/enact/pull/2859 PR, the Popup top and bottom paddings were added. So I removed them.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-125327

### Comments
