### PR TITLE
PLAT-139620: WizardPanels: Fixed touch effect to not be shown at another button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Panels.Header` to move focus in header properly via 5-way
+- `sandstone/WizardPanels` to not show focus effect on wrong element in `footer`
 
 ## [1.4.4-experimental-6] - 2021-02-23
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -429,7 +429,7 @@ const WizardPanelsBase = kind({
 							</ViewManager>
 						) : null}
 					</Cell>
-					<Cell className={css.footer} component="footer" shrink>
+					<Cell className={css.footer} component="footer" key={index} shrink>
 						{/* This should probably use portals */}
 						{footer}
 					</Cell>

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
-import React from 'react';
+import React, {Component} from 'react';
 import {storiesOf} from '@storybook/react';
 
 import BodyText from '@enact/sandstone/BodyText';
@@ -30,7 +30,7 @@ const inputData = {
 
 WizardPanels.displayName = 'WizardPanels';
 
-class WizardPanelsWidthFooterButtons extends React.Component {
+class WizardPanelsWidthFooterButtons extends Component {
 	constructor () {
 		super();
 		this.state = {
@@ -38,18 +38,32 @@ class WizardPanelsWidthFooterButtons extends React.Component {
 		};
 	}
 
+	onNextClick = (ev) => {
+		this.setState({index: 1});
+		action('onNextClick')(ev);
+	};
+
+	onPrevClick = (ev) => {
+		this.setState({index: 0});
+		action('onPrevClick')(ev);
+	};
+
 	render () {
 		return (
-			<WizardPanels noAnimation index={this.state.index}>
+			<WizardPanels
+				noAnimation index={this.state.index}
+				onNextClick={this.onNextClick}
+				onPrevClick={this.onPrevClick}
+			>
 				<Panel title={'Panel0'} subtitle={'subtitle'} nextButton={<Button>Next</Button>}>
 					<footer>
 						<Button>Dummy</Button>
-						<Button onClick={() => this.setState({index: 1})}>Next</Button>
+						<Button onClick={this.onNextClick}>Next</Button>
 					</footer>
 				</Panel>
-				<Panel title={'Panel1'} subtitle={'subtitle'}>
+				<Panel title={'Panel1'} subtitle={'subtitle'} prevButton={<Button>Previous</Button>}>
 					<footer>
-						<Button onClick={() => this.setState({index: 0})}>Previous</Button>
+						<Button onClick={this.onPrevClick}>Previous</Button>
 					</footer>
 				</Panel>
 			</WizardPanels>
@@ -144,5 +158,10 @@ storiesOf('WizardPanels', module)
 		'with footter buttons',
 		() => (
 			<WizardPanelsWidthFooterButtons />
-		)
+		),
+		{
+			props: {
+				noPanel: true
+			}
+		}
 	);

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-bind */
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import React from 'react';
@@ -8,6 +9,7 @@ import Button from '@enact/sandstone/Button';
 import Icon from '@enact/sandstone/Icon';
 import Item from '@enact/sandstone/Item';
 import {Scroller} from '@enact/sandstone/Scroller';
+import {Panel} from '@enact/sandstone/WizardPanels';
 import WizardPanels, {WizardPanelsBase} from '@enact/sandstone/WizardPanels';
 
 import {mergeComponentMetadata} from '@enact/storybook-utils';
@@ -27,6 +29,33 @@ const inputData = {
 };
 
 WizardPanels.displayName = 'WizardPanels';
+
+class WizardPanelsWidthFooterButtons extends React.Component {
+	constructor () {
+		super();
+		this.state = {
+			index: 0
+		};
+	}
+
+	render () {
+		return (
+			<WizardPanels noAnimation index={this.state.index}>
+				<Panel title={'Panel0'} subtitle={'subtitle'} nextButton={<Button>Next</Button>}>
+					<footer>
+						<Button>Dummy</Button>
+						<Button onClick={() => this.setState({index: 1})}>Next</Button>
+					</footer>
+				</Panel>
+				<Panel title={'Panel1'} subtitle={'subtitle'}>
+					<footer>
+						<Button onClick={() => this.setState({index: 0})}>Previous</Button>
+					</footer>
+				</Panel>
+			</WizardPanels>
+		);
+	}
+}
 
 storiesOf('WizardPanels', module)
 	.add(
@@ -111,4 +140,9 @@ storiesOf('WizardPanels', module)
 				noPanel: true
 			}
 		}
+	).add(
+		'with footter buttons',
+		() => (
+			<WizardPanelsWidthFooterButtons />
+		)
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Touch effect is shown at other button

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add key value to prevent reuse DOM in footer

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-139620

### Comments
