### PR TITLE
PLAT-141464: Fix Panels.Header to remeasure marquee metrics when `slotSize` changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
-## [unrelease]
+## [unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unrelease]
+
+### Fixed
+
+- `sandstone/Panels.Header` to remeasure marquee metrics when the size of slots changed
+
 ## [1.4.7] - 2021-03-03
 
 ### Added

--- a/Heading/Heading.js
+++ b/Heading/Heading.js
@@ -54,6 +54,15 @@ const HeadingBase = kind({
 		showLine: PropTypes.bool,
 
 		/**
+		 * The size for slotBefore and slotAfter.
+		 * This size is used for remeasuring marquee metrics for Panels.Header.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		slotSize: PropTypes.string,
+
+		/**
 		 * The size of the spacing around the Heading.
 		 *
 		 * Allowed values include:
@@ -85,6 +94,8 @@ const HeadingBase = kind({
 
 	render: ({css, ...rest}) => {
 		delete rest.showLine;
+		delete rest.slotSize;
+
 		return UiHeading.inline({css, ...rest});
 	}
 });
@@ -106,7 +117,7 @@ const HeadingDecorator = compose(
 		marqueeOn: 'render'
 	}),
 	Pure,
-	MarqueeDecorator,
+	MarqueeDecorator({invalidateProps: ['remeasure', 'slotSize']}),
 	Skinnable
 );
 

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -430,11 +430,12 @@ const HeaderBase = kind({
 			},
 			type
 		),
-		titleCell: ({arranger, centered, css, marqueeOn, subtitle, subtitleId, title, titleId, type}) => {
+		titleCell: ({arranger, centered, css, marqueeOn, slotSize, subtitle, subtitleId, title, titleId, type}) => {
 			const direction = isRtlText(title) || isRtlText(subtitle) ? 'rtl' : 'ltr';
 
 			const titleHeading = (
 				<Heading
+					{...centered ? {slotSize} : {}}
 					id={titleId}
 					size="title"
 					spacing="auto"
@@ -449,6 +450,7 @@ const HeaderBase = kind({
 
 			const subtitleHeading = (
 				<Heading
+					{...centered ? {slotSize} : {}}
 					id={subtitleId}
 					size="subtitle"
 					spacing="auto"


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In some tricky cases, by timing issue, the title of Panels.Header in FixedPopupPanel doesn't start marquee when the title is centered.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The reason why the marquee not starting is, when Header is centered and the `slotSize` updated, the Marquee itself thinks the props are not changed so it does not recalculate its metrics.
To be specific, when Header is centered, it calculates `slotSize` to give the size for `slotAfter` and `slotBefore` by `Measurable`. The title is in between `slotAfter` and `slotBefore` so if the size of the slots changed, the width of the title is also changing.
But the problem is, Header itself rerenders well but `Heading` component used for title and subtitle will never know they are updated or not since their prop has not changed at all. In this case, we should let them know by `Measureable` or something else.
Luckily, Marquee has `invalidateProps` for recalculating its metrics when the given prop has been changed.
So I've added `slotSize` prop to `invalidateProps` so Heading can recalculate its metrics.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Unfortunately, it's hard to reproduce the problem with samples so I can't create test case for this.

### Links
[//]: # (Related issues, references)
PLAT-141464

### Comments
