### PR TITLE
PLAT-132840: Show back button on Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Panels.Header` to always show back button
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold
 
 ### Changed
 
+- `sandstone/Panels.Header` to always show back button
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/Panels.Header` to always show back button
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold
 
 ### Changed

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -421,11 +421,11 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({backButtonAvailable, hover, noBackButton, entering, centered, children, type, styler}) => styler.append(
+		className: ({backButtonAvailable, noBackButton, centered, children, type, styler}) => styler.append(
 			{
 				centered,
 				// This likely doesn't need to be as verbose as it is, with the first 2 conditionals
-				showBack: (backButtonAvailable && !noBackButton && (hover || entering)),
+				showBack: (backButtonAvailable && !noBackButton),
 				withChildren: hasChildren(children)
 			},
 			type
@@ -492,7 +492,6 @@ const HeaderBase = kind({
 		closeButtonAriaLabel,
 		closeButtonBackgroundOpacity,
 		css,
-		hover,
 		noBackButton,
 		noCloseButton,
 		onBack,
@@ -508,6 +507,7 @@ const HeaderBase = kind({
 	}) => {
 		delete rest.arranger;
 		delete rest.entering;
+		delete rest.hover;
 		delete rest.marqueeOn;
 		delete rest.onHideBack;
 		delete rest.onShowBack;
@@ -528,7 +528,6 @@ const HeaderBase = kind({
 					iconFlip="auto"
 					onClick={onBack}
 					size="small"
-					spotlightDisabled={!(backButtonAvailable && !noBackButton && hover)}
 				/>
 			</div>
 		) : null);

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -1,16 +1,11 @@
 import EnactPropTypes from '@enact/core/internal/prop-types';
-import {forward, forProp, handle, not, adaptEvent} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import {isRtlText} from '@enact/i18n/util';
-import {getDirection, Spotlight} from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
-import {getLastPointerPosition, hasPointerMoved} from '@enact/spotlight/src/pointer';
-import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {Row, Cell} from '@enact/ui/Layout';
 import {useMeasurable} from '@enact/ui/Measurable';
 import {unit} from '@enact/ui/resolution';
 import Slottable from '@enact/ui/Slottable';
-import Toggleable from '@enact/ui/Toggleable';
 import ViewManager, {shape} from '@enact/ui/ViewManager';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
@@ -19,41 +14,13 @@ import {Children, useContext, useState} from 'react';
 import $L from '../internal/$L';
 import Button from '../Button';
 import Heading from '../Heading';
-import WindowEventable from '../internal/WindowEventable';
 
 import {PanelsStateContext} from '../internal/Panels';
 import {useContextAsDefaults} from '../internal/Panels/util';
 
 import componentCss from './Header.module.less';
 
-const isBackButton = ({target: node}) => node && node.classList.contains(componentCss.back);
-const isNewPointerPosition = ({clientX, clientY}) => hasPointerMoved(clientX, clientY);
-const forwardHideBack = adaptEvent(() => ({type: 'onHideBack'}), forward('onHideBack'));
-const forwardShowBack = adaptEvent(() => ({type: 'onShowBack'}), forward('onShowBack'));
-
 const hasChildren = (children) => (Children.toArray(children).filter(Boolean).length > 0);
-
-// Hides the back button when 5-way navigation when in pointer mode and the target would not be the
-// back button.
-const handleWindowKeyPress = handle(
-	Spotlight.getPointerMode,
-	forProp('backButtonAvailable', true),
-	({keyCode}) => {
-		const current = Spotlight.getCurrent();
-		const target = getTargetByDirectionFromPosition(getDirection(keyCode), getLastPointerPosition());
-
-		// when in pointer mode and back button is visible but focused, if 5-way would blur the back
-		// button, it should hide the back button.
-		if (isBackButton({target: current})) {
-			return target && target !== current;
-		}
-
-		// when in pointer mode and back button is visible but not focused, if 5-way would not focus
-		// the back button, it should hide the back button
-		return !isBackButton({target});
-	},
-	forwardHideBack
-);
 
 /**
  * A header component for a Panel with a `title` and `subtitle`, supporting several configurable
@@ -176,17 +143,6 @@ const HeaderBase = kind({
 		entering: PropTypes.bool,
 
 		/**
-		 * Sets the "hover" state.
-		 *
-		 * This is linked to displaying the "back" button.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		hover: PropTypes.bool,
-
-		/**
 		 * Determines what triggers the header content to start its animation.
 		 *
 		 * @type {('focus'|'hover'|'render')}
@@ -228,22 +184,6 @@ const HeaderBase = kind({
 		 * @public
 		 */
 		onClose: PropTypes.func,
-
-		/**
-		 * Called when the user leaves the header to hide the back button.
-		 *
-		 * @type {Function}
-		 * @public
-		 */
-		onHideBack: PropTypes.func,
-
-		/**
-		 * Called when the user enters the header to show the back button.
-		 *
-		 * @type {Function}
-		 * @public
-		 */
-		onShowBack: PropTypes.func,
 
 		/**
 		 * A location for arbitrary elements to be placed above the title
@@ -398,29 +338,6 @@ const HeaderBase = kind({
 		publicClassNames: ['header']
 	},
 
-	handlers: {
-		onBlur: handle(
-			isBackButton,
-			not(Spotlight.getPointerMode),
-			forwardHideBack
-		),
-		onMouseEnter: handle(
-			forward('onMouseEnter'),
-			Spotlight.getPointerMode,
-			forwardShowBack
-		),
-		onMouseLeave: handle(
-			forward('onMouseLeave'),
-			Spotlight.getPointerMode,
-			forwardHideBack
-		),
-		onMouseMove: handle(
-			forward('onMouseMove'),
-			isNewPointerPosition,
-			forwardShowBack
-		)
-	},
-
 	computed: {
 		className: ({backButtonAvailable, noBackButton, centered, children, type, styler}) => styler.append(
 			{
@@ -508,10 +425,7 @@ const HeaderBase = kind({
 	}) => {
 		delete rest.arranger;
 		delete rest.entering;
-		delete rest.hover;
 		delete rest.marqueeOn;
-		delete rest.onHideBack;
-		delete rest.onShowBack;
 		delete rest.subtitle;
 		delete rest.subtitleId;
 		delete rest.title;
@@ -637,9 +551,7 @@ const HeaderDecorator = compose(
 	SpotlightContainerDecorator,
 	Slottable({slots: ['title', 'subtitle', 'slotAbove', 'slotAfter', 'slotBefore']}),
 	ContextAsDefaultsHeader,
-	HeaderMeasurementDecorator,
-	Toggleable({prop: 'hover', activate: 'onShowBack', deactivate: 'onHideBack', toggle: null}),
-	WindowEventable({globalNode: 'document', onKeyDown: handleWindowKeyPress})
+	HeaderMeasurementDecorator
 );
 
 // Note that we only export this (even as HeaderBase). HeaderBase is not useful on its own.

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -60,9 +60,6 @@ const HeaderBase = kind({
 		 *
 		 * This does not represent whether it is showing, just whether it can or not.
 		 *
-		 * When a Header is used within [`Panels`]{@link sandstone/Panels.Panels} this property will
-		 * be set to `true` when being hovered.
-		 *
 		 * @type {Boolean}
 		 * @default false
 		 * @private
@@ -343,7 +340,6 @@ const HeaderBase = kind({
 			{
 				centered,
 				// This likely doesn't need to be as verbose as it is, with the first 2 conditionals
-				showBack: (backButtonAvailable && !noBackButton),
 				withChildren: hasChildren(children)
 			},
 			type

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -3,6 +3,7 @@ import {forward, forProp, handle, not, adaptEvent} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import {isRtlText} from '@enact/i18n/util';
 import {getDirection, Spotlight} from '@enact/spotlight';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {getLastPointerPosition, hasPointerMoved} from '@enact/spotlight/src/pointer';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {Row, Cell} from '@enact/ui/Layout';
@@ -633,6 +634,7 @@ const HeaderMeasurementDecorator = (Wrapped) => {
 };
 
 const HeaderDecorator = compose(
+	SpotlightContainerDecorator,
 	Slottable({slots: ['title', 'subtitle', 'slotAbove', 'slotAfter', 'slotBefore']}),
 	ContextAsDefaultsHeader,
 	HeaderMeasurementDecorator,

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -434,17 +434,15 @@ const HeaderBase = kind({
 
 		// Set up the back button
 		const backButton = (backButtonAvailable && !noBackButton ? (
-			<div className={css.backContainer}>
-				<Button
-					aria-label={backButtonAriaLabel == null ? $L('go to previous') : backButtonAriaLabel}
-					backgroundOpacity={backButtonBackgroundOpacity}
-					className={css.back}
-					icon="arrowhookleft"
-					iconFlip="auto"
-					onClick={onBack}
-					size="small"
-				/>
-			</div>
+			<Button
+				aria-label={backButtonAriaLabel == null ? $L('go to previous') : backButtonAriaLabel}
+				backgroundOpacity={backButtonBackgroundOpacity}
+				className={css.back}
+				icon="arrowhookleft"
+				iconFlip="auto"
+				onClick={onBack}
+				size="small"
+			/>
 		) : null);
 
 		// Set up the close button

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -336,7 +336,7 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({backButtonAvailable, noBackButton, centered, children, type, styler}) => styler.append(
+		className: ({centered, children, type, styler}) => styler.append(
 			{
 				centered,
 				// This likely doesn't need to be as verbose as it is, with the first 2 conditionals

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -130,16 +130,6 @@ const HeaderBase = kind({
 		css: PropTypes.object,
 
 		/**
-		 * When a Header is used within [`Panels`]{@link sandstone/Panels.Panels} this property will
-		 * be set automatically to `true` on render and `false` after animating into view.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		entering: PropTypes.bool,
-
-		/**
 		 * Determines what triggers the header content to start its animation.
 		 *
 		 * @type {('focus'|'hover'|'render')}
@@ -420,7 +410,6 @@ const HeaderBase = kind({
 		...rest
 	}) => {
 		delete rest.arranger;
-		delete rest.entering;
 		delete rest.marqueeOn;
 		delete rest.subtitle;
 		delete rest.subtitleId;

--- a/Panels/Header.module.less
+++ b/Panels/Header.module.less
@@ -66,24 +66,6 @@
 		}
 	}
 
-	.backContainer {
-		display: inline-block;
-		width: 0;
-		opacity: 0;
-		transition: width 400ms ease-in-out, transform 400ms ease-in-out, opacity 200ms ease-out;
-		transform: scale(0.5);
-		transform-origin: center left;
-		will-change: width, transform, opacity;
-	}
-
-	&.showBack {
-		.backContainer {
-			opacity: 1;
-			transform: scale(1);
-			width: @sand-header-back-container-width;
-		}
-	}
-
 	///
 	/// Begin child node rules configuration, shared across multiple types
 	///
@@ -91,10 +73,6 @@
 	.title,
 	.subtitle {
 		margin: 0;
-	}
-
-	.title {
-		will-change: width; // Preparation for the back button transition
 	}
 
 	.slotAbove {

--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -2,7 +2,6 @@ import {forward, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
-import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator, {spotlightDefaultClass} from '@enact/spotlight/SpotlightContainerDecorator';
 import ComponentOverride from '@enact/ui/ComponentOverride';
 import ForwardRef from '@enact/ui/ForwardRef';

--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -140,7 +140,6 @@ const PanelBase = kind({
 			noHeader: !header,
 			visible: !hideChildren
 		}),
-		entering: ({hideChildren}) => (hideChildren && Spotlight.getPointerMode()),
 		// nulling headerId prevents the aria-labelledby relationship which is necessary to allow
 		// aria-label to take precedence
 		// (see https://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby)
@@ -173,7 +172,6 @@ const PanelBase = kind({
 		componentRef,
 		css,
 		floatingLayerId,
-		entering,
 		header,
 		ids: {headerId = null, labelledby = null, subtitleId = null, titleId = null},
 		...rest
@@ -187,7 +185,6 @@ const PanelBase = kind({
 					<ComponentOverride
 						component={header}
 						data-index={rest['data-index']}
-						entering={entering}
 						subtitleId={subtitleId}
 						titleId={titleId}
 					/>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
back button on Header is shown always on 2022 UX 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Cherry-pick
https://github.com/enactjs/sandstone/pull/782
https://github.com/enactjs/sandstone/pull/869
* Remove unused handler
* Remove animation

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-132840

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)