### PR TITLE
PLAT-125217: Fixed bg color for Checkbox and Switch for high contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Checkbox` background-color for high contrast mode
 - `sandstone/Dropdown` to not show console error after selecting item
+- `sandstone/Switch` background-color for high contrast mode
 - `sandstone/VirtualList` to not block key down events after panel transition
 
 ## [2.0.0-alpha.1] - 2021-02-24

--- a/styles/colors-highcontrast.less
+++ b/styles/colors-highcontrast.less
@@ -19,6 +19,10 @@
 // ---------------------------------------
 @sand-alert-overlay-bg-color: @sand-alert-bg-color;
 
+// Checkbox
+// ---------------------------------------
+@sand-checkbox-selected-bg-color: @sand-highcontrast-overlay-bg-color;
+
 // ContextualPopup
 // ---------------------------------------
 @sand-contextualpopup-bg-color: @sand-highcontrast-overlay-bg-color;
@@ -35,3 +39,7 @@
 // ---------------------------------------
 @sand-popup-bg-color: @sand-highcontrast-overlay-bg-color;
 @sand-popup-scrimtransparent-bg-color: @sand-popup-bg-color;
+
+// Switch
+// ---------------------------------------
+@sand-switch-selected-bg-color: @sand-highcontrast-overlay-bg-color;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In high contrast, The checked checkbox/switch had background color as green instead of a grayish color

Actual Result:
- defined colors for high contrast for Checkbox and Switch

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-125217

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com