### PR TITLE
PLAT-132839: Show back button on Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/Input` to add a back button and props `backButtonAriaLabel`, `noBackButton` to customize a back button aria label and to not show a back button
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Input` to add a back button and props `backButtonAriaLabel`, `noBackButton` to customize a back button aria label and to not show a back button
+- `sandstone/Input` a back button and props `backButtonAriaLabel` and `noBackButton`
 - `sandstone/Input` and `sandstone/Input.InputPopup` `url` to prop `type`
 - `sandstone/Picker` and `sandstone/RangePicker` props `title` and `inlineTitle`
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {Fragment} from 'react';
 
+import $L from '../internal/$L';
 import Button from '../Button';
 import Popup from '../Popup';
 import Skinnable from '../Skinnable';
@@ -44,6 +45,15 @@ const InputPopupBase = kind({
 		 * @public
 		 */
 		announce: PropTypes.func,
+
+		/**
+		 * Sets the hint string read when focusing the back button.
+		 *
+		 * @type {String}
+		 * @default 'go to previous'
+		 * @public
+		 */
+		backButtonAriaLabel: PropTypes.string,
 
 		/**
 		 * Customize component style
@@ -115,6 +125,14 @@ const InputPopupBase = kind({
 		 * @public
 		 */
 		minLength: PropTypes.number,
+
+		/**
+		 * Omits the back button.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		noBackButton: PropTypes.bool,
 
 		/**
 		 * The type of numeric input to use.
@@ -306,8 +324,10 @@ const InputPopupBase = kind({
 
 	render: ({
 		announce,
+		backButtonAriaLabel,
 		children,
 		css,
+		noBackButton,
 		numberInputField,
 		onBeforeChange,
 		onClose,
@@ -331,6 +351,18 @@ const InputPopupBase = kind({
 
 		const inputProps = extractInputFieldProps(rest);
 		const numberMode = (numberInputField !== 'field') && (type === 'number' || type === 'passwordnumber');
+		// Set up the back button
+		const backButton = (!noBackButton ? (
+			<Button
+				aria-label={backButtonAriaLabel == null ? $L('go to previous') : backButtonAriaLabel}
+				className={css.back}
+				icon="arrowhookleft"
+				iconFlip="auto"
+				onClick={onClose}
+				size="small"
+			/>
+		) : null);
+		const heading = <Heading size="title" marqueeOn="render" alignment="center" className={css.title}>{title}</Heading>;
 
 		delete rest.length;
 		delete rest.onComplete;
@@ -346,9 +378,16 @@ const InputPopupBase = kind({
 				noAnimation
 				open={open}
 			>
+				{popupType === 'fullscreen' ? backButton : null}
 				<Layout orientation="vertical" align={`center ${numberMode ? 'space-between' : ''}`} className={css.body}>
 					<Cell shrink className={css.titles}>
-						<Heading size="title" marqueeOn="render" alignment="center" className={css.title}>{title}</Heading>
+						{popupType === 'fullscreen' ?
+							heading :
+							<>
+								{backButton}
+								{heading}
+							</>
+						}
 						<Heading size="subtitle" marqueeOn="render" alignment="center" className={css.subtitle}>{subtitle}</Heading>
 					</Cell>
 					<Cell shrink className={css.inputArea}>

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -2,11 +2,13 @@ import {handle, adaptEvent, forKey, forward} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import {extractAriaProps} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
+import {spotlightDefaultClass} from '@enact/spotlight/SpotlightContainerDecorator';
 import {useAnnounce} from '@enact/ui/AnnounceDecorator';
 import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
 import Toggleable from '@enact/ui/Toggleable';
 import Layout, {Cell} from '@enact/ui/Layout';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {Fragment} from 'react';
@@ -406,7 +408,7 @@ const InputPopupBase = kind({
 							/> :
 							<InputField
 								{...inputProps}
-								className={css.textField}
+								className={classnames(css.textField, spotlightDefaultClass)}
 								css={css}
 								maxLength={maxLength}
 								minLength={minLength}

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -12,12 +12,21 @@
 		/* Available for customization */
 	}
 
+	.back {
+		position: absolute;
+
+		.sand-custom-text({
+			.sand-small-button-text();
+		});
+	}
+
 	.body {
 		line-height: 0; // This removes an undesirable layout shift occurring when a number is entered into the numberCells (Popup adds a line-height to all children).
 	}
 
 	.titles {
 		max-width: 100%;
+		width: 100%;
 	}
 
 	.fieldWrapper {
@@ -77,6 +86,12 @@
 	}
 
 	&.fullscreen {
+		.back {
+			top: @sand-input-fullscreen-back-button-top;
+
+			.position-start-end(@sand-input-fullscreen-back-button-start, initial);
+		}
+
 		.body {
 			padding: @sand-input-fullscreen-padding;
 		}
@@ -142,11 +157,19 @@
 	}
 
 	&.overlay {
+		.back {
+			top: @sand-input-overlay-back-button-top;
+
+			.position-start-end(@sand-input-overlay-back-button-start, initial);
+		}
+
 		.body {
 			padding: @sand-input-overlay-padding;
 		}
 
 		.title {
+			margin: @sand-input-overlay-title-margin;
+
 			.sand-font-size(@sand-input-overlay-title-font-size, @sand-non-latin-input-overlay-title-font-size);
 		}
 

--- a/Input/Keypad.js
+++ b/Input/Keypad.js
@@ -5,6 +5,7 @@
 import kind from '@enact/core/kind';
 import {add} from '@enact/core/keymap';
 import {handle, oneOf, forKey, forward, adaptEvent} from '@enact/core/handle';
+import {spotlightDefaultClass} from '@enact/spotlight/SpotlightContainerDecorator';
 import Layout, {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 
@@ -77,6 +78,7 @@ const Keypad = kind({
 				{KEY_LIST.map((keyText, rowIndex) => {
 					return (
 						<Cell
+							className={rowIndex === 0 ? spotlightDefaultClass : null}
 							aria-label={keyText === 'backspace' ? $L('backspace') : keyText}
 							shrink
 							component={Key}

--- a/samples/qa-a11y/src/views/Input.js
+++ b/samples/qa-a11y/src/views/Input.js
@@ -37,6 +37,7 @@ const InputView = () => (
 			<Input alt="Aria-labelled and Disabled" aria-label="This is a Label 1." disabled />
 			<Input alt="With popupAriaLabel" popupAriaLabel="This is a Label 2." />
 			<Input alt="Number Type With Title, Subtitle, and Placeholder" aria-label="This is a Label 3." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
+			<Input alt="Number Type and backButtonAriaLabel With Title, Subtitle, and Placeholder" aria-label="This is a Label 4." backButtonAriaLabel="This is a Back." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
 		</Section>
 	</>
 );

--- a/samples/sampler/stories/default/Input.js
+++ b/samples/sampler/stories/default/Input.js
@@ -11,7 +11,8 @@ const prop = {
 	numericKind: ['auto', 'joined', 'separated', 'field'],
 	popupType: ['fullscreen', 'overlay'],
 	size: ['small', 'large'],
-	type: ['text', 'password', 'number', 'passwordnumber']
+	type: ['text', 'password', 'number', 'passwordnumber'],
+	backButtonAriaLabel: [null, 'Back']
 };
 
 export default {
@@ -39,7 +40,9 @@ export const _Input = () => {
 		title: text('title', ConfigPopup, 'Title Text'),
 		disabled: boolean('disabled', Config),
 		'aria-label': text('aria-label', ConfigPopup, ''),
-		popupAriaLabel: text('popupAriaLabel', ConfigPopup, '')
+		popupAriaLabel: text('popupAriaLabel', ConfigPopup, ''),
+		noBackButton: boolean('noBackButton', ConfigPopup),
+		backButtonAriaLabel: select('backButtonAriaLabel', prop.backButtonAriaLabel, ConfigPopup)
 	};
 
 	// Numeric specific props

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -639,6 +639,8 @@
 @sand-input-fullscreen-buttonarea-margin: 0;
 @sand-input-fullscreen-inputarea-margin: 222px 0 0 0;
 @sand-input-fullscreen-invalid-tooltip-width: 3240px;
+@sand-input-fullscreen-back-button-top: 132px;
+@sand-input-fullscreen-back-button-start: 96px;
 @sand-input-overlay-padding: (90px - .extract(@sand-popup-padding, top)[]) (90px - .extract(@sand-popup-padding, right)[]) (90px - .extract(@sand-popup-padding, bottom)[]) (90px - .extract(@sand-popup-padding, left)[]);
 @sand-input-overlay-inputarea-margin: 96px 0 0 0;
 @sand-input-overlay-numbercell-width: 174px;
@@ -655,6 +657,9 @@
 @sand-input-overlay-submitbutton-margin: 84px auto 0 auto;
 @sand-input-overlay-invalid-tooltip-width: 738px;
 @sand-input-overlay-textfield-width: 1164px;
+@sand-input-overlay-back-button-top: 9px;
+@sand-input-overlay-back-button-start: -42px;
+@sand-input-overlay-title-margin: 0 144px (@sand-heading-spacing-small - @sand-heading-border-width) 144px;
 @sand-input-invalid-tooltip-margin-top: @sand-inputfield-invalid-tooltip-margin-top;
 
 // InputField

--- a/tests/screenshot/apps/components/Input.js
+++ b/tests/screenshot/apps/components/Input.js
@@ -5,6 +5,7 @@ import {withConfig, withProps} from './utils';
 const BaseTests = [
 	<Input />,
 	<Input open title="Input Test" subtitle="Additional text" />,
+	<Input open title="Input Test" subtitle="Additional text" noBackButton />,
 	<Input open title="Input Test" subtitle="Additional text" placeholder="placeholder" />,
 	<Input open title="Input Test" subtitle="Additional text" value="value" />,
 	<Input open title="Input Test" subtitle="Additional text" value="value" type="password" />,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Need to add a back button in the Input


### Resolution
Migrate back button on Input patches from 2021 NMRM TV ("release/1.4.3-touch.x" branch)


### Additional Considerations


### Links
PLAT-132839


### Comments
