### PR TITLE
PLAT-126939: added separate labels for navigation buttons in WizardPanels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold
+- `sandstone/WizardPanels` props `nextButtonLabel` and `prevButtonLabel` to provide button lables matching latest designs
 
 ### Changed
 

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -90,6 +90,15 @@ const Panel = Slottable(
  */
 
 /**
+ * The label for the next button.
+ *
+ * @name nextButtonLabel
+ * @memberof sandstone/WizardPanels.Panel.prototype
+ * @type {String}
+ * @public
+ */
+
+/**
  * The button to use in place of the standard prev button.
  *
  * This prop accepts a component (e.g. `Button`), a component instance or a boolean value.
@@ -103,9 +112,18 @@ const Panel = Slottable(
  * prevButton={<Button icon="closex" aria-label="Back">Back</Button>}
  * ```
  *
- * @name PrevButton
+ * @name prevButton
  * @memberof sandstone/WizardPanels.Panel.prototype
  * @type {Boolean|Component}
+ * @public
+ */
+
+/**
+ * The label for the prev button.
+ *
+ * @name prevButtonLabel
+ * @memberof sandstone/WizardPanels.Panel.prototype
+ * @type {String}
  * @public
  */
 

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -80,7 +80,7 @@ const Panel = Slottable(
  *
  * Example:
  * ```
- * nextButton={<Button icon="closex" aria-label="Quit">Close</Button>}
+ * nextButton={<Button icon="closex" aria-label="Quit" />}
  * ```
  *
  * @name nextButton
@@ -109,7 +109,7 @@ const Panel = Slottable(
  *
  * Example:
  * ```
- * prevButton={<Button icon="closex" aria-label="Back">Back</Button>}
+ * prevButton={<Button icon="closex" aria-label="Back" />}
  * ```
  *
  * @name prevButton

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -17,7 +17,9 @@ function PanelBase ({
 	children,
 	footer,
 	nextButton,
+	nextButtonLabel,
 	prevButton,
+	prevButtonLabel,
 	subtitle,
 	title
 }) {
@@ -30,7 +32,9 @@ function PanelBase ({
 				children,
 				footer,
 				nextButton,
+				nextButtonLabel,
 				prevButton,
+				prevButtonLabel,
 				subtitle,
 				title
 			});
@@ -40,7 +44,9 @@ function PanelBase ({
 		children,
 		footer,
 		nextButton,
+		nextButtonLabel,
 		prevButton,
+		prevButtonLabel,
 		subtitle,
 		set,
 		title

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -28,6 +28,11 @@ import css from './WizardPanels.module.less';
 const WizardPanelsContext = createContext(null);
 const DecoratedPanelBase = FloatingLayerIdProvider(PanelBase);
 const HeaderContainer = SpotlightContainerDecorator(Header);
+const ButtonLabel = (props) => (
+	<div className={css.buttonLabel}>
+		<div className={css.label} {...props} />
+	</div>
+);
 
 /**
  * A WizardPanels that has steps with corresponding panels.
@@ -122,6 +127,8 @@ const WizardPanelsBase = kind({
 		 */
 		nextButton: PropTypes.oneOfType([PropTypes.bool, EnactPropTypes.componentOverride]),
 
+		nextButtonLabel: PropTypes.string,
+
 		/**
 		 * Specifies when and how to show `nextButton` on WizardPanel.
 		 *
@@ -215,6 +222,8 @@ const WizardPanelsBase = kind({
 		 * @private
 		 */
 		prevButton: PropTypes.oneOfType([PropTypes.bool, EnactPropTypes.componentOverride]),
+
+		prevButtonLabel: PropTypes.string,
 
 		/**
 		 * Specifies when and how to show `prevButton` on WizardPanel.
@@ -348,6 +357,7 @@ const WizardPanelsBase = kind({
 		footer,
 		index,
 		nextButton,
+		nextButtonLabel,
 		nextButtonVisibility,
 		noAnimation,
 		onNextClick,
@@ -355,6 +365,7 @@ const WizardPanelsBase = kind({
 		onTransition,
 		onWillTransition,
 		prevButton,
+		prevButtonLabel,
 		prevButtonVisibility,
 		reverseTransition,
 		steps,
@@ -385,29 +396,37 @@ const WizardPanelsBase = kind({
 						type="wizard"
 					>
 						{steps}
-						<NavigationButton
-							aria-label={$L('Previous')}
-							backgroundOpacity="transparent"
-							component={prevButton}
-							icon="arrowlargeleft"
-							iconFlip="auto"
-							minWidth={false}
-							onClick={onPrevClick}
+						<div
 							slot="slotBefore"
-							visible={isPrevButtonVisible}
-						/>
-						<NavigationButton
-							aria-label={$L('Next')}
-							backgroundOpacity="transparent"
-							component={nextButton}
-							icon="arrowlargeright"
-							iconFlip="auto"
-							iconPosition="after"
-							minWidth={false}
-							onClick={onNextClick}
+						>
+							<NavigationButton
+								aria-label={$L('Previous')}
+								backgroundOpacity="transparent"
+								component={prevButton}
+								icon="arrowlargeleft"
+								iconFlip="auto"
+								minWidth={false}
+								onClick={onPrevClick}
+								visible={isPrevButtonVisible}
+							/>
+							{prevButtonLabel ? <ButtonLabel>{prevButtonLabel}</ButtonLabel> : null}
+						</div>
+						<div
 							slot="slotAfter"
-							visible={isNextButtonVisible}
-						/>
+						>
+							{nextButtonLabel ? <ButtonLabel>{nextButtonLabel}</ButtonLabel> : null}
+							<NavigationButton
+								aria-label={$L('Next')}
+								backgroundOpacity="transparent"
+								component={nextButton}
+								icon="arrowlargeright"
+								iconFlip="auto"
+								iconPosition="after"
+								minWidth={false}
+								onClick={onNextClick}
+								visible={isNextButtonVisible}
+							/>
+						</div>
 					</HeaderContainer>
 				}
 				panelType="wizard"

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -119,7 +119,7 @@ const WizardPanelsBase = kind({
 		 *
  		 * Example:
  		 * ```
-		 * nextButton={<Button icon="closex" aria-label="Quit">Close</Button>}
+		 * nextButton={<Button icon="closex" aria-label="Quit" />}
 		 * ```
 		 *
 		 * @type {Boolean|Component}
@@ -127,6 +127,12 @@ const WizardPanelsBase = kind({
 		 */
 		nextButton: PropTypes.oneOfType([PropTypes.bool, EnactPropTypes.componentOverride]),
 
+		/**
+		 * The label for the next button.
+		 *
+		 * @type {String}
+		 * @private
+		 */
 		nextButtonLabel: PropTypes.string,
 
 		/**
@@ -215,7 +221,7 @@ const WizardPanelsBase = kind({
 		 *
  		 * Example:
  		 * ```
-		 * prevButton={<Button icon="closex" aria-label="Back">Back</Button>}
+		 * prevButton={<Button icon="closex" aria-label="Back" />}
 		 * ```
 		 *
 		 * @type {Boolean|Component}
@@ -223,6 +229,12 @@ const WizardPanelsBase = kind({
 		 */
 		prevButton: PropTypes.oneOfType([PropTypes.bool, EnactPropTypes.componentOverride]),
 
+		/**
+		 * The label for the prev button.
+		 *
+		 * @type {String}
+		 * @private
+		 */
 		prevButtonLabel: PropTypes.string,
 
 		/**

--- a/WizardPanels/WizardPanels.module.less
+++ b/WizardPanels/WizardPanels.module.less
@@ -18,4 +18,18 @@
 		text-align: center;
 		margin: @sand-wizardpanels-footer-margin;
 	}
+
+	.buttonLabel {
+		.sand-large-button-text();
+		display: inline-block;
+		height: @sand-button-height;
+		max-width: 660px;
+		vertical-align: middle;
+
+		& .label {
+			display: flex;
+			height: 100%;
+			align-items: center;
+		}
+	}
 }

--- a/samples/sampler/stories/default/WizardPanels.js
+++ b/samples/sampler/stories/default/WizardPanels.js
@@ -39,9 +39,14 @@ export const _WizardPanels = () => (
 			title="WizardPanel View 1"
 			prevButton={
 				boolean('custom first Panel prevButton', Config) ? (
-					<Button icon="closex" aria-label="exit">
-						Exit
-					</Button>
+					<Button icon="closex" aria-label="exit" />
+				) : (
+					void 0
+				)
+			}
+			prevButtonLabel={
+				boolean('custom first Panel prevButton', Config) ? (
+					'Exit'
 				) : (
 					void 0
 				)
@@ -129,9 +134,14 @@ export const _WizardPanels = () => (
 			title="WizardPanel View 4"
 			nextButton={
 				boolean('custom last Panel nextButton', Config) ? (
-					<Button icon="closex" aria-label="quit">
-						Close
-					</Button>
+					<Button icon="closex" aria-label="quit" />
+				) : (
+					void 0
+				)
+			}
+			nextButtonLabel={
+				boolean('custom last Panel nextButton', Config) ? (
+					'Close'
 				) : (
 					void 0
 				)


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
GUI requires to show button labels not as a part of a button but as a separate label along with an icon button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `nextButtonLabel` and `prevButtonLabel` props to `WizardPanels.panel`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-126939

### Comments
