### PR TITLE
PLAT-139778: Spotlight moves to wrong target with PageDown key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ coverage
 
 # Mac
 .DS_Store
-.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage
 
 # Mac
 .DS_Store
+.idea/*

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -387,7 +387,7 @@ export const WithExtraItems = () => {
 				verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
 				wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
 			/>
-			<Cell shrink component={Item}>
+			<Cell shrink component={Item} style={{marginTop: '3px'}}>
 				extra item1
 			</Cell>
 			<Cell shrink component={Item}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [  ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [  ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In VirtualList > 'with extra items' qa-sampler Spotlight moves to wrong target with PageDown key. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a small margin-top to the first extra item beneath the virtualList.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
PLAT-139778


### Comments
