### PR TITLE
PLAT-132842: Hide Scrollbar after N secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
+- `sandstone/Scroller` and `sandstone/VirtualList` to hide the scrollbar after N seconds
 
 ### Fixed
 

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -16,6 +16,7 @@ const useThemeScrollbar = (props) => {
 
 	const {
 		'aria-label': ariaLabel,
+		cbAlertScrollbarTrack,
 		focusableScrollbar,
 		onInteractionForScroll,
 		rtl,
@@ -68,6 +69,7 @@ const useThemeScrollbar = (props) => {
 		scrollbarTrackProps: {
 			...scrollbarTrackProps,
 			'aria-label': ariaLabel,
+			cbAlertScrollbarTrack,
 			focusableScrollbar,
 			onInteractionForScroll,
 			rtl,

--- a/useScroll/Scrollbar.module.less
+++ b/useScroll/Scrollbar.module.less
@@ -7,6 +7,10 @@
 .scrollbar {
 	background: none;
 	border-color: transparent;
+	opacity: 1;
+
+	transition: opacity 100ms ease-out;
+	will-change: opacity;
 
 	&.horizontal {
 		.enact-locale-rtl({
@@ -14,6 +18,11 @@
 			direction: ltr;
 			transform: scaleX(-1);
 		});
+	}
+
+	/* ScrollbarTrack */
+	.scrollbarTrackShown {
+		opacity: 1;
 	}
 }
 

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -32,12 +32,13 @@ const SpottableDiv = Spottable('div');
  */
 const ScrollbarTrack = forwardRef((props, ref) => {
 	const
-		{'aria-label': ariaLabel, focusableScrollbar, onInteractionForScroll, rtl, scrollbarTrackCss, vertical, ...rest} = props,
+		{'aria-label': ariaLabel, cbAlertScrollbarTrack, focusableScrollbar, onInteractionForScroll, rtl, scrollbarTrackCss, vertical, ...rest} = props,
 		className = classNames(css.scrollbarTrack, {[css.vertical]: vertical, [css.focusableScrollbar]: focusableScrollbar}),
 		ScrollbarThumb = focusableScrollbar ? SpottableDiv : 'div',
 		announceRef = useRef({});
 
 	useEffect (() => {
+		cbAlertScrollbarTrack();
 		SpotlightAccelerator.reset();
 
 		return () => {
@@ -110,6 +111,14 @@ ScrollbarTrack.displayName = 'ScrollbarTrack';
 
 ScrollbarTrack.propTypes = /** @lends sandstone/useScroll.ScrollbarTrack.prototype */ {
 	/**
+	 * Called when [ScrollbarTrack]{@link sandstone/useScroll.ScrollbarTrack} is updated.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	cbAlertScrollbarTrack: PropTypes.func,
+
+	/**
 	 * `true` if scroll thumb is spottable.
 	 *
 	 * @type {Boolean|'byEnter'}
@@ -157,6 +166,7 @@ ScrollbarTrack.propTypes = /** @lends sandstone/useScroll.ScrollbarTrack.prototy
 };
 
 ScrollbarTrack.defaultProps = {
+	cbAlertScrollbarTrack: nop,
 	focusableScrollbar: false,
 	onInteractionForScroll: nop,
 	rtl: false,

--- a/useScroll/ScrollbarTrack.module.less
+++ b/useScroll/ScrollbarTrack.module.less
@@ -16,8 +16,16 @@
 	width: 100%;
 	background-color: @sand-scrollbar-track-bg-color;
 	border-radius: @sand-scrollbar-track-border-radius;
+	opacity: 0;
+	transition: opacity 100ms ease-out;
+
+	&:hover {
+		opacity: 1;
+	}
 
 	&.focusableScrollbar {
+		// Always show the scrollbar
+		opacity: 1;
 		--scrollbar-track-margin: @sand-scrollbar-track-focusable-margin;
 	}
 

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -106,6 +106,7 @@ const useThemeScroll = (props, instances) => {
 	} = useEventVoice(props, instances);
 
 	const scrollbarProps = {
+		cbAlertScrollbarTrack: alertScrollbarTrack,
 		onInteractionForScroll,
 		scrollbarTrackCss
 	};
@@ -162,6 +163,12 @@ const useThemeScroll = (props, instances) => {
 		}
 
 		scrollContainerHandle.current.scrollToAccumulatedTarget(direction * distance, isVerticalScrollBar, props.overscrollEffectOn[inputType]);
+	}
+
+	function alertScrollbarTrack () {
+		const bounds = scrollContainerHandle.current.getScrollBounds();
+		scrollContainerHandle.current.showScrollbarTrack(bounds);
+		scrollContainerHandle.current.startHidingScrollbarTrack();
 	}
 
 	function focusOnItem () {
@@ -338,7 +345,9 @@ const useScroll = (props) => {
 		scrollToInfo: null,
 		scrollTop: null,
 		setOverscrollStatus: null,
+		showScrollbarTrack: null,
 		start: null,
+		startHidingScrollbarTrack: null,
 		stop: null,
 		wheelDirection: null
 	});


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
TV UX was changed to hide Scrollbar after N seconds.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Revert "PLAT-123585: Scroller: keep showing scroll thumb (#776)"

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-132842

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)