### PR TITLE
PLAT-114690: QA Sampler - Input: add a sample to test a marquee long 'Invalid' tooltip

### DIFF
--- a/samples/sampler/stories/qa/Input.js
+++ b/samples/sampler/stories/qa/Input.js
@@ -129,6 +129,8 @@ storiesOf('Input/Text/Fullscreen', module)
 		'long invalid tooltip',
 		() => (
 			<Input
+				title="Fullscreen Input (invalid tooltip)"
+				subtitle={inputData.textSubtitle}
 				popupType="fullscreen"
 				invalid={boolean('invalid', Config, true)}
 				invalidMessage={inputData.longInvalidTooltip}
@@ -189,6 +191,8 @@ storiesOf('Input/Text/Overlay', module)
 		'long invalid tooltip',
 		() => (
 			<Input
+				title="Overlay Input (invalid tooltip)"
+				subtitle={inputData.textSubtitle}
 				popupType="overlay"
 				invalid={boolean('invalid', Config, true)}
 				invalidMessage={inputData.longInvalidTooltip}
@@ -307,6 +311,8 @@ storiesOf('Input/Number/Fullscreen', module)
 		'long invalid tooltip',
 		() => (
 			<Input
+				title="Fullscreen Input (invalid tooltip)"
+				subtitle={inputData.numberSubtitle}
 				popupType="fullscreen"
 				type="number"
 				invalid={boolean('invalid', Config, true)}
@@ -401,6 +407,8 @@ storiesOf('Input/Number/Overlay', module)
 		'long invalid tooltip',
 		() => (
 			<Input
+				title="Overlay Input (invalid tooltip)"
+				subtitle={inputData.numberSubtitle}
 				popupType="overlay"
 				type="number"
 				invalid={boolean('invalid', Config, true)}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Yunho Lee (yunho2.lee@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Since marquee was added to the long invalid tooltip, it needs a sample to test.


### Resolution
Add a sample to test a long invalid tooltip.


### Additional Considerations


### Links
PLAT-114690


### Comments
