### PR TITLE
PLAT-130862: Fixed uncaught TypeError: Cannot read property 'isItemSized' of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Dropdown` to not show console error after selecting item
 - `sandstone/VirtualList` to not block key down events after panel transition
 
 ## [2.0.0-alpha.1] - 2021-02-24

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -4,7 +4,7 @@ import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import utilEvent from '@enact/ui/useScroll/utilEvent';
 import clamp from 'ramda/src/clamp';
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef} from 'react';
 
 const
 	isDown = is('down'),
@@ -239,12 +239,12 @@ const useEventKey = (props, instances, context) => {
 const useEventFocus = (props, instances) => {
 	const {scrollContainerRef, scrollContentHandle} = instances;
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		function handleFocus (ev) {
 			// only for VirtualGridList
 			// To make the focused item cover other near items
 			// We need to find out the general solution for multiple spottable inside of one item
-			if (ev.target && scrollContentHandle.current.isItemSized) {
+			if (ev.target && scrollContentHandle.current && scrollContentHandle.current.isItemSized) {
 				ev.target.parentNode.style.setProperty('z-index', 1);
 			}
 		}
@@ -252,7 +252,7 @@ const useEventFocus = (props, instances) => {
 		function handleBlur (ev) {
 			// only for VirtualGridList
 			// To make the blurred item normal
-			if (ev.target && scrollContentHandle.current.isItemSized) {
+			if (ev.target && scrollContentHandle.current && scrollContentHandle.current.isItemSized) {
 				ev.target.parentNode.style.setProperty('z-index', null);
 			}
 		}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is console error after selecting `Dropdown` item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It cause because the blur event occur after virtuallist is removed.
```
useEvent.js:243 useEffect
useEvent.js:264 addEventListener
useEvent.js:245 handleFocus
useEvent.js:257 handleBlur
useEvent.js:258 {current: null} // scrollContentHandle.current is null in handleBlur()
useEvent.js:269 removeEventListener
```
The event handler should have been removed when the DOM unmount. 
But, the useEffect() is not synchronous, so events handler was not removed proper timing.
So I changed useEffect to useLayoutEffect
```
useEvent.js:243 useLayoutEffect
useEvent.js:264 addEventListener
useEvent.js:245 handleFocus
useEvent.js:269 removeEventListener
```

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I added checking condition "scrollContentHandle.current", just in case

### Links
[//]: # (Related issues, references)
PLAT-130862


### Comments
