### PR TITLE
PLAT-132041: Fixed FlexiblePopupPanels padding in RTL locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Alert` to read out properly after closing it in a `sandstone/PopupTabLayout`
+- `sandstone/FlexiblePopupPanels` padding in RTL locales
 - `sandstone/Heading` `font-style` to use oblique font instead of fake `italic`
 - `sandstone/Input` to not have initial focus with pointer when `type` prop is `'number'` or `'passwordnumber'`
 - `sandstone/Panel` to not reset scroll position by events from others

--- a/FlexiblePopupPanels/FlexiblePopupPanels.module.less
+++ b/FlexiblePopupPanels/FlexiblePopupPanels.module.less
@@ -59,6 +59,9 @@
 		position: relative;
 		pointer-events: none;
 		padding: 0;
+		.enact-locale-rtl({
+			padding: 0;
+		});
 	}
 
 	&.fullHeight {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
FlexiblePopupPanels padding in RTL is different from LTR.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Define padding in RTL locales

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-132041

### Comments
