### PR TITLE
PLAT-112207: Knob does not show on the Slider by the thumbnail with 5-way Down then 5-way Up immediately after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Input` button label when default value is `0`
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
+- `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way
 
 ## [2.0.0-alpha.3] - 2021-03-31
 

--- a/MediaPlayer/MediaSlider.module.less
+++ b/MediaPlayer/MediaSlider.module.less
@@ -32,11 +32,11 @@
 			.knob::before {
 				opacity: 1;
 			}
+
 			&.active,
 			&.pressed {
 				.knob::before {
 					transform: @knob-transform-active;
-					opacity: 1;
 				}
 			}
 		});

--- a/MediaPlayer/MediaSlider.module.less
+++ b/MediaPlayer/MediaSlider.module.less
@@ -29,6 +29,9 @@
 
 		// Grow the knob when the Slider gets spotted
 		.focus({
+			.knob::before {
+				opacity: 1;
+			}
 			&.active,
 			&.pressed {
 				.knob::before {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In `VideoPlayer` as the video plays back, by pressing 5-way down to show mediaControls, then 5-way up to focus the mediaSlider, the knob is not shown alongside thumbnail

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added an opacity to knob when mediaSlider gets focused

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
PLAT-112207


### Comments

Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com