### PR TITLE
PLAT-127114: Fixed RangePicker label when value is out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Dropdown` to not show console error after selecting item
+- `sandstone/RangePicker` to update label when value is out of range
 - `sandstone/VirtualList` to not block key down events after panel transition
 
 ## [2.0.0-alpha.1] - 2021-02-24

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -265,8 +265,7 @@ const RangePickerBase = kind({
 
 	render: ({label, value, voiceLabel, ...rest}) => {
 		delete rest.padded;
-		console.log(value);
-		console.log(label);
+
 		return (
 			<Picker {...rest} css={css} data-webos-voice-labels-ext={voiceLabel} index={0} reverse={false} type="number" value={value}>
 				<PickerItem key={value} marqueeDisabled style={{direction: 'ltr'}}>{label}</PickerItem>

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -238,6 +238,8 @@ const RangePickerBase = kind({
 	computed: {
 		disabled: ({disabled, max, min}) => min >= max ? true : disabled,
 		label: ({max, min, padded, value}) => {
+			value = clamp(min, max, value);
+
 			if (padded) {
 				const maxDigits = digits(Math.max(Math.abs(min), Math.abs(max)));
 				const valueDigits = digits(value);
@@ -263,6 +265,8 @@ const RangePickerBase = kind({
 
 	render: ({label, value, voiceLabel, ...rest}) => {
 		delete rest.padded;
+		console.log(value);
+		console.log(label);
 		return (
 			<Picker {...rest} css={css} data-webos-voice-labels-ext={voiceLabel} index={0} reverse={false} type="number" value={value}>
 				<PickerItem key={value} marqueeDisabled style={{direction: 'ltr'}}>{label}</PickerItem>

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -265,7 +265,6 @@ const RangePickerBase = kind({
 
 	render: ({label, value, voiceLabel, ...rest}) => {
 		delete rest.padded;
-
 		return (
 			<Picker {...rest} css={css} data-webos-voice-labels-ext={voiceLabel} index={0} reverse={false} type="number" value={value}>
 				<PickerItem key={value} marqueeDisabled style={{direction: 'ltr'}}>{label}</PickerItem>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Displayed value did not change when it became out of range(min or max has changed)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Limited the label value to be in range


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-127114

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com