### PR TITLE
PLAT-134499: Added focusableScrollbar to second scroller

### DIFF
--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -529,6 +529,11 @@ export const WithNestedScroller = () => {
 			</Scroller>
 			<Scroller
 				direction="horizontal"
+				focusableScrollbar={
+					prop.focusableScrollbarOption[
+						select('focusableScrollbar', ['false', 'true', '"byEnter"'], Config)
+					]
+				}
 				horizontalScrollbar="visible"
 				key={select('scrollMode', prop.scrollModeOption, Config) + '3'}
 				noScrollByWheel={noScrollByWheel}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The scrollbar for the second scroller was not focusable

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added focusableScrollbar to second scroller

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-134499

### Comments

Enact-DCO-1.0-Signed-off-by: Paul Beldean paul.beldean@lgepartner.com