### PR TITLE
PLAT-129000: Scroller: Activate voice intent when scrolling is possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller`, `sandstone/VirtualList`, `sandstone/VirtualGridList` to activate voice control intent when scrolling is possible
+- `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 
 ## [2.0.0-alpha.3] - 2021-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Dropdown` to not show console error after selecting item
 - `sandstone/VirtualList` to not block key down events after panel transition
+- `sandstone/Scroller`, `sandstone/VirtualList`, `sandstone/VirtualGridList` to activate voice control intent when scrolling is possible
 
 ## [2.0.0-alpha.1] - 2021-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller`, `sandstone/VirtualList`, `sandstone/VirtualGridList` to activate voice control intent when scrolling is possible
+
 ## [2.0.0-alpha.3] - 2021-03-31
 
 ### Added
@@ -15,7 +21,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Dropdown` to not show console error after selecting item
 - `sandstone/RangePicker` to update label when value is out of range
 - `sandstone/VirtualList` to not block key down events after panel transition
-- `sandstone/Scroller`, `sandstone/VirtualList`, `sandstone/VirtualGridList` to activate voice control intent when scrolling is possible
 
 ## [2.0.0-alpha.2] - 2021-03-26
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -533,7 +533,13 @@ const useEventVoice = (props, instances) => {
 	function addVoiceEventListener (scrollContentRef) {
 		if (platform.webos) {
 			utilEvent('webOSVoice').addEventListener(scrollContentRef, handleVoice);
-			scrollContentRef.current.setAttribute('data-webos-voice-intent', 'Scroll');
+
+			if (scrollContainerHandle && scrollContainerHandle.current && scrollContainerHandle.current.getScrollBounds) {
+				const bounds = scrollContainerHandle.current.getScrollBounds();
+				if (scrollContainerHandle.current.canScrollVertically(bounds) || scrollContainerHandle.current.canScrollHorizontally(bounds)) {
+					scrollContentRef.current.setAttribute('data-webos-voice-intent', 'Scroll');
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In current status, voice intent is always exist. For this reason, guide message of voice control can be listen.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check scrolling is possible and declare scroll intent dynamically.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-129000

### Comments
N/A