### PR TITLE
PLAT-140746: Fixed horizontal VirtualList to align items well when navigating with 5-way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` button label when default value is `0`
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way
+- hotizontal `sandstone/VirtualList` to align items well when navigating with 5-way
 - `sandstone/WizardPanels` to not show focus effect on the wrong element in `footer`
 
 ## [2.0.0-alpha.3] - 2021-03-31

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -143,10 +143,11 @@ const useSpottable = (props, instances) => {
 	// Functions
 
 	function onAcceleratedKeyDown ({isWrapped, keyCode, nextIndex, repeat, target}) {
-		const {cbScrollTo, wrap} = props;
+		const {cbScrollTo, wrap, direction: orientation} = props;
 		const {dimensionToExtent, primary: {clientSize, itemSize}, scrollPosition, scrollPositionTarget} = scrollContentHandle.current;
 		const index = getNumberValue(target.dataset.index);
 		const direction = getDirection(keyCode);
+		const allowAffordance = !(noAffordance || orientation === 'horizontal');
 
 		mutableRef.current.isScrolledBy5way = false;
 		mutableRef.current.isScrolledByJump = false;
@@ -158,7 +159,7 @@ const useSpottable = (props, instances) => {
 				start = scrollContentHandle.current.getGridPosition(nextIndex).primaryPosition,
 				end = props.itemSizes ? scrollContentHandle.current.getItemBottomPosition(nextIndex) : start + itemSize,
 				startBoundary = (scrollMode === 'native') ? scrollPosition : scrollPositionTarget,
-				endBoundary = startBoundary + clientSize - (noAffordance ? 0 : ri.scale(affordanceSize));
+				endBoundary = startBoundary + clientSize - (!allowAffordance ? 0 : ri.scale(affordanceSize));
 
 			mutableRef.current.lastFocusedIndex = nextIndex;
 
@@ -185,7 +186,7 @@ const useSpottable = (props, instances) => {
 				cbScrollTo({
 					index: nextIndex,
 					stickTo,
-					offset: (!noAffordance && stickTo === 'end') ? ri.scale(affordanceSize) : 0,
+					offset: (allowAffordance && stickTo === 'end') ? ri.scale(affordanceSize) : 0,
 					animate: !(isWrapped && wrap === 'noAnimation')
 				});
 			}
@@ -236,12 +237,11 @@ const useSpottable = (props, instances) => {
 	}
 
 	function calculatePositionOnFocus ({item, scrollPosition = scrollContentHandle.current.scrollPosition}) {
-		const
-
-			{pageScroll} = props,
-			{state: {numOfItems}, primary} = scrollContentHandle.current,
-			offsetToClientEnd = primary.clientSize - primary.itemSize - (noAffordance ? 0 : ri.scale(affordanceSize)),
-			focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
+		const {pageScroll, direction} = props;
+		const {state: {numOfItems}, primary} = scrollContentHandle.current;
+		const allowAffordance = !(noAffordance || direction === 'horizontal');
+		const offsetToClientEnd = primary.clientSize - primary.itemSize - (!allowAffordance ? 0 : ri.scale(affordanceSize));
+		const focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
 		if (focusedIndex >= 0) {
 			let gridPosition = scrollContentHandle.current.getGridPosition(focusedIndex);

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -38,6 +38,15 @@ const renderItem = ({index, ...rest}) => {
 	);
 };
 
+// eslint-disable-next-line enact/prop-types
+const renderItemWithoutLabels = ({index, ...rest}) => {
+	const {source} = items[index];
+
+	return (
+		<ImageItem {...rest} src={source} />
+	);
+};
+
 const updateDataSize = (dataSize) => {
 	const itemNumberDigits = dataSize > 0 ? (dataSize - 1 + '').length : 0;
 	const headingZeros = Array(itemNumberDigits).join('0');
@@ -187,3 +196,35 @@ HorizontalVirtualGridList.parameters = {
 export const WithButtonSpotlightGoesToCorrectTarget = () => <ButtonAndVirtualGridList />;
 
 WithButtonSpotlightGoesToCorrectTarget.storyName = 'with Button, Spotlight goes to correct target';
+
+export const HorizontalSquaredVirtualGridList = () => (
+	<VirtualGridList
+		dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+		direction="horizontal"
+		horizontalScrollbar="hidden"
+		itemRenderer={renderItemWithoutLabels}
+		itemSize={{
+			minWidth: ri.scale(number('minSize', Config, 804)),
+			minHeight: ri.scale(number('minSize', Config, 804))
+		}}
+		key={select('scrollMode', prop.scrollModeOption, Config)}
+		noScrollByWheel={boolean('noScrollByWheel', Config)}
+		onKeyDown={action('onKeyDown')}
+		onScrollStart={action('onScrollStart')}
+		onScrollStop={action('onScrollStop')}
+		scrollMode={select('scrollMode', prop.scrollModeOption, Config)}
+		spacing={ri.scale(number('spacing', Config, 0))}
+		style={{
+			width: ri.scaleToRem(804),
+			height: ri.scaleToRem(804),
+			backgroundColor: 'white'
+		}}
+		spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+		wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+	/>
+);
+
+HorizontalSquaredVirtualGridList.storyName = 'Horizontal Squared VirtualGridList';
+HorizontalSquaredVirtualGridList.parameters = {
+	propTables: [Config]
+};

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -47,7 +47,7 @@ const wrapOption = {
 const renderItem = (ItemComponent, size, vertical, onClick) => ({index, ...rest}) => {
 	const style = vertical ?
 		{} :
-		{height: '100%', width: ri.unit(size, 'rem'), writingMode: 'vertical-lr'};
+		{height: '100%', width: ri.unit(size, 'rem'), writingMode: 'vertical-lr', margin: '0'};
 
 	return (
 		<ItemComponent index={index} style={style} onClick={onClick} {...rest}>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We had added "affordance" space for showing shadow when we navigate with 5way.
But we should not add this space for horizontal VL because the shadow is showing on the y-axis.
It leads to unwanted space when we navigate with 5-way in horizontal VL.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
See the direction and if the direction is horizontal, we do not add the space for the affordance.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-140746

### Comments
