### PR TITLE
PLAT-134480: keep the MediaSlider bar's color when dragging in touch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/MediaSlider` to not changing bar's color when dragging in touch mode
+
 ## [1.4.4-experimental-5] - 2021-01-26
 
 ### Fixed
@@ -10,7 +16,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [1.4.4-experimental-4] - 2021-01-13
 
-### Fixed 
+### Fixed
 
 - `sandstone/Panels.Header` to not show back button in the first panel
 

--- a/MediaPlayer/MediaSlider.module.less
+++ b/MediaPlayer/MediaSlider.module.less
@@ -109,6 +109,22 @@
 				});
 			});
 
+			:global(.touch-mode) &.pressed {
+				.bar {
+					background-color: @sand-mediaslider-bar-bg-color;
+				}
+
+				.fill {
+					background-color: @sand-mediaslider-fill-bg-color;
+				}
+
+				.knob {
+					&::before {
+						background-color: @sand-mediaplayer-slider-knob-color;
+					}
+				}
+			}
+
 			.disabled({
 				.bar {
 					opacity: @sand-mediaslider-disabled-bar-opacity;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
MediaSlider: Background color is changed briefly when dragging in touch mode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It is because the previous fetch override the style when press. https://github.com/enyojs/sandstone/pull/791
So, I re-override the background style when press in touch mode.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-134480

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>
