### PR TITLE
ENYO-6132: Sample to test layering order with ContextualPopup and tooltip

### DIFF
--- a/samples/qa-a11y/src/views/ContextualPopupDecorator.js
+++ b/samples/qa-a11y/src/views/ContextualPopupDecorator.js
@@ -63,16 +63,6 @@ const renderPopup4 = () => (
 	</Group>
 );
 
-const renderPopup5 = () => (
-	<div>
-		<Button
-			size="large"
-			tooltipPosition="above center"
-			tooltipText="tooltip"
-		>Tooltip button</Button>
-	</div>
-);
-
 const ContextualPopupDecoratorView = () => {
 	return (
 		<Section title="Button wrapped with ContextualPopupDecorator">
@@ -81,7 +71,6 @@ const ContextualPopupDecoratorView = () => {
 			<ContextualButton alt="With RadioItems in Group" direction="below" popupComponent={renderPopup3}>Text 2</ContextualButton>
 			<ContextualButton alt="With Disabled RadioItems in Group" direction="below" popupComponent={renderPopup4}>Text 3</ContextualButton>
 			<ContextualButton alt="Disabled" disabled popupComponent={renderPopup1}>Text 4</ContextualButton>
-			<ContextualButton alt="With button that has tooltip" popupComponent={renderPopup5}>Text 5</ContextualButton>
 		</Section>
 	);
 };

--- a/samples/qa-a11y/src/views/ContextualPopupDecorator.js
+++ b/samples/qa-a11y/src/views/ContextualPopupDecorator.js
@@ -63,6 +63,16 @@ const renderPopup4 = () => (
 	</Group>
 );
 
+const renderPopup5 = () => (
+	<div>
+		<Button
+			size="large"
+			tooltipText="tooltip"
+			tooltipPosition="above center"
+		>Test</Button>
+	</div>
+);
+
 const ContextualPopupDecoratorView = () => {
 	return (
 		<Section title="Button wrapped with ContextualPopupDecorator">
@@ -71,6 +81,7 @@ const ContextualPopupDecoratorView = () => {
 			<ContextualButton alt="With RadioItems in Group" direction="below" popupComponent={renderPopup3}>Text 2</ContextualButton>
 			<ContextualButton alt="With Disabled RadioItems in Group" direction="below" popupComponent={renderPopup4}>Text 3</ContextualButton>
 			<ContextualButton alt="Disabled" disabled popupComponent={renderPopup1}>Text 4</ContextualButton>
+			<ContextualButton alt="With button that has tooltip" popupComponent={renderPopup5}>Text 5</ContextualButton>
 		</Section>
 	);
 };

--- a/samples/qa-a11y/src/views/ContextualPopupDecorator.js
+++ b/samples/qa-a11y/src/views/ContextualPopupDecorator.js
@@ -67,8 +67,8 @@ const renderPopup5 = () => (
 	<div>
 		<Button
 			size="large"
-			tooltipText="tooltip"
 			tooltipPosition="above center"
+			tooltipText="tooltip"
 		>Tooltip button</Button>
 	</div>
 );

--- a/samples/qa-a11y/src/views/ContextualPopupDecorator.js
+++ b/samples/qa-a11y/src/views/ContextualPopupDecorator.js
@@ -69,7 +69,7 @@ const renderPopup5 = () => (
 			size="large"
 			tooltipText="tooltip"
 			tooltipPosition="above center"
-		>Test</Button>
+		>Tooltip button</Button>
 	</div>
 );
 

--- a/samples/sampler/stories/qa/ContextualPopupDecorator.js
+++ b/samples/sampler/stories/qa/ContextualPopupDecorator.js
@@ -33,6 +33,16 @@ const renderSuperTallPopup = () => (
 	</div>
 );
 
+const renderButtonWithTooltip = () => (
+	<div style={{textAlign: 'center'}}>
+		<Button
+			size="large"
+			tooltipPosition="below center"
+			tooltipText="Longer tooltip"
+		>Tooltip button</Button>
+	</div>
+);
+
 class ContextualPopupWithActivator extends Component {
 	constructor (props) {
 		super(props);
@@ -169,3 +179,17 @@ export const WithOverflows = () => (
 );
 
 WithOverflows.storyName = 'with overflows';
+
+export const WithButtonThatHasTooltip = () => (
+	<div style={{textAlign: 'center', marginTop: ri.scaleToRem(260)}}>
+		<ContextualPopupWithActivator
+			direction="above"
+			popupComponent={renderButtonWithTooltip}
+			spotlightRestrict="self-only"
+		>
+			Contextual Button
+		</ContextualPopupWithActivator>
+	</div>
+);
+
+WithButtonThatHasTooltip.storyName = 'with button that has tooltip';

--- a/samples/sampler/stories/qa/ContextualPopupDecorator.js
+++ b/samples/sampler/stories/qa/ContextualPopupDecorator.js
@@ -180,7 +180,7 @@ export const WithOverflows = () => (
 
 WithOverflows.storyName = 'with overflows';
 
-export const WithButtonThatHasTooltip = () => (
+export const WithButtonTooltip = () => (
 	<div style={{textAlign: 'center', marginTop: ri.scaleToRem(260)}}>
 		<ContextualPopupWithActivator
 			direction="above"
@@ -192,4 +192,4 @@ export const WithButtonThatHasTooltip = () => (
 	</div>
 );
 
-WithButtonThatHasTooltip.storyName = 'with button that has tooltip';
+WithButtonTooltip.storyName = 'with button tooltip';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added sampler to test layering order between ContextualPopup and tooltip

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6132

### Comments

Enact-DCO-1.0-Signed-off-by: Paul Beldean paul.beldean@lgepartner.com