### PR TITLE
PLAT-132841: Navigating with left and right keys in PopupTabLayout and FixedPopupPanels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` left key handler to go to the previous panel
 - `sandstone/Input` a back button and props `backButtonAriaLabel` and `noBackButton`
 - `sandstone/Input` and `sandstone/Input.InputPopup` `url` to prop `type`
 - `sandstone/Picker` and `sandstone/RangePicker` props `title` and `inlineTitle`

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -47,6 +47,7 @@ const fixedPopupPanelsHandlers = {
 		stop
 	)
 };
+
 /**
  * An instance of [`Panels`]{@link sandstone/Panels.Panels} which restricts the `Panel` to the right
  * or left side of the screen inside a popup. Typically used for overlaying panels over other
@@ -60,8 +61,8 @@ const fixedPopupPanelsHandlers = {
 const FixedPopupPanels = (props) => {
 	const handlers = useHandlers(fixedPopupPanelsHandlers, props);
 
-	return <FixedPopupPanelsBase {...props} {...handlers} />
-}
+	return <FixedPopupPanelsBase {...props} {...handlers} />;
+};
 
 /**
  * Size of the popup.

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -9,8 +9,8 @@
 
 import {forKey, forward, handle, stop} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
-import Spotlight from '@enact/spotlight';
 import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
+import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import compose from 'ramda/src/compose';
 
 import {BasicArranger, PopupDecorator, Viewport} from '../internal/Panels';
@@ -36,13 +36,8 @@ const fixedPopupPanelsHandlers = {
 		forward('onKeyDown'),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
-		(ev) => {
-			if (Spotlight.move('left') || getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
-				ev.stopPropagation();
-				return false;
-			}
-			return true;
-		},
+		({target}) => (getContainerNode(getContainersForNode(target).pop()).tagName !== 'HEADER'),
+		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forward('onBack'),
 		stop
 	)

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -37,14 +37,7 @@ const fixedPopupPanelsHandlers = {
 		forKey('left'),
 		(ev, {index}) => (index > 0),
 		(ev) => {
-			if (Spotlight.move('left')) {
-				ev.stopPropagation();
-				return false;
-			}
-			return true;
-		},
-		(ev) => {
-			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
+			if (Spotlight.move('left') || getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
 				ev.stopPropagation();
 				return false;
 			}

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -13,6 +13,7 @@ import kind from '@enact/core/kind';
 import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
+import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
 import PropTypes from 'prop-types';
 import {useContext, useEffect} from 'react';
 import compose from 'ramda/src/compose';
@@ -363,7 +364,20 @@ const tabPanelsHandlers = {
 		forward('onKeyDown'),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
-		() => !Spotlight.move('left'),
+		(ev) => {
+			if (Spotlight.move('left')) {
+				ev.stopPropagation();
+				return false;
+			}
+			return true;
+		},
+		(ev) => {
+			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
+				ev.stopPropagation();
+				return false;
+			}
+			return true;
+		},
 		forward('onBack'),
 		stop
 	)

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -372,7 +372,13 @@ const tabPanelsHandlers = {
 			}
 			return true;
 		},
-		({target}) => (getTargetByDirectionFromElement('left', target) === null),
+		({target}) => {
+			const next = getTargetByDirectionFromElement('left', target);
+			if (next === null || (next && !getContainerNode(getContainersForNode(target).pop()).contains(next))) {
+				return true;
+			}
+			return false;
+		},
 		forward('onBack'),
 		stop
 	)

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -14,6 +14,7 @@ import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
 import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
+import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import PropTypes from 'prop-types';
 import {useContext, useEffect} from 'react';
 import compose from 'ramda/src/compose';
@@ -365,12 +366,13 @@ const tabPanelsHandlers = {
 		forKey('left'),
 		(ev, {index}) => (index > 0),
 		(ev) => {
-			if (Spotlight.move('left') || getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
+			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
 				ev.stopPropagation();
 				return false;
 			}
 			return true;
 		},
+		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forward('onBack'),
 		stop
 	)

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -8,7 +8,9 @@
  * @exports TabPanel
  */
 
+import {forKey, forward, handle, stop} from '@enact/core/handle';
 import kind from '@enact/core/kind';
+import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
 import PropTypes from 'prop-types';
@@ -350,6 +352,27 @@ PopupTabLayout.Tab = Tab;
  * @ui
  */
 
+
+/**
+ * Handlers for sandstone/PopupTabLayout.TabPanels.
+ *
+ */
+const tabPanelsHandlers = {
+	onTransition: handle(
+		forward('onTransition'),
+		(ev, props, {onTransition}) => {
+			onTransition(ev);
+		}
+	),
+	onKeyDown: handle(
+		forward('onKeyDown'),
+		forKey('left'),
+		(ev, {index}) => (index > 0),
+		forward('onBack'),
+		stop
+	)
+};
+
 /**
  * A customized version of Panels for use inside this component.
  *
@@ -360,7 +383,9 @@ PopupTabLayout.Tab = Tab;
  */
 const TabPanels = (props) => {
 	const onTransition = useContext(TabLayoutContext);
-	return <Panels noCloseButton {...props} css={css} onTransition={onTransition} />;
+	const handlers = useHandlers(tabPanelsHandlers, props, {onTransition});
+
+	return <Panels noCloseButton {...props} css={css} {...handlers} />;
 };
 
 /**

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -363,6 +363,7 @@ const tabPanelsHandlers = {
 		forward('onKeyDown'),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
+		() => !Spotlight.move('left'),
 		forward('onBack'),
 		stop
 	)

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -352,11 +352,6 @@ PopupTabLayout.Tab = Tab;
  * @ui
  */
 
-
-/**
- * Handlers for sandstone/PopupTabLayout.TabPanels.
- *
- */
 const tabPanelsHandlers = {
 	onTransition: handle(
 		forward('onTransition'),

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -365,14 +365,7 @@ const tabPanelsHandlers = {
 		forKey('left'),
 		(ev, {index}) => (index > 0),
 		(ev) => {
-			if (Spotlight.move('left')) {
-				ev.stopPropagation();
-				return false;
-			}
-			return true;
-		},
-		(ev) => {
-			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
+			if (Spotlight.move('left') || getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
 				ev.stopPropagation();
 				return false;
 			}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -267,7 +267,7 @@ const TabLayoutBase = kind({
 			const {collapsed, 'data-spotlight-id': spotlightId, type} = props;
 			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
 
-			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === "0") {
+			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === '0') {
 				if (collapsed) {
 					forward('onExpand', ev, props);
 				}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -267,7 +267,7 @@ const TabLayoutBase = kind({
 			const {collapsed, 'data-spotlight-id': spotlightId, type} = props;
 			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
 
-			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === '0') {
+			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === "0") {
 				if (collapsed) {
 					forward('onExpand', ev, props);
 				}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -30,6 +30,7 @@ import TabGroup from './TabGroup';
 import Tab from './Tab';
 
 import componentCss from './TabLayout.module.less';
+import popupTabLayoutComponentCss from '../PopupTabLayout/PopupTabLayout.module.less';
 
 const TabLayoutContext = createContext(null);
 
@@ -241,31 +242,37 @@ const TabLayoutBase = kind({
 	handlers: {
 		onKeyDown: (ev, props) => {
 			const {keyCode, target} = ev;
-			const {collapsed, orientation, 'data-spotlight-id': spotlightId, type} = props;
-			const contentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
+			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
 			const direction = getDirection(keyCode);
 
-			if (forwardWithPrevent('onKeyDown', ev, props)) {
-				if (direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
-					Spotlight.setPointerMode(false);
-					ev.preventDefault();
+			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
+				Spotlight.setPointerMode(false);
+				ev.preventDefault();
 
-					if (Spotlight.move(direction)) {
-						ev.stopPropagation();
-					} else if (contentRef.contains(target)) {
-						Spotlight.set(spotlightId, {navigableFilter: null});
-						const nextTarget = getTargetByDirectionFromElement(direction, target);
-						Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
+				if (Spotlight.move(direction)) {
+					ev.stopPropagation();
+				} else if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
+					Spotlight.set(spotlightId, {navigableFilter: null});
+					const nextTarget = getTargetByDirectionFromElement(direction, target);
+					Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
 
-						if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
-							forward('onExpand', ev, props);
-						}
+					if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
+						forward('onExpand', ev, props);
 					}
 				}
-				if (is('cancel')(keyCode) && type === 'popup' && contentRef.contains(target)) {
-					Spotlight.move('left');
-					ev.nativeEvent.stopImmediatePropagation();
+			}
+		},
+		onKeyUp: (ev, props) => {
+			const {keyCode, target} = ev;
+			const {collapsed, 'data-spotlight-id': spotlightId, type} = props;
+			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
+
+			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === "0") {
+				if (collapsed) {
+					forward('onExpand', ev, props);
 				}
+				Spotlight.move('left');
+				ev.stopPropagation();
 			}
 		},
 		onSelect: handle(

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -11,7 +11,6 @@
 
 import {adaptEvent, forward, forwardWithPrevent, forProp, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
-import {is} from '@enact/core/keymap';
 import {cap, mapAndFilterChildren} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
@@ -241,30 +240,23 @@ const TabLayoutBase = kind({
 	handlers: {
 		onKeyDown: (ev, props) => {
 			const {keyCode, target} = ev;
-			const {collapsed, orientation, 'data-spotlight-id': spotlightId, type} = props;
-			const contentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
+			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
 			const direction = getDirection(keyCode);
 
-			if (forwardWithPrevent('onKeyDown', ev, props)) {
-				if (direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
-					Spotlight.setPointerMode(false);
-					ev.preventDefault();
+			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
+				Spotlight.setPointerMode(false);
+				ev.preventDefault();
 
-					if (Spotlight.move(direction)) {
-						ev.stopPropagation();
-					} else if (contentRef.contains(target)) {
-						Spotlight.set(spotlightId, {navigableFilter: null});
-						const nextTarget = getTargetByDirectionFromElement(direction, target);
-						Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
+				if (Spotlight.move(direction)) {
+					ev.stopPropagation();
+				} else if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
+					Spotlight.set(spotlightId, {navigableFilter: null});
+					const nextTarget = getTargetByDirectionFromElement(direction, target);
+					Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
 
-						if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
-							forward('onExpand', ev, props);
-						}
+					if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
+						forward('onExpand', ev, props);
 					}
-				}
-				if (is('cancel')(keyCode) && type === 'popup' && contentRef.contains(target)) {
-					Spotlight.move('left');
-					ev.nativeEvent.stopImmediatePropagation();
 				}
 			}
 		},

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -11,6 +11,7 @@
 
 import {adaptEvent, forward, forwardWithPrevent, forProp, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
+import {is} from '@enact/core/keymap';
 import {cap, mapAndFilterChildren} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
@@ -240,23 +241,30 @@ const TabLayoutBase = kind({
 	handlers: {
 		onKeyDown: (ev, props) => {
 			const {keyCode, target} = ev;
-			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
+			const {collapsed, orientation, 'data-spotlight-id': spotlightId, type} = props;
+			const contentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 			const direction = getDirection(keyCode);
 
-			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
-				Spotlight.setPointerMode(false);
-				ev.preventDefault();
+			if (forwardWithPrevent('onKeyDown', ev, props)) {
+				if (direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
+					Spotlight.setPointerMode(false);
+					ev.preventDefault();
 
-				if (Spotlight.move(direction)) {
-					ev.stopPropagation();
-				} else if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
-					Spotlight.set(spotlightId, {navigableFilter: null});
-					const nextTarget = getTargetByDirectionFromElement(direction, target);
-					Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
+					if (Spotlight.move(direction)) {
+						ev.stopPropagation();
+					} else if (contentRef.contains(target)) {
+						Spotlight.set(spotlightId, {navigableFilter: null});
+						const nextTarget = getTargetByDirectionFromElement(direction, target);
+						Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
 
-					if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
-						forward('onExpand', ev, props);
+						if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
+							forward('onExpand', ev, props);
+						}
 					}
+				}
+				if (is('cancel')(keyCode) && type === 'popup' && contentRef.contains(target)) {
+					Spotlight.move('left');
+					ev.nativeEvent.stopImmediatePropagation();
 				}
 			}
 		},

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
+import {is} from '@enact/core/keymap';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select} from '@enact/storybook-utils/addons/knobs';
@@ -20,13 +21,16 @@ import spriteGear4k from '../../images/sprite-gear-4k.png';
 PopupTabLayout.displayName = 'PopupTabLayout';
 const Config = mergeComponentMetadata('PopupTabLayout', PopupBase, Popup, TabLayoutBase, TabLayout);
 
+const isLeft = is('left');
+const isRight = is('right');
+
 const navPrev = (callback, value, actionName) => () => {
 	const index = Math.max(value - 1, 0);
 	action(actionName)({index});
 	callback(index);
 };
 const navNext = (callback, value) => () => {
-	const index = Math.min(value + 1, 5);
+	const index = Math.min(value + 1, 1);
 	// action(actionName)({index});
 	callback(index);
 };
@@ -56,6 +60,14 @@ export const _PopupTabLayout = () => {
 	const handleNetworkPrev = navPrev(setIndexNetwork, indexNetwork, 'onBack');
 	const handleSoundNext = navNext(setIndexSound, indexSound, 'onNext');
 	const handleSoundPrev = navPrev(setIndexSound, indexSound, 'onBack');
+
+	const handleKeyDown = (setState, state) => ({keyCode}) => {
+		if (isLeft(keyCode)) {
+			navPrev(setState, state, 'onBack')();
+		} else if (isRight(keyCode)) {
+			navNext(setState, state, 'onNext')();
+		}
+	};
 
 	return (
 		<div>
@@ -89,7 +101,7 @@ export const _PopupTabLayout = () => {
 					onTabClick={action('onTabClick')}
 					title="Display"
 				>
-					<TabPanels index={indexDisplay} onBack={handleDisplayPrev} onClose={handleClose}>
+					<TabPanels index={indexDisplay} onBack={handleDisplayPrev} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>
 						<TabPanel>
 							<Header title="Display Settings" type="compact" />
 							<Item onClick={handleDisplayNext}>Picture Modes</Item>
@@ -118,7 +130,7 @@ export const _PopupTabLayout = () => {
 					</TabPanels>
 				</Tab>
 				<Tab icon={includeIcons ? 'speaker' : null} onTabClick={action('onTabClick')} title="Sound">
-					<TabPanels index={indexSound} onBack={handleSoundPrev} onClose={handleClose}>
+					<TabPanels index={indexSound} onBack={handleSoundPrev} onKeyDown={handleKeyDown(setIndexSound, indexSound)}>
 						<TabPanel>
 							<Header title="Sound Settings" type="compact" />
 							<Item onClick={handleSoundNext}>Advanced Audio</Item>
@@ -136,7 +148,7 @@ export const _PopupTabLayout = () => {
 					onTabClick={action('onTabClick')}
 					title="Network"
 				>
-					<TabPanels index={indexNetwork} onBack={handleNetworkPrev} onClose={handleClose}>
+					<TabPanels index={indexNetwork} onBack={handleNetworkPrev} onKeyDown={handleKeyDown(setIndexNetwork, indexNetwork)}>
 						<TabPanel>
 							<Header title="Network Settings" type="compact" />
 							<Item onClick={handleNetworkNext}>Wired</Item>
@@ -164,7 +176,7 @@ export const _PopupTabLayout = () => {
 					}}
 					title="General"
 				>
-					<TabPanels index={indexGeneral} onBack={handleGeneralPrev} onClose={handleClose}>
+					<TabPanels index={indexGeneral} onBack={handleGeneralPrev} onKeyDown={handleKeyDown(setIndexGeneral, indexGeneral)}>
 						<TabPanel>
 							<Header title="General Settings" type="compact" />
 							<Item onClick={handleGeneralNext}>About</Item>

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -61,11 +61,16 @@ export const _PopupTabLayout = () => {
 	const handleSoundNext = navNext(setIndexSound, indexSound, 'onNext');
 	const handleSoundPrev = navPrev(setIndexSound, indexSound, 'onBack');
 
-	const handleKeyDown = (setState, state) => ({keyCode}) => {
-		if (isLeft(keyCode)) {
+	// Navigate menus with left and right key.
+	// We need to stopPropagation to prevent tabs to be expanded by this action.
+	const handleKeyDown = (setState, state) => (ev) => {
+		const {keyCode} = ev;
+		if (state > 0 && isLeft(keyCode)) {
 			navPrev(setState, state, 'onBack')();
+			ev.stopPropagation();
 		} else if (isRight(keyCode)) {
 			navNext(setState, state, 'onNext')();
+			ev.stopPropagation();
 		}
 	};
 

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -60,8 +60,7 @@ export const _PopupTabLayout = () => {
 	const handleSoundNext = navNext(setIndexSound, indexSound, 'onNext');
 	const handleSoundPrev = navPrev(setIndexSound, indexSound, 'onBack');
 
-	// Navigate menus with left and right key.
-	// We need to stopPropagation to prevent tabs to be expanded by this action.
+	// Navigate menus with the right key. The left key is handled by framework.
 	const handleKeyDown = (setState, state) => (ev) => {
 		const {keyCode} = ev;
 

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -21,7 +21,6 @@ import spriteGear4k from '../../images/sprite-gear-4k.png';
 PopupTabLayout.displayName = 'PopupTabLayout';
 const Config = mergeComponentMetadata('PopupTabLayout', PopupBase, Popup, TabLayoutBase, TabLayout);
 
-const isLeft = is('left');
 const isRight = is('right');
 
 const navPrev = (callback, value, actionName) => () => {
@@ -65,10 +64,8 @@ export const _PopupTabLayout = () => {
 	// We need to stopPropagation to prevent tabs to be expanded by this action.
 	const handleKeyDown = (setState, state) => (ev) => {
 		const {keyCode} = ev;
-		if (state > 0 && isLeft(keyCode)) {
-			navPrev(setState, state, 'onBack')();
-			ev.stopPropagation();
-		} else if (isRight(keyCode)) {
+
+		if (isRight(keyCode)) {
 			navNext(setState, state, 'onNext')();
 		}
 	};

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -70,7 +70,6 @@ export const _PopupTabLayout = () => {
 			ev.stopPropagation();
 		} else if (isRight(keyCode)) {
 			navNext(setState, state, 'onNext')();
-			ev.stopPropagation();
 		}
 	};
 

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -101,11 +101,11 @@ export const _PopupTabLayout = () => {
 					onTabClick={action('onTabClick')}
 					title="Display"
 				>
-					<TabPanels index={indexDisplay} onBack={handleDisplayPrev} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>
+					<TabPanels index={indexDisplay} onBack={handleDisplayPrev}>
 						<TabPanel>
 							<Header title="Display Settings" type="compact" />
-							<Item onClick={handleDisplayNext}>Picture Modes</Item>
-							<Item onClick={handleDisplayNext}>Color Adjust</Item>
+							<Item onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>Picture Modes</Item>
+							<Item onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>Color Adjust</Item>
 						</TabPanel>
 						<TabPanel>
 							<Header title="Picture Modes" type="compact" />
@@ -130,10 +130,10 @@ export const _PopupTabLayout = () => {
 					</TabPanels>
 				</Tab>
 				<Tab icon={includeIcons ? 'speaker' : null} onTabClick={action('onTabClick')} title="Sound">
-					<TabPanels index={indexSound} onBack={handleSoundPrev} onKeyDown={handleKeyDown(setIndexSound, indexSound)}>
+					<TabPanels index={indexSound} onBack={handleSoundPrev}>
 						<TabPanel>
 							<Header title="Sound Settings" type="compact" />
-							<Item onClick={handleSoundNext}>Advanced Audio</Item>
+							<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)}>Advanced Audio</Item>
 						</TabPanel>
 						<TabPanel>
 							<Header title="Advanced Audio Settings" type="compact" />
@@ -148,11 +148,11 @@ export const _PopupTabLayout = () => {
 					onTabClick={action('onTabClick')}
 					title="Network"
 				>
-					<TabPanels index={indexNetwork} onBack={handleNetworkPrev} onKeyDown={handleKeyDown(setIndexNetwork, indexNetwork)}>
+					<TabPanels index={indexNetwork} onBack={handleNetworkPrev}>
 						<TabPanel>
 							<Header title="Network Settings" type="compact" />
-							<Item onClick={handleNetworkNext}>Wired</Item>
-							<Item onClick={handleNetworkNext}>Wireless</Item>
+							<Item onClick={handleNetworkNext} onKeyDown={handleKeyDown(setIndexNetwork, indexNetwork)}>Wired</Item>
+							<Item onClick={handleNetworkNext} onKeyDown={handleKeyDown(setIndexNetwork, indexNetwork)}>Wireless</Item>
 						</TabPanel>
 						<TabPanel>
 							<Header title="Wired Settings" type="compact" />
@@ -176,11 +176,11 @@ export const _PopupTabLayout = () => {
 					}}
 					title="General"
 				>
-					<TabPanels index={indexGeneral} onBack={handleGeneralPrev} onKeyDown={handleKeyDown(setIndexGeneral, indexGeneral)}>
+					<TabPanels index={indexGeneral} onBack={handleGeneralPrev}>
 						<TabPanel>
 							<Header title="General Settings" type="compact" />
-							<Item onClick={handleGeneralNext}>About</Item>
-							<Item onClick={handleGeneralNext}>Reset</Item>
+							<Item onClick={handleGeneralNext} onKeyDown={handleKeyDown(setIndexGeneral, indexGeneral)}>About</Item>
+							<Item onClick={handleGeneralNext} onKeyDown={handleKeyDown(setIndexGeneral, indexGeneral)}>Reset</Item>
 						</TabPanel>
 						<TabPanel>
 							<Header title="Wired Settings" type="compact" />

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -10,6 +10,7 @@ import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels
 import Dropdown from '@enact/sandstone/Dropdown';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
+import Slider from '@enact/sandstone/Slider';
 import {VirtualList} from '@enact/sandstone/VirtualList';
 import Spotlight from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
@@ -321,6 +322,7 @@ export const WithVariousItems = () => {
 								{['a', 'b', 'c', 'd', 'e', 'f']}
 							</Dropdown>
 							<br />
+							<Slider />
 						</Cell>
 						<Cell shrink component={BodyText}>
 							This text should be visible.
@@ -353,6 +355,7 @@ export const WithVariousItems = () => {
 								{['a', 'b', 'c', 'd', 'e', 'f']}
 							</Dropdown>
 							<br />
+							<Button size="small">Slider</Button><Slider style={{display: 'inline-block', width: '30%'}} />
 						</Cell>
 						<Cell shrink component={BodyText}>
 							This text should be visible.
@@ -385,6 +388,7 @@ export const WithVariousItems = () => {
 								{['a', 'b', 'c', 'd', 'e', 'f']}
 							</Dropdown>
 							<br />
+							<Slider />
 						</Cell>
 						<Cell shrink component={BodyText}>
 							This text should be visible.

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -8,6 +8,7 @@ import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels';
 import Dropdown from '@enact/sandstone/Dropdown';
+import Icon from '@enact/sandstone/Icon';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import Slider from '@enact/sandstone/Slider';
@@ -309,7 +310,7 @@ export const WithVariousItems = () => {
 							A 3-Cell Layout with various items
 						</Cell>
 						<Cell>
-							<span>This is a text.</span>
+							<span>This is the first panel.</span>
 							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
 							<br />
 							<br />
@@ -317,12 +318,14 @@ export const WithVariousItems = () => {
 							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
 							<br />
 							<br />
+							<Slider />
+							<br />
 							<Button size="small" disabled>Button4</Button>
 							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
 								{['a', 'b', 'c', 'd', 'e', 'f']}
 							</Dropdown>
 							<br />
-							<Slider />
+							<br />
 						</Cell>
 						<Cell shrink component={BodyText}>
 							This text should be visible.
@@ -342,20 +345,21 @@ export const WithVariousItems = () => {
 							A 3-Cell Layout with various items
 						</Cell>
 						<Cell>
-							<span>This is a text.</span>
-							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+							<span>This is the second panel.</span>
+							<Item onClick={nextPanel} onKeyDown={handleKeyDown} slotAfter={<Icon>arrowlargeright</Icon>}>Go to the next</Item>
+							<Button size="small" disabled>Button1</Button>
+							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+								{['a', 'b', 'c', 'd', 'e', 'f']}
+							</Dropdown>
 							<br />
 							<br />
 							<Button size="small">Button2</Button>
 							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
 							<br />
 							<br />
-							<Button size="small" disabled>Button4</Button>
-							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
-								{['a', 'b', 'c', 'd', 'e', 'f']}
-							</Dropdown>
-							<br />
 							<Button size="small">Slider</Button><Slider style={{display: 'inline-block', width: '30%'}} />
+							<br />
+							<br />
 						</Cell>
 						<Cell shrink component={BodyText}>
 							This text should be visible.
@@ -366,57 +370,21 @@ export const WithVariousItems = () => {
 					<Header>
 						<title>Panel 3</title>
 						<subtitle>This is the subtitle</subtitle>
-						<slotAfter>
-							<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
-						</slotAfter>
 					</Header>
 					<Column>
 						<Cell shrink component={BodyText}>
 							A 3-Cell Layout with various items
 						</Cell>
 						<Cell>
-							<span>This is a text.</span>
-							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+							<span>This is the last panel.</span>
+							<Button>Button1</Button>
 							<br />
 							<br />
-							<Button size="small">Button2</Button>
-							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
+							<Button size="small" disabled>Button2</Button>
 							<br />
-							<br />
-							<Button size="small" disabled>Button4</Button>
-							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
-								{['a', 'b', 'c', 'd', 'e', 'f']}
-							</Dropdown>
 							<br />
 							<Slider />
-						</Cell>
-						<Cell shrink component={BodyText}>
-							This text should be visible.
-						</Cell>
-					</Column>
-				</Panel>
-				<Panel>
-					<Header>
-						<title>Panel 4</title>
-						<subtitle>This is the subtitle</subtitle>
-					</Header>
-					<Column>
-						<Cell shrink component={BodyText}>
-							A 3-Cell Layout with various items
-						</Cell>
-						<Cell>
-							<span>This is a text.</span>
-							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
 							<br />
-							<br />
-							<Button size="small">Button2</Button>
-							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
-							<br />
-							<br />
-							<Button size="small" disabled>Button4</Button>
-							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
-								{['a', 'b', 'c', 'd', 'e', 'f']}
-							</Dropdown>
 							<br />
 						</Cell>
 						<Cell shrink component={BodyText}>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -7,6 +7,7 @@ import {boolean, select} from '@enact/storybook-utils/addons/knobs';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels';
+import Dropdown from '@enact/sandstone/Dropdown';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import {VirtualList} from '@enact/sandstone/VirtualList';
@@ -252,5 +253,182 @@ WithScroller.storyName = 'with Scroller';
 WithScroller.parameters = {
 	info: {
 		text: 'QA -  Scroller with text inside FixedPopupPanels'
+	}
+};
+
+export const WithVariousItems = () => {
+	const defaultOpen = true;
+	const [open, setOpenState] = useState(defaultOpen);
+	const toggleOpen = () => setOpenState(!open);
+	const handleClose = compose(toggleOpen, action('onClose'));
+
+	const defaultIndex = 0;
+	const [index, setPanelIndexState] = useState(defaultIndex);
+
+	const nextPanel = () => setPanelIndexState(Math.min(index + 1, 3));
+	const prevPanel = () => setPanelIndexState(Math.max(index - 1, 0));
+	const handleBack = compose(prevPanel, action('onBack'));
+
+	// Navigate menus with the right key. The left key is handled by framework.
+	const handleKeyDown = (ev) => {
+		const {keyCode} = ev;
+
+		if (isRight(keyCode) && ev.target && !ev.target.hasAttribute('disabled')) {
+			nextPanel();
+		}
+	};
+
+	return (
+		<div>
+			<FixedPopupPanels
+				index={index}
+				open={open}
+				position={select('position', ['left', 'right'], Config)}
+				fullHeight={boolean('fullHeight', Config)}
+				width={select('width', ['narrow', 'half'], Config)}
+				noAnimation={boolean('noAnimation', Config)}
+				noAutoDismiss={boolean('noAutoDismiss', Config)}
+				onBack={handleBack}
+				onClose={handleClose}
+				onHide={action('onHide')}
+				onShow={action('onShow')}
+				scrimType={select('scrimType', ['none', 'translucent', 'transparent'], Config)}
+				spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], Config)}
+			>
+				<Panel>
+					<Header>
+						<title>Panel 1</title>
+						<subtitle>This is the subtitle</subtitle>
+						<slotAfter>
+							<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
+						</slotAfter>
+					</Header>
+					<Column>
+						<Cell shrink component={BodyText}>
+							A 3-Cell Layout with various items
+						</Cell>
+						<Cell>
+							<span>This is a text.</span>
+							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+							<br />
+							<br />
+							<Button size="small">Button2</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
+							<br />
+							<br />
+							<Button size="small" disabled>Button4</Button>
+							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+								{['a', 'b', 'c', 'd', 'e', 'f']}
+							</Dropdown>
+							<br />
+						</Cell>
+						<Cell shrink component={BodyText}>
+							This text should be visible.
+						</Cell>
+					</Column>
+				</Panel>
+				<Panel>
+					<Header>
+						<title>Panel 2</title>
+						<subtitle>This is the subtitle</subtitle>
+						<slotAfter>
+							<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
+						</slotAfter>
+					</Header>
+					<Column>
+						<Cell shrink component={BodyText}>
+							A 3-Cell Layout with various items
+						</Cell>
+						<Cell>
+							<span>This is a text.</span>
+							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+							<br />
+							<br />
+							<Button size="small">Button2</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
+							<br />
+							<br />
+							<Button size="small" disabled>Button4</Button>
+							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+								{['a', 'b', 'c', 'd', 'e', 'f']}
+							</Dropdown>
+							<br />
+						</Cell>
+						<Cell shrink component={BodyText}>
+							This text should be visible.
+						</Cell>
+					</Column>
+				</Panel>
+				<Panel>
+					<Header>
+						<title>Panel 3</title>
+						<subtitle>This is the subtitle</subtitle>
+						<slotAfter>
+							<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
+						</slotAfter>
+					</Header>
+					<Column>
+						<Cell shrink component={BodyText}>
+							A 3-Cell Layout with various items
+						</Cell>
+						<Cell>
+							<span>This is a text.</span>
+							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+							<br />
+							<br />
+							<Button size="small">Button2</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
+							<br />
+							<br />
+							<Button size="small" disabled>Button4</Button>
+							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+								{['a', 'b', 'c', 'd', 'e', 'f']}
+							</Dropdown>
+							<br />
+						</Cell>
+						<Cell shrink component={BodyText}>
+							This text should be visible.
+						</Cell>
+					</Column>
+				</Panel>
+				<Panel>
+					<Header>
+						<title>Panel 4</title>
+						<subtitle>This is the subtitle</subtitle>
+					</Header>
+					<Column>
+						<Cell shrink component={BodyText}>
+							A 3-Cell Layout with various items
+						</Cell>
+						<Cell>
+							<span>This is a text.</span>
+							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+							<br />
+							<br />
+							<Button size="small">Button2</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
+							<br />
+							<br />
+							<Button size="small" disabled>Button4</Button>
+							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+								{['a', 'b', 'c', 'd', 'e', 'f']}
+							</Dropdown>
+							<br />
+						</Cell>
+						<Cell shrink component={BodyText}>
+							This text should be visible.
+						</Cell>
+					</Column>
+				</Panel>
+			</FixedPopupPanels>
+			<Button onClick={toggleOpen}>Open FixedPopupPanels</Button>
+		</div>
+	);
+};
+
+WithVariousItems.storyName = 'with various items';
+WithVariousItems.parameters = {
+	info: {
+		text: 'QA - Various items inside FixedPopupPanels'
 	}
 };

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
+import {is} from '@enact/core/keymap';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select} from '@enact/storybook-utils/addons/knobs';
@@ -21,6 +22,8 @@ Config.defaultProps.position = 'right';
 Config.defaultProps.scrimType = 'translucent';
 Config.defaultProps.spotlightRestrict = 'self-only';
 Config.defaultProps.width = 'narrow';
+
+const isRight = is('right');
 
 class FixedPopupPanelsWithPause extends Component {
 	constructor () {
@@ -85,6 +88,15 @@ export const WithVirtualList = () => {
 	const prevPanel = () => setPanelIndexState(Math.max(index - 1, 0));
 	const handleBack = compose(prevPanel, action('onBack'));
 
+	// Navigate menus with the right key. The left key is handled by framework.
+	const handleKeyDown = (ev) => {
+		const {keyCode} = ev;
+
+		if (isRight(keyCode)) {
+			nextPanel();
+		}
+	};
+
 	const itemHeight = 156;
 	const itemSize = ri.scale(itemHeight);
 
@@ -120,7 +132,7 @@ export const WithVirtualList = () => {
 						<Cell
 							size={itemHeight * 4}
 							component={VirtualList}
-							childProps={{onClick: nextPanel}}
+							childProps={{onClick: nextPanel, onKeyDown: handleKeyDown}}
 							itemSize={itemSize}
 							itemRenderer={itemRenderer}
 							dataSize={20}
@@ -144,7 +156,7 @@ export const WithVirtualList = () => {
 						</Cell>
 						<Cell size={itemHeight * 3}>
 							<VirtualList
-								childProps={{onClick: nextPanel}}
+								childProps={{onClick: nextPanel, onKeyDown: handleKeyDown}}
 								itemSize={itemSize}
 								itemRenderer={itemRenderer}
 								dataSize={3}
@@ -164,7 +176,7 @@ export const WithVirtualList = () => {
 						</slotAfter>
 					</Header>
 					<VirtualList
-						childProps={{onClick: nextPanel}}
+						childProps={{onClick: nextPanel, onKeyDown: handleKeyDown}}
 						itemSize={itemSize}
 						itemRenderer={itemRenderer}
 						dataSize={20}

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -10,6 +10,7 @@ import Item from '@enact/sandstone/Item';
 import {Panel, Header} from '@enact/sandstone/Panels';
 import PopupTabLayout, {Tab, TabPanels, TabPanel} from '@enact/sandstone/PopupTabLayout';
 import Scroller from '@enact/sandstone/Scroller';
+import Slider from '@enact/sandstone/Slider';
 import SwitchItem from '@enact/sandstone/SwitchItem';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {useState} from 'react';
@@ -190,6 +191,7 @@ export const WithVariousItems = () => {
 							<Heading>heading</Heading>
 							<Item onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)} slotAfter={<Icon>arrowsmallright</Icon>}>Color Adjust</Item>
 							<Button>button</Button>
+							<Slider style={{display: 'inline-block', width: '30%'}} />
 						</TabPanel>
 						<TabPanel>
 							<Header title="Color Adjust" type="compact" />
@@ -199,6 +201,7 @@ export const WithVariousItems = () => {
 							<Heading>heading</Heading>
 							<Item>Color Adjust</Item>
 							<Button>button</Button>
+							<Slider style={{display: 'inline-block', width: '30%'}} />
 						</TabPanel>
 					</TabPanels>
 				</Tab>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -1,16 +1,34 @@
 /* eslint-disable react/jsx-no-bind */
 
+import {is} from '@enact/core/keymap';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Heading from '@enact/sandstone/Heading';
+import Icon from '@enact/sandstone/Icon';
 import Input from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import {Panel, Header} from '@enact/sandstone/Panels';
 import PopupTabLayout, {Tab, TabPanels, TabPanel} from '@enact/sandstone/PopupTabLayout';
 import Scroller from '@enact/sandstone/Scroller';
 import SwitchItem from '@enact/sandstone/SwitchItem';
+import {action} from '@enact/storybook-utils/addons/actions';
+import {useState} from 'react';
+import compose from 'ramda/src/compose';
 
 PopupTabLayout.displayName = 'PopupTabLayout';
+
+const isRight = is('right');
+
+const navPrev = (callback, value, actionName) => () => {
+	const index = Math.max(value - 1, 0);
+	action(actionName)({index});
+	callback(index);
+};
+const navNext = (callback, value) => () => {
+	const index = Math.min(value + 1, 1);
+	// action(actionName)({index});
+	callback(index);
+};
 
 export default {
 	title: 'Sandstone/PopupTabLayout',
@@ -132,4 +150,74 @@ export const WithoutIcon = () => {
 };
 
 WithoutIcon.storyName = 'without icon';
+
+export const WithVariousItems = () => {
+	const defaultOpen = true;
+	const [open, setOpenState] = useState(defaultOpen);
+	const toggleOpen = () => setOpenState(!open);
+	const handleClose = compose(toggleOpen, action('onClose'));
+
+	const [indexDisplay, setIndexDisplay] = useState(0);
+	const [indexSound, setIndexSound] = useState(0);
+
+	const handleDisplayNext = navNext(setIndexDisplay, indexDisplay, 'onNext');
+	const handleDisplayPrev = navPrev(setIndexDisplay, indexDisplay, 'onBack');
+	const handleSoundNext = navNext(setIndexSound, indexSound, 'onNext');
+	const handleSoundPrev = navPrev(setIndexSound, indexSound, 'onBack');
+
+	// Navigate menus with the right key. The left key is handled by framework.
+	const handleKeyDown = (setState, state) => (ev) => {
+		const {keyCode} = ev;
+
+		if (isRight(keyCode) && ev.target && !ev.target.hasAttribute('disabled')) {
+			navNext(setState, state, 'onNext')();
+		}
+	};
+
+	return (
+		<div>
+			<PopupTabLayout
+				open={open}
+				onClose={handleClose}
+			>
+				<Tab icon="picture" title="Display">
+					<TabPanels index={indexDisplay} onBack={handleDisplayPrev}>
+						<TabPanel>
+							<Header title="Display Settings" type="compact" />
+							<SwitchItem>Picture Modes</SwitchItem>
+							<Button size="small" onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>button1</Button>
+							<Button size="small" onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)} disabled>button2</Button>
+							<Heading>heading</Heading>
+							<Item onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)} slotAfter={<Icon>arrowsmallright</Icon>}>Color Adjust</Item>
+							<Button>button</Button>
+						</TabPanel>
+						<TabPanel>
+							<Header title="Color Adjust" type="compact" />
+							<SwitchItem>Picture Modes</SwitchItem>
+							<Button size="small" disabled>button1</Button>
+							<Button size="small">button2</Button>
+							<Heading>heading</Heading>
+							<Item>Color Adjust</Item>
+							<Button>button</Button>
+						</TabPanel>
+					</TabPanels>
+				</Tab>
+				<Tab icon="sound" title="Sound">
+					<TabPanels index={indexSound} onBack={handleSoundPrev}>
+						<TabPanel>
+							<Header title="Sound Settings" type="compact" />
+							<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Advanced Audio</Item>
+						</TabPanel>
+						<TabPanel>
+							<Header title="Advanced Audio" type="compact" />
+							<Item>Balance</Item>
+						</TabPanel>
+					</TabPanels>
+				</Tab>
+			</PopupTabLayout>
+		</div>
+	);
+};
+
+WithVariousItems.storyName = 'with various items';
 

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -3,6 +3,7 @@
 import {is} from '@enact/core/keymap';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
+import Dropdown from '@enact/sandstone/Dropdown';
 import Heading from '@enact/sandstone/Heading';
 import Icon from '@enact/sandstone/Icon';
 import Input from '@enact/sandstone/Input';
@@ -13,6 +14,7 @@ import Scroller from '@enact/sandstone/Scroller';
 import Slider from '@enact/sandstone/Slider';
 import SwitchItem from '@enact/sandstone/SwitchItem';
 import {action} from '@enact/storybook-utils/addons/actions';
+import {Cell} from '@enact/ui/Layout';
 import {useState} from 'react';
 import compose from 'ramda/src/compose';
 
@@ -185,23 +187,44 @@ export const WithVariousItems = () => {
 					<TabPanels index={indexDisplay} onBack={handleDisplayPrev}>
 						<TabPanel>
 							<Header title="Display Settings" type="compact" />
-							<SwitchItem>Picture Modes</SwitchItem>
-							<Button size="small" onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>button1</Button>
-							<Button size="small" onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)} disabled>button2</Button>
-							<Heading>heading</Heading>
-							<Item onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)} slotAfter={<Icon>arrowsmallright</Icon>}>Color Adjust</Item>
-							<Button>button</Button>
-							<Slider style={{display: 'inline-block', width: '30%'}} />
+							<Cell>
+								<span>This is the first panel.</span>
+								<Button size="small" disabled onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>Button1</Button>
+								<br />
+								<br />
+								<Button size="small">Button2</Button>
+								<Button size="small" onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)}>Button3</Button>
+								<br />
+								<br />
+								<Item onClick={handleDisplayNext} onKeyDown={handleKeyDown(setIndexDisplay, indexDisplay)} slotAfter={<Icon>arrowlargeright</Icon>}>Color Adjust</Item>
+								<Slider />
+								<br />
+								<Button size="small" disabled>Button4</Button>
+								<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+									{['a', 'b', 'c', 'd', 'e', 'f']}
+								</Dropdown>
+								<br />
+								<br />
+							</Cell>
 						</TabPanel>
 						<TabPanel>
 							<Header title="Color Adjust" type="compact" />
-							<SwitchItem>Picture Modes</SwitchItem>
-							<Button size="small" disabled>button1</Button>
-							<Button size="small">button2</Button>
-							<Heading>heading</Heading>
-							<Item>Color Adjust</Item>
-							<Button>button</Button>
-							<Slider style={{display: 'inline-block', width: '30%'}} />
+							<Cell>
+								<span>This is the second panel.</span>
+								<Button size="small" disabled>Button1</Button>
+								<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+									{['a', 'b', 'c', 'd', 'e', 'f']}
+								</Dropdown>
+								<br />
+								<br />
+								<Button size="small" disabled>Button2</Button>
+								<Button size="small">Button3</Button>
+								<br />
+								<br />
+								<Button size="small">Slider</Button><Slider style={{display: 'inline-block', width: '30%'}} />
+								<br />
+								<br />
+							</Cell>
 						</TabPanel>
 					</TabPanels>
 				</Tab>

--- a/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
+++ b/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
@@ -1,5 +1,6 @@
-const Page = require('./FixedPopupPanelsPage');
+const {getFocusedText} = require('../utils');
 
+const Page = require('./FixedPopupPanelsPage');
 
 describe('FixedPopupPanels', function () {
 	const Interface = Page.fixedPopupPanels;
@@ -24,6 +25,52 @@ describe('FixedPopupPanels', function () {
 
 			Page.backKey();
 			Interface.waitForClose();
+		});
+
+		it('should navigate to the previous panel with left key on an Item', function () {
+			Page.open();
+
+			expect(Interface.openButton.isFocused(), 'focus Open button').to.be.true();
+
+			Page.spotlightSelect();
+
+			Page.waitForFocused(Interface.item1);
+
+			Interface.waitForEnter(2, () => {
+				Page.spotlightSelect();
+			});
+
+			Interface.waitForEnter(1, () => {
+				Page.spotlightLeft();
+			});
+
+			Page.backKey();
+			Interface.waitForClose();
+		});
+
+		it('should not go to the previous panel with left key on the back button', function () {
+			Page.open();
+
+			expect(Interface.openButton.isFocused(), 'focus Open button').to.be.true();
+
+			Page.spotlightSelect();
+
+			Page.waitForFocused(Interface.item1);
+
+			Interface.waitForEnter(2, () => {
+				Page.spotlightSelect();
+			});
+
+			Page.spotlightUp();
+			Page.spotlightLeft();
+			Page.delay(500);
+
+			Page.spotlightDown();
+
+			const expected = "Example Item 1 on Panel 2";
+			const actual = browser.execute(getFocusedText);
+
+			expect(actual).to.equal(expected);
 		});
 
 		it('should not duplicate 5-way actions', function () {

--- a/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
+++ b/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
@@ -67,7 +67,7 @@ describe('FixedPopupPanels', function () {
 
 			Page.spotlightDown();
 
-			const expected = "Example Item 1 on Panel 2";
+			const expected = 'Example Item 1 on Panel 2';
 			const actual = browser.execute(getFocusedText);
 
 			expect(actual).to.equal(expected);

--- a/tests/ui/specs/PopupTabLayout/PopupTabLayout-specs.js
+++ b/tests/ui/specs/PopupTabLayout/PopupTabLayout-specs.js
@@ -59,16 +59,53 @@ describe('PopupTabLayout', function () {
 				});
 
 				it('should expand the tabs when focus returns to the tabs', function () {
-					Page.waitTransitionEnd(1500, 'waiting for Panel transition', () => {
-						Page.spotlightRight();
-						Page.spotlightSelect();
-					});
-					Page.waitTransitionEnd(1500, 'waiting for Panel transition', () => {
-						Page.spotlightLeft();
-					});
+					Page.spotlightRight();
+					Page.spotlightSelect();
+					Page.delay(500);
+
+					// To the upper menu
+					Page.spotlightLeft();
+					Page.delay(500);
+
+					Page.spotlightLeft();
+					Page.delay(500);
 
 					const expected = false;
 					const actual = popupTabLayout.isCollapsed;
+
+					expect(actual).to.equal(expected);
+				});
+
+				it('should go to the upper menu with the left key', function () {
+					Page.spotlightRight();
+					Page.spotlightSelect();
+					Page.delay(500);
+
+					// To the upper menu
+					Page.spotlightLeft();
+					Page.delay(500);
+
+					const expected = 'Color Adjust';
+					const actual = browser.execute(getFocusedText);
+
+					expect(actual).to.equal(expected);
+				});
+
+				it('should not move the focus with the left key on the back button', function () {
+					Page.spotlightRight();
+					Page.spotlightSelect();
+					Page.delay(500);
+
+					// To the back button
+					Page.spotlightUp();
+
+					Page.spotlightLeft();
+					Page.delay(500);
+
+					Page.spotlightDown();
+
+					const expected = $('#brightness').isFocused();
+					const actual = true;
 
 					expect(actual).to.equal(expected);
 				});
@@ -217,6 +254,11 @@ describe('PopupTabLayout', function () {
 				expect(popupTabLayout.isCollapsed).to.be.false();
 
 				Page.spotlightSelect();
+				Page.delay(500);
+				expect(popupTabLayout.isCollapsed).to.be.true();
+
+				// To the upper menu
+				Page.spotlightLeft();
 				Page.delay(500);
 				expect(popupTabLayout.isCollapsed).to.be.true();
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added new UX that navigating with left and right keys in PopupTablayout and FixedPopupPanels.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
For right key navigation, the framework cannot support this feature so I added some example to the sampler
For left key navigation, added handles for the left key to the component and if it's the left-most spottable then it calls `onBack`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Miscellaneous sampler bug also fixed.

### Links
[//]: # (Related issues, references)
PLAT-132841

### Comments
