### PR TITLE
PLAT-132843: PopupTabLayout: Collapse Tab only when a user enters a menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
+
 ### Fixed
 
 - `sandstone/Input` button label when default value is `0`

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -359,8 +359,8 @@ PopupTabLayout.Tab = Tab;
  */
 const TabPanels = (props) => {
 	const onTransition = useContext(TabLayoutContext);
-	return <Panels noCloseButton {...props} css={css} onTransition={onTransition}/>;
-}
+	return <Panels noCloseButton {...props} css={css} onTransition={onTransition} />;
+};
 
 /**
  * Omits the close button.

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -12,12 +12,12 @@ import kind from '@enact/core/kind';
 import {cap} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
-import {useEffect} from 'react';
+import {useContext, useEffect} from 'react';
 import compose from 'ramda/src/compose';
 
 import Skinnable from '../Skinnable';
 import Panels, {Panel} from '../Panels';
-import TabLayout, {Tab} from '../TabLayout';
+import TabLayout, {TabLayoutContext, Tab} from '../TabLayout';
 import Popup from '../Popup';
 
 import css from './PopupTabLayout.module.less';
@@ -272,7 +272,6 @@ const PopupTabLayoutBase = kind({
 					css={css}
 					align="start"
 					anchorTo="left"
-					type="popup"
 				>
 					{children}
 				</TabLayout>
@@ -358,7 +357,10 @@ PopupTabLayout.Tab = Tab;
  * @extends sandstone/Panels.Panels
  * @ui
  */
-const TabPanels = (props) => <Panels noCloseButton {...props} css={css} />;
+const TabPanels = (props) => {
+	const onTransition = useContext(TabLayoutContext);
+	return <Panels noCloseButton {...props} css={css} onTransition={onTransition}/>;
+}
 
 /**
  * Omits the close button.

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -272,6 +272,7 @@ const PopupTabLayoutBase = kind({
 					css={css}
 					align="start"
 					anchorTo="left"
+					type="popup"
 				>
 					{children}
 				</TabLayout>

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -202,7 +202,16 @@ const TabLayoutBase = kind({
 		 * @type {Number}
 		 * @public
 		 */
