### PR TITLE
PLAT-141390: Changed back key behavior on PopupTabLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Changed
 
+- `sandstone/PopupTabLayout` back key behavior to match latest UX
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Changed
 
-- `sandstone/PopupTabLayout` back key behavior to match the latest UX
 - `sandstone/Panels.Header` to always show back button
+- `sandstone/PopupTabLayout` back key behavior to match the latest UX
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` and `sandstone/VirtualList` to hide the scrollbar after N seconds

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -275,7 +275,7 @@ const TabLayoutBase = kind({
 			const {collapsed, 'data-spotlight-id': spotlightId, type} = props;
 			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
 
-			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === '0') {
+			if (forwardWithPrevent('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === '0') {
 				if (collapsed) {
 					forward('onExpand', ev, props);
 				}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -10,6 +10,7 @@
  */
 
 import {adaptEvent, forward, forwardWithPrevent, forProp, handle} from '@enact/core/handle';
+import {is} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
 import {cap, mapAndFilterChildren} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
@@ -29,6 +30,7 @@ import TabGroup from './TabGroup';
 import Tab from './Tab';
 
 import componentCss from './TabLayout.module.less';
+import popupTabLayoutComponentCss from '../PopupTabLayout/PopupTabLayout.module.less';
 
 const TabLayoutContext = createContext(null);
 
@@ -258,6 +260,19 @@ const TabLayoutBase = kind({
 						forward('onExpand', ev, props);
 					}
 				}
+			}
+		},
+		onKeyUp: (ev, props) => {
+			const {keyCode, target} = ev;
+			const {collapsed, 'data-spotlight-id': spotlightId, type} = props;
+			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
+
+			if (forward('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef.contains(target) && popupPanelRef.dataset.index === '0') {
+				if (collapsed) {
+					forward('onExpand', ev, props);
+				}
+				Spotlight.move('left');
+				ev.stopPropagation();
 			}
 		},
 		onSelect: handle(

--- a/tests/ui/specs/PopupTabLayout/PopupTabLayout-specs.js
+++ b/tests/ui/specs/PopupTabLayout/PopupTabLayout-specs.js
@@ -110,7 +110,7 @@ describe('PopupTabLayout', function () {
 					expect(actual).to.equal(expected);
 				});
 
-				it('should close the popup on back', function () {
+				it('should close the popup on back when the focus is on the tabs', function () {
 					Page.waitTransitionEnd(1500, 'waiting for popup to close', () => {
 						Page.backKey();
 					});
@@ -136,6 +136,52 @@ describe('PopupTabLayout', function () {
 
 					expect(actual).to.equal(expected);
 				});
+
+				it('should collapse tab only when user enters a menu', function () {
+					Page.spotlightRight();
+					Page.delay(500);
+					expect(popupTabLayout.isCollapsed).to.be.false();
+
+					Page.spotlightSelect();
+					Page.delay(500);
+					expect(popupTabLayout.isCollapsed).to.be.true();
+
+					Page.spotlightLeft();
+					Page.delay(500);
+					expect(popupTabLayout.isCollapsed).to.be.false();
+				});
+
+				it('should not close the popup when pressing back key on the first panel of content', function () {
+					// Go to the second depth of the content
+					Page.spotlightRight();
+					Page.spotlightSelect();
+					Page.delay(500);
+
+					// Press back key to go to the first panel
+					Page.backKey();
+					Page.delay(500);
+
+					// Make sure the focus is on the first panel
+					expect(browser.execute(getFocusedText)).to.equal('Color Adjust');
+
+					// Press back key to move the focus on the tabs
+					Page.backKey();
+					Page.delay(500);
+
+					// Make sure the focus is on the tabs
+					expect(browser.execute(getFocusedText)).to.equal('Display');
+
+					// Press back key to close the popup
+					Page.waitTransitionEnd(1500, 'waiting for popup to close', () => {
+						Page.backKey();
+					});
+
+					const expected = $('#tabLayout').isExisting();
+					const actual = false;
+
+					expect(actual).to.equal(expected);
+				});
+
 			});
 
 			// describe('pointer interaction', function () {
@@ -209,20 +255,6 @@ describe('PopupTabLayout', function () {
 				const actual = browser.execute(getFocusedText);
 
 				expect(actual).to.equal(expected);
-			});
-
-			it('should collapse tab only when user enters a menu ', function () {
-				Page.spotlightRight();
-				Page.delay(500);
-				expect(popupTabLayout.isCollapsed).to.be.false();
-
-				Page.spotlightSelect();
-				Page.delay(500);
-				expect(popupTabLayout.isCollapsed).to.be.true();
-
-				Page.spotlightLeft();
-				Page.delay(500);
-				expect(popupTabLayout.isCollapsed).to.be.false();
 			});
 		});
 	});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the back key pressed from the content which is the first panel, it should not close the popup but it should move the focus to tabs area.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `onKeyUp` handler to TabLayout and see if the target is from the content that is the first panel, move the spotlight to the tabs and call `stopPropagation` to not close the Popup.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141390

### Comments
