### PR TITLE
PLAT-127115: Fixed Input label when value is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Dropdown` to not show console error after selecting item
+- `sandstone/Input` button label when default value is `0`
 - `sandstone/RangePicker` to update label when value is out of range
 - `sandstone/VirtualList` to not block key down events after panel transition
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Input` button label when default value is `0`
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 
 ## [2.0.0-alpha.3] - 2021-03-31
@@ -19,7 +20,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Dropdown` to not show console error after selecting item
-- `sandstone/Input` button label when default value is `0`
 - `sandstone/RangePicker` to update label when value is out of range
 - `sandstone/VirtualList` to not block key down events after panel transition
 

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -466,7 +466,7 @@ const InputBase = kind({
 
 	computed: {
 		buttonAriaLabel: ({placeholder, type, value}) => {
-			if (value) {
+			if (value || value === 0) {
 				type = isPasswordType(type) ? 'password' : type;
 				return calcAriaLabel('', type, type === 'number' ? value.split('') : value);
 			}
@@ -474,7 +474,11 @@ const InputBase = kind({
 			return calcAriaLabel('', null, placeholder);
 		},
 		buttonLabel: ({placeholder, type, value}) => {
-			return (isPasswordType(type) ? convertToPasswordFormat(value) : value) || typeof value === 'number' ? value.toString() : placeholder;
+			if (value || value === 0) {
+				return isPasswordType(type) ? convertToPasswordFormat(value) : value.toString();
+			} else {
+				return placeholder;
+			}
 		}
 	},
 

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -474,7 +474,7 @@ const InputBase = kind({
 			return calcAriaLabel('', null, placeholder);
 		},
 		buttonLabel: ({placeholder, type, value}) => {
-			return (isPasswordType(type) ? convertToPasswordFormat(value) : value) || placeholder;
+			return (isPasswordType(type) ? convertToPasswordFormat(value) : value) || typeof value === 'number' ? value.toString() : placeholder;
 		}
 	},
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- The issue was discovered in the qa-sampler for a picker with add/remove items which contains an input, with default value 0 Click on the index input field. --> Input '0'. --> Index Button's inner text is still 'Index'

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Updated the computed value for ButtonLabel inside InputBase to take a value of `0` as a valid value

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-127115

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com