### PR TITLE
PLAT-140367: WizardPanels: Fix touch effect is shown at another button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` button label when default value is `0`
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way
-- `sandstone/WizardPanels` to not show focus effect on the wrong element in `footer` when touch
+- `sandstone/WizardPanels` to not show focus effect on the wrong element in `footer`
 
 ## [2.0.0-alpha.3] - 2021-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/WizardPanels` to not show focus effect on wrong element in `footer`
 - `sandstone/FormCheckboxItem` to show correct color for `slotBefore` icon in disabled state when focused
 - `sandstone/ImageItem` to resize the image properly
 - `sandstone/Input` button label when default value is `0`
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way
+- `sandstone/WizardPanels` to not show focus effect on wrong element in `footer`
 
 ## [2.0.0-alpha.3] - 2021-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/WizardPanels` to not show focus effect on wrong element in `footer`
 - `sandstone/FormCheckboxItem` to show correct color for `slotBefore` icon in disabled state when focused
 - `sandstone/ImageItem` to resize the image properly
 - `sandstone/Input` button label when default value is `0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` button label when default value is `0`
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way
-- `sandstone/WizardPanels` to not show focus effect on wrong element in `footer`
+- `sandstone/WizardPanels` to not show focus effect on the wrong element in `footer` when touch
 
 ## [2.0.0-alpha.3] - 2021-03-31
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -429,7 +429,7 @@ const WizardPanelsBase = kind({
 							</ViewManager>
 						) : null}
 					</Cell>
-					<Cell className={css.footer} component="footer" shrink>
+					<Cell className={css.footer} component="footer" key={index} shrink>
 						{/* This should probably use portals */}
 						{footer}
 					</Cell>

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -46,7 +46,8 @@ class WizardPanelsWidthFooterButtons extends Component {
 	render () {
 		return (
 			<WizardPanels
-				noAnimation index={this.state.index}
+				index={this.state.index}
+				noAnimation
 				onNextClick={this.onNextClick}
 				onPrevClick={this.onPrevClick}
 			>

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -6,7 +6,9 @@ import Button from '@enact/sandstone/Button';
 import Icon from '@enact/sandstone/Icon';
 import Item from '@enact/sandstone/Item';
 import {Scroller} from '@enact/sandstone/Scroller';
+import {Panel} from '@enact/sandstone/WizardPanels';
 import WizardPanels, {WizardPanelsBase} from '@enact/sandstone/WizardPanels';
+import {Component} from 'react';
 
 WizardPanels.displayName = 'WizardPanels';
 const Config = mergeComponentMetadata('WizardPanels', WizardPanelsBase, WizardPanels);
@@ -23,6 +25,47 @@ const inputData = {
 	longerString:
 	'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Purus faucibus ornare suspendisse sed nisi. Vestibulum sed arcu non odio euismod lacinia at quis. Elementum eu facilisis sed odio morbi quis commodo. Scelerisque mauris pellentesque pulvinar pellentesque habitant morbi. Neque ornare aenean euismod elementum. Iaculis nunc sed augue lacus viverra vitae congue eu consequat. Vulputate eu scelerisque felis imperdiet proin fermentum leo vel orci. Tincidunt augue interdum velit euismod. Nunc sed augue lacus viverra vitae congue eu consequat. Ultricies integer quis auctor elit sed vulputate. Pellentesque adipiscing commodo elit at imperdiet dui accumsan sit.'
 };
+
+class WizardPanelsWidthFooterButtons extends Component {
+	constructor () {
+		super();
+		this.state = {
+			index: 0
+		};
+	}
+
+	onNextClick = (ev) => {
+		this.setState({index: 1});
+		action('onNextClick')(ev);
+	};
+
+	onPrevClick = (ev) => {
+		this.setState({index: 0});
+		action('onPrevClick')(ev);
+	};
+
+	render () {
+		return (
+			<WizardPanels
+				noAnimation index={this.state.index}
+				onNextClick={this.onNextClick}
+				onPrevClick={this.onPrevClick}
+			>
+				<Panel title={'Panel0'} subtitle={'subtitle'} nextButton={<Button>Next</Button>}>
+					<footer>
+						<Button>Dummy</Button>
+						<Button onClick={this.onNextClick}>Next</Button>
+					</footer>
+				</Panel>
+				<Panel title={'Panel1'} subtitle={'subtitle'} prevButton={<Button>Previous</Button>}>
+					<footer>
+						<Button onClick={this.onPrevClick}>Previous</Button>
+					</footer>
+				</Panel>
+			</WizardPanels>
+		);
+	}
+}
 
 export default {
 	title: 'Sandstone/WizardPanels',
@@ -129,6 +172,15 @@ export const LongPrevNextButtons = () => (
 
 LongPrevNextButtons.storyName = 'long prev next buttons';
 LongPrevNextButtons.parameters = {
+	props: {
+		noPanel: true
+	}
+};
+
+export const WithFooterButtons = () => <WizardPanelsWidthFooterButtons />;
+
+WithFooterButtons.storyName = 'with footer buttons';
+WithFooterButtons.parameters = {
 	props: {
 		noPanel: true
 	}

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -6,8 +6,7 @@ import Button from '@enact/sandstone/Button';
 import Icon from '@enact/sandstone/Icon';
 import Item from '@enact/sandstone/Item';
 import {Scroller} from '@enact/sandstone/Scroller';
-import {Panel} from '@enact/sandstone/WizardPanels';
-import WizardPanels, {WizardPanelsBase} from '@enact/sandstone/WizardPanels';
+import WizardPanels, {Panel, WizardPanelsBase} from '@enact/sandstone/WizardPanels';
 import {Component} from 'react';
 
 WizardPanels.displayName = 'WizardPanels';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Touch effect is shown at another button in the footer of WizardPanels when navigating panels.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This issue was solved in https://github.com/enactjs/sandstone/pull/871.
This PR is for applying the patch to develop.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-140367

### Comments
