### PR TITLE
PLAT-137855: Add a QA sample to test Dropdown in Scroller

### DIFF
--- a/samples/sampler/stories/qa/Dropdown.js
+++ b/samples/sampler/stories/qa/Dropdown.js
@@ -229,19 +229,20 @@ storiesOf('Dropdown', module)
 					pageKey: true,
 					track: true,
 					wheel: true
-			}}>
+				}}
+			>
 				<Item>Scroll down to see Dropdown</Item>
-				<Item disabled></Item>
+				<Item disabled />
 				<Item>Scroller has an overscroll effect intentionally</Item>
-				<Item disabled></Item>
-				<Item disabled></Item>
+				<Item disabled />
+				<Item disabled />
 				<Dropdown>
 					{['a', 'b', 'c', 'd', 'e', 'f', 'g']}
 				</Dropdown>
-				<Item disabled></Item>
-				<Item disabled></Item>
+				<Item disabled />
+				<Item disabled />
 				<Item>Scroller has an overscroll effect intentionally</Item>
-				<Item disabled></Item>
+				<Item disabled />
 				<Item>Scroll up to see Dropdown</Item>
 			</Scroller>
 		)


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
From enactjs/enact/pull/2906, a bug is fixed that a touchable component underlying an open dropdown catches `onDrag` and `onFlick` events unintentionally. To test this case, this PR adds a QA sample.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Dropdown in Scroller sample is added.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-137855
enactjs/enact/pull/2906

### Comments
