### PR TITLE
PLAT-141375: Fix Scroller  initial focus filter when `focusableScrollbar = byEnter`

### DIFF
--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -5,7 +5,7 @@ import {getRect} from '@enact/spotlight/src/utils';
 import ri from '@enact/ui/resolution';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import classNames from 'classnames';
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useLayoutEffect} from 'react';
 
 import {affordanceSize} from '../useScroll';
 
@@ -356,12 +356,12 @@ const useThemeScroller = (props, scrollContentProps, contentId, isHorizontalScro
 	const {calculatePositionOnFocus, focusOnNode, setContainerDisabled} = useSpottable(scrollContentProps, {scrollContainerRef, scrollContentHandle, scrollContentRef});
 	const {setNavigableFilter, ...focusableBodyProps} = (props.focusableScrollbar === 'byEnter') ? getFocusableBodyProps(scrollContainerRef, contentId, isScrollbarVisible) : {};
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		// Initial filter setting
 		if (setNavigableFilter) {
 			setNavigableFilter({filterTarget: 'body'});
 		}
-	}, [props.focusableScrollbar]); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [props.focusableScrollbar, scrollContainerRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
 
 
 	scrollContentProps.setThemeScrollContentHandle({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller focus moves wrong target when using "byEnter"
 - Spotlight moved to scroller-body instaed of scroller-thumb via 5-way key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
After updating ref, update spotlight navigableFilter.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Changed `useEffect` to `useLayoutEffec` for safety. `useEffect` is sometime invoked too late.

### Links
[//]: # (Related issues, references)
PLAT-141375

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

