### PR TITLE
PLAT-125063: ContextualPopup doesn't open when another ContextualPopup opens

### DIFF
--- a/samples/qa-a11y/src/views/ContextualPopupDecorator.js
+++ b/samples/qa-a11y/src/views/ContextualPopupDecorator.js
@@ -67,7 +67,7 @@ const ContextualPopupDecoratorView = () => {
 	return (
 		<Section title="Button wrapped with ContextualPopupDecorator">
 			<ContextualButton alt="With Texts" popupComponent={renderPopup1}>Text 0</ContextualButton>
-			<ContextualButton alt="With Buttons" popupComponent={renderPopup2} spotlightRestrict="self-only">Text 1</ContextualButton>
+			<ContextualButton alt="With Buttons" popupComponent={renderPopup2}>Text 1</ContextualButton>
 			<ContextualButton alt="With RadioItems in Group" direction="below" popupComponent={renderPopup3}>Text 2</ContextualButton>
 			<ContextualButton alt="With Disabled RadioItems in Group" direction="below" popupComponent={renderPopup4}>Text 3</ContextualButton>
 			<ContextualButton alt="Disabled" disabled popupComponent={renderPopup1}>Text 4</ContextualButton>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
qa-a11y sampler ContextualPopup doesn't open when another ContextualPopup opens

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Made ContextualPopup open

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-125063

### Comments

Enact-DCO-1.0-Signed-off-by: Paul Beldean paul.beldean@lgepartner.com