### PR TITLE
PLAT-110254: InputField: Fix cursor jumps unexpectedly when the cursor is at the end of the text and clicking the field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/FormCheckboxItem` to show correct color for `slotBefore` icon in disabled state when focused
 - `sandstone/ImageItem` to resize the image properly
 - `sandstone/Input` button label when default value is `0`
+- `sandstone/InputField` cursor behavior to not jump unexpectedly
 - `sandstone/Panels.Header` to remeasure marquee metrics when the size of slots changed
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs
 
+### Fixed
+
+- `sandstone/InputField` cursor not to jump unexpectedly when mouse down
+
 ## [2.0.0-beta.1] - 2021-05-21
 
 - Enhanced touch support
@@ -34,7 +38,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/FormCheckboxItem` to show correct color for `slotBefore` icon in disabled state when focused
 - `sandstone/ImageItem` to resize the image properly
 - `sandstone/Input` button label when default value is `0`
-- `sandstone/InputField` cursor not to jump unexpectedly when mouse down
 - `sandstone/Panels.Header` to remeasure marquee metrics when the size of slots changed
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/FormCheckboxItem` to show correct color for `slotBefore` icon in disabled state when focused
 - `sandstone/ImageItem` to resize the image properly
 - `sandstone/Input` button label when default value is `0`
-- `sandstone/InputField` cursor behavior to not jump unexpectedly
+- `sandstone/InputField` cursor not to jump unexpectedly when mouse down
 - `sandstone/Panels.Header` to remeasure marquee metrics when the size of slots changed
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -145,7 +145,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.state = {
 				focused: null,
 				node: null,
-				mouseDowned: null
+				fromMouse: false
 			};
 
 			this.ariaHidden = props.noReadoutOnFocus || null;
@@ -181,8 +181,11 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				Spotlight.getCurrent() !== this.state.node &&
 				(this.paused.isPaused() || !Spotlight.isPaused())
 			) {
-				if (this.state.mouseDowned) this.state.node.focus({preventScroll: true});
-				else this.state.node.focus();
+				if (this.state.fromMouse) {
+					this.state.node.focus({preventScroll: true});
+				} else {
+					this.state.node.focus();
+				}
 			}
 
 			const focusChanged = this.state.focused !== prevState.focused;
@@ -203,12 +206,12 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		};
 
-		focus = (focused, node, calledFromMouseDown) => {
+		focus = (focused, node, fromMouse) => {
 			this.setState(() => (
 				{
 					focused,
 					node,
-					mouseDowned: calledFromMouseDown
+					fromMouse: fromMouse
 				}
 			));
 		};
@@ -223,8 +226,8 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.focus('decorator', decorator, false);
 		};
 
-		focusInput = (decorator, calledFromMouseDown) => {
-			this.focus('input', decorator.querySelector('input'), calledFromMouseDown);
+		focusInput = (decorator, fromMouse) => {
+			this.focus('input', decorator.querySelector('input'), fromMouse);
 		};
 
 		onBlur = (ev) => {

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -177,16 +177,12 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		updateFocus = (prevState) => {
 			// focus node if `InputSpotlightDecorator` is pausing Spotlight or if Spotlight is paused
 			if (
-				!this.state.mouseDowned &&
 				this.state.node &&
 				Spotlight.getCurrent() !== this.state.node &&
 				(this.paused.isPaused() || !Spotlight.isPaused())
 			) {
-				// focus prev node if it is 'input' so that the blur event is occurred
-				if (this.state.focused && prevState.focused === 'input') {
-					prevState.node.focus();
-				}
-				this.state.node.focus();
+				if (this.state.mouseDowned) this.state.node.focus({preventScroll: true});
+				else this.state.node.focus();
 			}
 
 			const focusChanged = this.state.focused !== prevState.focused;

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -144,7 +144,8 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.state = {
 				focused: null,
-				node: null
+				node: null,
+				mouseDowned: null
 			};
 
 			this.ariaHidden = props.noReadoutOnFocus || null;
@@ -176,6 +177,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		updateFocus = (prevState) => {
 			// focus node if `InputSpotlightDecorator` is pausing Spotlight or if Spotlight is paused
 			if (
+				!this.state.mouseDowned &&
 				this.state.node &&
 				Spotlight.getCurrent() !== this.state.node &&
 				(this.paused.isPaused() || !Spotlight.isPaused())
@@ -202,7 +204,13 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		focus = (focused, node) => {
-			this.setState({focused, node});
+			this.setState((state) => (
+				{
+					focused,
+					node,
+					mouseDowned: state.mouseDowned
+				}
+			));
 		};
 
 		blur = () => {
@@ -249,6 +257,14 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		onMouseDown = (ev) => {
 			const {disabled, spotlightDisabled} = this.props;
 
+			this.setState((state) => (
+				{
+					focused: state.focused,
+					node: state.node,
+					mouseDowned: true
+				}
+			));
+
 			this.setDownTarget(ev);
 			// focus the <input> whenever clicking on any part of the component to ensure both that
 			// the <input> has focus and Spotlight is paused.
@@ -257,6 +273,16 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			forwardMouseDown(ev, this.props);
+		};
+
+		onMouseUp = () => {
+			this.setState((state) => (
+				{
+					focused: state.focused,
+					node: state.node,
+					mouseDowned: false
+				}
+			));
 		};
 
 		onFocus = (ev) => {
@@ -372,6 +398,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					{...props}
 					onBlur={this.onBlur}
 					onMouseDown={this.onMouseDown}
+					onMouseUp={this.onMouseUp}
 					onFocus={this.onFocus}
 					onKeyDown={this.handleKeyDown}
 					onKeyUp={this.onKeyUp}

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -207,13 +207,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		focus = (focused, node, fromMouse) => {
-			this.setState(() => (
-				{
-					focused,
-					node,
-					fromMouse: fromMouse
-				}
-			));
+			this.setState({focused, node, fromMouse});
 		};
 
 		blur = () => {

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -203,12 +203,12 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 		};
 
-		focus = (focused, node) => {
-			this.setState((state) => (
+		focus = (focused, node, calledFromMouseDown) => {
+			this.setState(() => (
 				{
 					focused,
 					node,
-					mouseDowned: state.mouseDowned
+					mouseDowned: calledFromMouseDown
 				}
 			));
 		};
@@ -220,11 +220,11 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		focusDecorator = (decorator) => {
-			this.focus('decorator', decorator);
+			this.focus('decorator', decorator, false);
 		};
 
-		focusInput = (decorator) => {
-			this.focus('input', decorator.querySelector('input'));
+		focusInput = (decorator, calledFromMouseDown) => {
+			this.focus('input', decorator.querySelector('input'), calledFromMouseDown);
 		};
 
 		onBlur = (ev) => {
@@ -257,32 +257,14 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		onMouseDown = (ev) => {
 			const {disabled, spotlightDisabled} = this.props;
 
-			this.setState((state) => (
-				{
-					focused: state.focused,
-					node: state.node,
-					mouseDowned: true
-				}
-			));
-
 			this.setDownTarget(ev);
 			// focus the <input> whenever clicking on any part of the component to ensure both that
 			// the <input> has focus and Spotlight is paused.
 			if (!disabled && !spotlightDisabled) {
-				this.focusInput(ev.currentTarget);
+				this.focusInput(ev.currentTarget, true);
 			}
 
 			forwardMouseDown(ev, this.props);
-		};
-
-		onMouseUp = () => {
-			this.setState((state) => (
-				{
-					focused: state.focused,
-					node: state.node,
-					mouseDowned: false
-				}
-			));
 		};
 
 		onFocus = (ev) => {
@@ -291,7 +273,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// when in autoFocus mode, focusing the decorator directly will cause it to
 			// forward the focus onto the <input>
 			if (!isBubbling(ev) && (this.props.autoFocus && this.state.focused === null && !Spotlight.getPointerMode())) {
-				this.focusInput(ev.currentTarget);
+				this.focusInput(ev.currentTarget, false);
 				ev.stopPropagation();
 			}
 		};
@@ -369,7 +351,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 						// prevent Enter onKeyPress which triggers an onMouseDown via Spotlight
 						ev.preventDefault();
 					} else if (this.state.focused !== 'input' && is('enter', keyCode)) {
-						this.focusInput(currentTarget);
+						this.focusInput(currentTarget, false);
 					}
 				}
 			}
@@ -398,7 +380,6 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					{...props}
 					onBlur={this.onBlur}
 					onMouseDown={this.onMouseDown}
-					onMouseUp={this.onMouseUp}
 					onFocus={this.onFocus}
 					onKeyDown={this.handleKeyDown}
 					onKeyUp={this.onKeyUp}

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -182,6 +182,10 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				Spotlight.getCurrent() !== this.state.node &&
 				(this.paused.isPaused() || !Spotlight.isPaused())
 			) {
+				// focus prev node if it is 'input' so that the blur event is occurred
+				if (this.state.focused && prevState.focused === 'input') {
+					prevState.node.focus();
+				}
 				this.state.node.focus();
 			}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The input tag within the InputField is double focused by the onMouseDown handler and clicking it.
So when the cursor is outside the field and focused by the onMouseDown handler, the text inside the field moves so that the cursor shows. And then, the mouse click is actually applied, the cursor seems to be jumped unexpectedly.
It needs to be fixed.


### Resolution
Prevent scroll while focusing when the mouse button is downed.


### Additional Considerations
It might generate some side-effects, so should be tested with the screenshot test and existed TCs.


### Links
PLAT-110254


### Comments
