### PR TITLE
PLAT-130864: Fix QA sampler warnings

### DIFF
--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -472,16 +472,6 @@ storiesOf('Spotlight', module)
 										>
 											Button
 										</Button>
-										<Button
-											backgroundOpacity="translucent"
-											onSpotlightDown={action('onSpotlightDown')}
-											onSpotlightLeft={action('onSpotlightLeft')}
-											onSpotlightRight={action('onSpotlightRight')}
-											onSpotlightUp={action('onSpotlightUp')}
-											spotlightDisabled={boolean('Spottable spotlightDisabled', Container, false)}
-										>
-											Translucent
-										</Button>
 									</div>
 									<div>
 										<Button
@@ -605,18 +595,14 @@ storiesOf('Spotlight', module)
 								</Cell>
 								<Cell component={Scroller}>
 									<DatePicker
-										onSpotlightDown={action('onSpotlightDown')}
 										onSpotlightLeft={action('onSpotlightLeft')}
 										onSpotlightRight={action('onSpotlightRight')}
-										onSpotlightUp={action('onSpotlightUp')}
 										spotlightDisabled={boolean('Spottable spotlightDisabled', Container, false)}
 										title="DatePicker"
 									/>
 									<TimePicker
-										onSpotlightDown={action('onSpotlightDown')}
 										onSpotlightLeft={action('onSpotlightLeft')}
 										onSpotlightRight={action('onSpotlightRight')}
-										onSpotlightUp={action('onSpotlightUp')}
 										spotlightDisabled={boolean('Spottable spotlightDisabled', Container, false)}
 										title="TimePicker"
 									/>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Two issues are found;
- onSpotlightUp and onSpotlightDown callback props are specified for `DatePicker` and `TimePicker`. Those callback props are used for 'action' log in a sampler, but DatePicker/TimePicker consumes key up/down input internally due to its UX.
- There is a `Button` component with `'translucent'` value for `backgroundOpacity`. Our `Button` component does not support that value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In this PR;
- Removed meaningless onSpotlightUp and onSpotlightDown for DatePicker and TimePicker components in a sampler
- Removed a button component with an invalid prop value.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-130864

### Comments
