### PR TITLE
PLAT-123300: Added rtlProp to RangePicker

### DIFF
--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -11,6 +11,7 @@
 
 import kind from '@enact/core/kind';
 import {clamp} from '@enact/core/util';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
@@ -186,6 +187,14 @@ const RangePickerBase = kind({
 		padded: PropTypes.bool,
 
 		/**
+		 * Indicates the content's text direction is right-to-left.
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		rtl: PropTypes.bool,
+
+		/**
 		 * The smallest value change allowed for the picker.
 		 *
 		 * For example, a step of `2` would cause the picker to increment from 0 to 2 to 4, etc.
@@ -263,9 +272,11 @@ const RangePickerBase = kind({
 
 	render: ({label, value, voiceLabel, ...rest}) => {
 		delete rest.padded;
+		delete rest.rtl;
+
 		return (
 			<Picker {...rest} css={css} data-webos-voice-labels-ext={voiceLabel} index={0} reverse={false} type="number" value={value}>
-				<PickerItem key={value} marqueeDisabled style={{direction: 'ltr'}}>{label}</PickerItem>
+				<PickerItem key={value} marqueeDisabled>{label}</PickerItem>
 			</Picker>
 		);
 	}
@@ -285,8 +296,9 @@ const RangePickerBase = kind({
  * @public
  */
 const RangePicker = Pure(
-	Changeable(
-		RangePickerBase
+	I18nContextDecorator(
+		{rtlProp: 'rtl'},
+		Changeable(RangePickerBase)
 	)
 );
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
RangePicker minus sign was not displayed correctly on RTL

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
RangePicker minus sign displays correctly on RTL

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-123300

### Comments

Enact-DCO-1.0-Signed-off-by: Paul Beldean paul.beldean@lgepartner.com