-		tabSize: PropTypes.number
+		tabSize: PropTypes.number,
+
+		/**
+		 * Type of TabLayout.
+		 *
+		 * @type {('normal'|'popup')}
+		 * @default 'normal'
+		 * @private
+		 */
+		 type: PropTypes.oneOf(['normal', 'popup'])
 	},
 
 	defaultProps: {
@@ -218,7 +227,8 @@ const TabLayoutBase = kind({
 			}
 		},
 		index: 0,
-		orientation: 'vertical'
+		orientation: 'vertical',
+		type: 'normal'
 	},
 
 	styles: {
@@ -297,9 +307,8 @@ const TabLayoutBase = kind({
 		}
 	},
 
-	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleEnter, handleTabsTransitionEnd, index, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, ...rest}) => {
+	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleEnter, handleTabsTransitionEnd, index, onCollapse, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, type, ...rest}) => {
 		delete rest.anchorTo;
-		delete rest.onCollapse;
 		delete rest.onTabAnimationEnd;
 
 		const contentSize = (collapsed ? dimensions.content.expanded : dimensions.content.normal);
@@ -344,6 +353,7 @@ const TabLayoutBase = kind({
 						component={ViewManager}
 						index={index}
 						noAnimation
+						onFocus={(type === 'normal' && !collapsed) ? onCollapse : null}
 						orientation={orientation}
 					>
 						{children}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -3,11 +3,13 @@
  *
  * @module sandstone/TabLayout
  * @exports TabLayout
+ * @exports TabLayoutBase
+ * @exports TabLayoutContext
+ * @exports TabLayoutDecorator
  * @exports Tab
  */
 
 import {adaptEvent, forward, forwardWithPrevent, forProp, handle} from '@enact/core/handle';
-import {is} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
 import {cap, mapAndFilterChildren} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
@@ -20,7 +22,7 @@ import Toggleable from '@enact/ui/Toggleable';
 import ViewManager from '@enact/ui/ViewManager';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {Fragment} from 'react';
+import {createContext, Fragment} from 'react';
 
 import RefocusDecorator, {getNavigableFilter, getTabsSpotlightId} from './RefocusDecorator';
 import TabGroup from './TabGroup';
@@ -28,7 +30,7 @@ import Tab from './Tab';
 
 import componentCss from './TabLayout.module.less';
 
-const isEnter = is('enter');
+const TabLayoutContext = createContext(null);
 
 /**
  * Tabbed Layout component.
@@ -200,16 +202,7 @@ const TabLayoutBase = kind({
 		 * @type {Number}
 		 * @public
 		 */
-		tabSize: PropTypes.number,
-
-		/**
-		 * Type of TabLayout.
-		 *
-		 * @type {('normal'|'popup')}
-		 * @default 'normal'
-		 * @private
-		 */
-		type: PropTypes.oneOf(['normal', 'popup'])
+		tabSize: PropTypes.number
 	},
 
 	defaultProps: {
@@ -226,7 +219,6 @@ const TabLayoutBase = kind({
 		},
 		index: 0,
 		orientation: 'vertical',
-		type: 'normal'
 	},
 
 	styles: {
@@ -238,7 +230,7 @@ const TabLayoutBase = kind({
 	handlers: {
 		onKeyDown: (ev, props) => {
 			const {keyCode, target} = ev;
-			const {collapsed, orientation, 'data-spotlight-id': spotlightId, type} = props;
+			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
 			const direction = getDirection(keyCode);
 
 			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
@@ -257,22 +249,6 @@ const TabLayoutBase = kind({
 					}
 				}
 			}
-
-			if (forward('onKeyDown', ev, props) && type === 'popup' && isEnter(keyCode) && !collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
-				if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
-					forward('onCollapse', ev, props);
-				}
-			}
-		},
-		onClick: (ev, props) => {
-			const {target} = ev;
-			const {collapsed, orientation, 'data-spotlight-id': spotlightId, type} = props;
-
-			if (forward('onClick', ev, props) && type === 'popup' && !collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
-				if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
-					forward('onCollapse', ev, props);
-				}
-			}
 		},
 		onSelect: handle(
 			adaptEvent(({selected}) => ({index: selected}), forward('onSelect'))
@@ -286,6 +262,9 @@ const TabLayoutBase = kind({
 				(ev, {collapsed}) => ({type: 'onTabAnimationEnd', collapsed: Boolean(collapsed)}),
 				forward('onTabAnimationEnd')
 			)
+		),
+		handleEnter: handle(
+			forward('onCollapse')
 		)
 	},
 
@@ -314,7 +293,7 @@ const TabLayoutBase = kind({
 		}
 	},
 
-	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleTabsTransitionEnd, index, onCollapse, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, type, ...rest}) => {
+	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleEnter, handleTabsTransitionEnd, index, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, ...rest}) => {
 		delete rest.anchorTo;
 		delete rest.onTabAnimationEnd;
 
@@ -333,37 +312,39 @@ const TabLayoutBase = kind({
 
 		// In vertical orientation, render two sets of tabs, one just icons, one with icons and text.
 		return (
-			<Layout {...rest} orientation={tabOrientation} data-spotlight-id={spotlightId}>
-				<Cell className={css.tabs} shrink onTransitionEnd={handleTabsTransitionEnd}>
-					<TabGroup
-						{...tabGroupProps}
-						collapsed={isVertical}
-						spotlightId={getTabsSpotlightId(spotlightId, isVertical)}
-						tabSize={!isVertical ? tabSize : null}
-						spotlightDisabled={!collapsed && isVertical}
-					/>
-				</Cell>
-				{isVertical ? <Cell
-					className={css.tabs + ' ' + css.tabsExpanded}
-					size={dimensions.tabs.normal}
-				>
-					<TabGroup
-						{...tabGroupProps}
-						spotlightId={getTabsSpotlightId(spotlightId, false)}
-						spotlightDisabled={collapsed}
-					/>
-				</Cell> : null}
-				<Cell
-					size={isVertical ? contentSize : null}
-					className={css.content}
-					component={ViewManager}
-					index={index}
-					noAnimation
-					orientation={orientation}
-				>
-					{children}
-				</Cell>
-			</Layout>
+			<TabLayoutContext.Provider value={handleEnter}>
+				<Layout {...rest} orientation={tabOrientation} data-spotlight-id={spotlightId}>
+					<Cell className={css.tabs} shrink onTransitionEnd={handleTabsTransitionEnd}>
+						<TabGroup
+							{...tabGroupProps}
+							collapsed={isVertical}
+							spotlightId={getTabsSpotlightId(spotlightId, isVertical)}
+							tabSize={!isVertical ? tabSize : null}
+							spotlightDisabled={!collapsed && isVertical}
+						/>
+					</Cell>
+					{isVertical ? <Cell
+						className={css.tabs + ' ' + css.tabsExpanded}
+						size={dimensions.tabs.normal}
+					>
+						<TabGroup
+							{...tabGroupProps}
+							spotlightId={getTabsSpotlightId(spotlightId, false)}
+							spotlightDisabled={collapsed}
+						/>
+					</Cell> : null}
+					<Cell
+						size={isVertical ? contentSize : null}
+						className={css.content}
+						component={ViewManager}
+						index={index}
+						noAnimation
+						orientation={orientation}
+					>
+						{children}
+					</Cell>
+				</Layout>
+			</TabLayoutContext.Provider>
 		);
 	}
 });
@@ -398,6 +379,7 @@ export default TabLayout;
 export {
 	TabLayout,
 	TabLayoutBase,
+	TabLayoutContext,
 	TabLayoutDecorator,
 	Tab
 };

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -218,7 +218,7 @@ const TabLayoutBase = kind({
 			}
 		},
 		index: 0,
-		orientation: 'vertical',
+		orientation: 'vertical'
 	},
 
 	styles: {

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -211,7 +211,7 @@ const TabLayoutBase = kind({
 		 * @default 'normal'
 		 * @private
 		 */
-		 type: PropTypes.oneOf(['normal', 'popup'])
+		type: PropTypes.oneOf(['normal', 'popup'])
 	},
 
 	defaultProps: {

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -263,9 +263,13 @@ const TabLayoutBase = kind({
 				forward('onTabAnimationEnd')
 			)
 		),
-		handleEnter: handle(
-			forward('onCollapse')
-		)
+		handleEnter: (ev, props) => {
+			const {index, previousIndex} = ev;
+
+			if (index > previousIndex) {
+				forward('onCollapse', ev, props);
+			}
+		}
 	},
 
 	computed: {
@@ -295,6 +299,7 @@ const TabLayoutBase = kind({
 
 	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleEnter, handleTabsTransitionEnd, index, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, ...rest}) => {
 		delete rest.anchorTo;
+		delete rest.onCollapse;
 		delete rest.onTabAnimationEnd;
 
 		const contentSize = (collapsed ? dimensions.content.expanded : dimensions.content.normal);

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -197,7 +197,16 @@ const TabLayoutBase = kind({
 		 * @type {Number}
 		 * @public
 		 */
-		tabSize: PropTypes.number
+		tabSize: PropTypes.number,
+
+		/**
+		 * Type of TabLayout.
+		 *
+		 * @type {('normal'|'popup')}
+		 * @default 'normal'
+		 * @private
+		 */
+		type: PropTypes.oneOf(['normal', 'popup'])
 	},
 
 	defaultProps: {
@@ -213,7 +222,8 @@ const TabLayoutBase = kind({
 			}
 		},
 		index: 0,
-		orientation: 'vertical'
+		orientation: 'vertical',
+		type: 'normal'
 	},
 
 	styles: {
@@ -285,7 +295,7 @@ const TabLayoutBase = kind({
 		}
 	},
 
-	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleTabsTransitionEnd, index, onCollapse, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, ...rest}) => {
+	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleTabsTransitionEnd, index, onCollapse, onExpand, onSelect, orientation, tabOrientation, tabSize, tabs, type, ...rest}) => {
 		delete rest.anchorTo;
 		delete rest.onTabAnimationEnd;
 
@@ -301,6 +311,9 @@ const TabLayoutBase = kind({
 			selectedIndex: index,
 			tabs
 		};
+
+		const collapsable = (type === 'normal') ? !collapsed :
+			!collapsed && children[index] && children[index].props && children[index].props.children && children[index].props.children.props && children[index].props.children.props.index > 0;
 
 		// In vertical orientation, render two sets of tabs, one just icons, one with icons and text.
 		return (
@@ -330,7 +343,7 @@ const TabLayoutBase = kind({
 					component={ViewManager}
 					index={index}
 					noAnimation
-					onFocus={!collapsed ? onCollapse : null}
+					onFocus={collapsable ? onCollapse : null}
 					orientation={orientation}
 				>
 					{children}

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -21,7 +21,7 @@ describe('TabLayout specs', () => {
 		);
 
 		const expected = 'collapsed';
-		const actual = subject.prop('className');
+		const actual = subject.find('.tabLayout').prop('className');
 
 		expect(actual).toContain(expected);
 	});
@@ -42,7 +42,7 @@ describe('TabLayout specs', () => {
 		);
 
 		const expected = 'vertical';
-		const actual = subject.prop('className');
+		const actual = subject.find('.tabLayout').prop('className');
 
 		expect(actual).toContain(expected);
 	});
@@ -65,7 +65,7 @@ describe('TabLayout specs', () => {
 		);
 
 		const expected = 'horizontal';
-		const actual = subject.prop('className');
+		const actual = subject.find('.tabLayout').prop('className');
 
 		expect(actual).toContain(expected);
 	});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
PopupTabLayout should collapse its tab only when a user enters a menu.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To notify a user enters a menu, added `TabLayoutContext` to handle `onTransition` from `PopupTabLayout.TabPanels`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-132843

### Comments
