### PR TITLE
PLAT-140535: Add url type in Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/Input` and `sandstone/Input.InputPopup` url to prop `type`
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Input` and `sandstone/Input.InputPopup` url to prop `type`
+- `sandstone/Input` and `sandstone/Input.InputPopup` `url` to prop `type`
 - `sandstone/Picker` and `sandstone/RangePicker` props `title` and `inlineTitle`
 - `sandstone/Slider` prop `keyFrequency` to control the accelerating speed when key hold
 

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -235,11 +235,11 @@ const InputPopupBase = kind({
 		/**
 		 * Type of the input.
 		 *
-		 * @type {('text'|'password'|'number'|'passwordnumber')}
+		 * @type {('text'|'password'|'number'|'passwordnumber'|'url')}
 		 * @default 'text'
 		 * @public
 		 */
-		type: PropTypes.oneOf(['text', 'password', 'number', 'passwordnumber']),
+		type: PropTypes.oneOf(['text', 'password', 'number', 'passwordnumber', 'url']),
 
 		/**
 		 * Value of the input.
@@ -269,7 +269,7 @@ const InputPopupBase = kind({
 	handlers: {
 		onShow: handle(
 			forward('onShow'),
-			(ev, {type}) => type === 'text' || type === 'password',
+			(ev, {type}) => type === 'text' || type === 'password' || type === 'url',
 			() => Spotlight.setPointerMode(false)
 		),
 		onNumberComplete: handle(
@@ -438,11 +438,11 @@ const InputBase = kind({
 		/**
 		 * Type of the input.
 		 *
-		 * @type {('text'|'password'|'number'|'passwordnumber')}
+		 * @type {('text'|'password'|'number'|'passwordnumber'|'url')}
 		 * @default 'text'
 		 * @public
 		 */
-		type: PropTypes.oneOf(['text', 'password', 'number', 'passwordnumber']),
+		type: PropTypes.oneOf(['text', 'password', 'number', 'passwordnumber', 'url']),
 
 		/**
 		 * Value of the input.

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -269,7 +269,7 @@ const InputPopupBase = kind({
 	handlers: {
 		onShow: handle(
 			forward('onShow'),
-			(ev, {type}) => type === 'text' || type === 'password' || type === 'url',
+			(ev, {type}) => !type.includes('number'),
 			() => Spotlight.setPointerMode(false)
 		),
 		onNumberComplete: handle(

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -134,7 +134,8 @@
 		}
 
 		&.text,
-		&.password {
+		&.password,
+		&.url {
 			.inputArea {
 				margin: @sand-input-fullscreen-inputarea-margin;
 			}

--- a/Input/tests/Input-specs.js
+++ b/Input/tests/Input-specs.js
@@ -91,6 +91,19 @@ describe('Input specs', () => {
 		expect(actual).toBe(expected);
 	});
 
+	test('should set type to url at input when input type is "url"', () => {
+		const subject = mount(
+			<FloatingLayerController>
+				<Input open type="url" />
+			</FloatingLayerController>
+		);
+
+		const expected = 'url';
+		const actual = subject.find('input').prop('type');
+
+		expect(actual).toBe(expected);
+	});
+
 	test('should set disabled at button when popup is disabled', () => {
 		const subject = mount(<Input disabled />);
 

--- a/samples/qa-a11y/src/views/Input.js
+++ b/samples/qa-a11y/src/views/Input.js
@@ -20,6 +20,8 @@ const InputView = () => (
 			<Input alt="Disabled Passwordnumber Type with Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="passwordnumber" value="1234" />
 			<Input alt="Password Type With Title, Subtitle, and Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="password" />
 			<Input alt="Disabled Password Type With Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="password" value="1234" />
+			<Input alt="Url Type With Title, Subtitle, and Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="url" />
+			<Input alt="Disabled Url Type With Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="url" value="http://enactjs.com" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="With iconAfter">

--- a/samples/qa-a11y/src/views/InputField.js
+++ b/samples/qa-a11y/src/views/InputField.js
@@ -19,6 +19,8 @@ const InputFieldView = () => (
 			<InputField alt="Disabled Number type with Placeholder" disabled placeholder="Placeholder" type="number" />
 			<InputField alt="Password type with Placeholder" placeholder="Placeholder" type="password" />
 			<InputField alt="Disabled Password type with Placeholder" disabled placeholder="Placeholder" type="password" />
+			<InputField alt="Url type with Placeholder" placeholder="Placeholder" type="url" />
+			<InputField alt="Disabled Url type with Placeholder" disabled placeholder="Placeholder" type="url" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="With iconBefore">

--- a/samples/sampler/stories/default/Input.js
+++ b/samples/sampler/stories/default/Input.js
@@ -11,7 +11,7 @@ const prop = {
 	numericKind: ['auto', 'joined', 'separated', 'field'],
 	popupType: ['fullscreen', 'overlay'],
 	size: ['small', 'large'],
-	type: ['text', 'password', 'number', 'passwordnumber']
+	type: ['text', 'password', 'number', 'passwordnumber', 'url']
 };
 
 export default {

--- a/samples/sampler/stories/default/InputField.js
+++ b/samples/sampler/stories/default/InputField.js
@@ -12,7 +12,7 @@ const Config = mergeComponentMetadata('InputField', InputFieldBase, InputField);
 
 // Set up some defaults for info and knobs
 const prop = {
-	type: ['text', 'number', 'password']
+	type: ['text', 'number', 'password', 'url']
 };
 
 export default {

--- a/samples/sampler/stories/qa/common/Input_Common.js
+++ b/samples/sampler/stories/qa/common/Input_Common.js
@@ -21,11 +21,11 @@ export const buttons = {
 };
 
 export const propOptions = {
-	fieldTypes: ['text', 'number', 'password'],
+	fieldTypes: ['text', 'number', 'password', 'url'],
 	numberTypes: ['number', 'passwordnumber'],
 	popupTypes: ['fullscreen', 'overlay'],
 	size: ['small', 'large'],
-	textTypes: ['text', 'password'],
+	textTypes: ['text', 'password', 'url'],
 	buttons: Object.keys(buttons),
 	lengths: {
 		'2 (separate)': 2,

--- a/tests/screenshot/apps/components/Input.js
+++ b/tests/screenshot/apps/components/Input.js
@@ -10,6 +10,7 @@ const BaseTests = [
 	<Input open title="Input Test" subtitle="Additional text" value="value" type="password" />,
 	<Input open title="Input Test" subtitle="Additional text" value="1234" type="number" />,
 	<Input open title="Input Test" subtitle="Additional text" value="1234" type="passwordnumber" />,
+	<Input open title="Input Test" subtitle="Additional text" value="http://enactjs.com" type="url" />,
 	<Input open title="Input Test" subtitle="Additional text" value="1234" type="number" length={10} />
 ];
 

--- a/tests/screenshot/apps/components/InputField.js
+++ b/tests/screenshot/apps/components/InputField.js
@@ -25,6 +25,8 @@ const InputFieldTests = [
 	<InputField value="1234567890" type="number" disabled />,
 	<InputField value="Simple value" type="password" />,
 	<InputField value="Simple value" type="password" disabled />,
+	<InputField value="http://enactjs.com" type="url" />,
+	<InputField value="http://enactjs.com" type="url" disabled />,
 
 	// Long Text: Ellipses display with Letters, Numbers, Special Characters - [GT-28621]
 	<InputField value={LoremString} />,
@@ -118,6 +120,14 @@ const InputFieldTests = [
 	{
 		locale: 'ar-SA',
 		component: <InputField value="Simple value" type="password" disabled />
+	},
+	{
+		locale: 'ar-SA',
+		component: <InputField value="http://enactjs.com" type="url" />
+	},
+	{
+		locale: 'ar-SA',
+		component: <InputField value="http://enactjs.com" type="url" disabled />
 	},
 
 	// Long Text: Ellipses display with Letters, Numbers, Special Characters - [GT-28621]


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add url type in Input and InputPopup

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `url` to the list of acceptable values for `type` prop in Input and InputPopup

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-140535

### Comments
