### PR TITLE
PLAT-126939: Separate labels for navigation buttons in WizardPanels

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -128,15 +128,6 @@ const ButtonBase = kind({
 		focusEffect: PropTypes.oneOf(['expand', 'static']),
 
 		/**
-		 * Set the visual effect target when focused.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		focusIconOnly: PropTypes.bool,
-
-		/**
 		 * The component used to render the [icon]{@link sandstone/Button.ButtonBase.icon}.
 		 *
 		 * This component will receive the `icon` class to customize its styling.
@@ -187,7 +178,6 @@ const ButtonBase = kind({
 		collapsable: false,
 		collapsed: false,
 		focusEffect: 'expand',
-		focusIconOnly: false,
 		iconComponent: Icon,
 		iconOnly: false,
 		iconPosition: 'before',
@@ -196,14 +186,13 @@ const ButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['button', 'bg', 'client', 'large', 'pressed', 'selected', 'small']
+		publicClassNames: ['button', 'bg', 'client', 'hasIcon', 'icon', 'iconAfter', 'iconBefore', 'large', 'pressed', 'selected', 'small']
 	},
 
 	computed: {
-		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, focusIconOnly, iconOnly, iconPosition, size, styler}) => styler.append(
+		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, size, styler}) => styler.append(
 			{
 				hasColor: color,
-				focusIconOnly: focusIconOnly && !iconOnly,
 				iconOnly,
 				collapsable,
 				collapsed
@@ -226,7 +215,6 @@ const ButtonBase = kind({
 		delete rest.iconOnly;
 		delete rest.iconPosition;
 		delete rest.focusEffect;
-		delete rest.focusIconOnly;
 
 		return UiButtonBase.inline({
 			'data-webos-voice-intent': 'Select',

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -128,6 +128,15 @@ const ButtonBase = kind({
 		focusEffect: PropTypes.oneOf(['expand', 'static']),
 
 		/**
+		 * Set the visual effect target when focused.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		focusIconOnly: PropTypes.bool,
+
+		/**
 		 * The component used to render the [icon]{@link sandstone/Button.ButtonBase.icon}.
 		 *
 		 * This component will receive the `icon` class to customize its styling.
@@ -178,6 +187,7 @@ const ButtonBase = kind({
 		collapsable: false,
 		collapsed: false,
 		focusEffect: 'expand',
+		focusIconOnly: false,
 		iconComponent: Icon,
 		iconOnly: false,
 		iconPosition: 'before',
@@ -190,9 +200,10 @@ const ButtonBase = kind({
 	},
 
 	computed: {
-		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, size, styler}) => styler.append(
+		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, focusIconOnly, iconOnly, iconPosition, size, styler}) => styler.append(
 			{
 				hasColor: color,
+				focusIconOnly: focusIconOnly && !iconOnly,
 				iconOnly,
 				collapsable,
 				collapsed
@@ -215,6 +226,7 @@ const ButtonBase = kind({
 		delete rest.iconOnly;
 		delete rest.iconPosition;
 		delete rest.focusEffect;
+		delete rest.focusIconOnly;
 
 		return UiButtonBase.inline({
 			'data-webos-voice-intent': 'Select',

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -38,6 +38,23 @@
 		border-radius: @sand-button-border-radius;
 	}
 
+	&.hasIcon.focusIconOnly {
+		&.large .bg {
+			.position-start-end(calc(100% - @sand-icon-large-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding), 0);
+		}
+		&.small .bg {
+			.position-start-end(calc(100% - @sand-icon-small-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding), 0);
+		}
+		&.hasColor {
+			&.large .bg {
+				.position-start-end(calc(100% - @sand-icon-large-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding - @sand-button-colordot-width), 0);
+			}
+			&.small .bg {
+				.position-start-end(calc(100% - @sand-icon-small-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding - @sand-button-colordot-width), 0);
+			}
+		}
+	}
+
 	.client {
 		padding: @sand-button-border-width 0;	// We account for the button border-width here, since that is applied to .bg, not .client. Having these match means the text doesn't overlap the border
 		border-radius: inherit;

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -38,23 +38,6 @@
 		border-radius: @sand-button-border-radius;
 	}
 
-	&.hasIcon.focusIconOnly {
-		&.large .bg {
-			.position-start-end(calc(100% - @sand-icon-large-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding), 0);
-		}
-		&.small .bg {
-			.position-start-end(calc(100% - @sand-icon-small-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding), 0);
-		}
-		&.hasColor {
-			&.large .bg {
-				.position-start-end(calc(100% - @sand-icon-large-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding - @sand-button-colordot-width), 0);
-			}
-			&.small .bg {
-				.position-start-end(calc(100% - @sand-icon-small-size - @sand-button-icon-margin-end - @sand-button-with-icon-h-padding - @sand-button-colordot-width), 0);
-			}
-		}
-	}
-
 	.client {
 		padding: @sand-button-border-width 0;	// We account for the button border-width here, since that is applied to .bg, not .client. Having these match means the text doesn't overlap the border
 		border-radius: inherit;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` and `sandstone/VirtualList` to hide the scrollbar after N seconds
+- `sandstone/WizardPanels.Panel` buttons to show labels separately to match latest designs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` and `sandstone/VirtualList` to hide the scrollbar after N seconds
-- `sandstone/WizardPanels.Panel` buttons to show labels separately to match latest designs
+- `sandstone/WizardPanels.Panel` `nextButton` and `prevButton` to show labels separately to match latest designs
 
 ### Fixed
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -389,6 +389,7 @@ const WizardPanelsBase = kind({
 							aria-label={$L('Previous')}
 							backgroundOpacity="transparent"
 							component={prevButton}
+							focusIconOnly
 							icon="arrowlargeleft"
 							iconFlip="auto"
 							minWidth={false}
@@ -400,6 +401,7 @@ const WizardPanelsBase = kind({
 							aria-label={$L('Next')}
 							backgroundOpacity="transparent"
 							component={nextButton}
+							focusIconOnly
 							icon="arrowlargeright"
 							iconFlip="auto"
 							iconPosition="after"

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -389,7 +389,7 @@ const WizardPanelsBase = kind({
 							aria-label={$L('Previous')}
 							backgroundOpacity="transparent"
 							component={prevButton}
-							focusIconOnly
+							focusEffectIconOnly
 							icon="arrowlargeleft"
 							iconFlip="auto"
 							minWidth={false}
@@ -401,7 +401,7 @@ const WizardPanelsBase = kind({
 							aria-label={$L('Next')}
 							backgroundOpacity="transparent"
 							component={nextButton}
-							focusIconOnly
+							focusEffectIconOnly
 							icon="arrowlargeright"
 							iconFlip="auto"
 							iconPosition="after"

--- a/internal/Panels/NavigationButton.js
+++ b/internal/Panels/NavigationButton.js
@@ -5,6 +5,8 @@ import {isValidElement} from 'react';
 
 import Button from '../../Button';
 
+import componentCss from './NavigationButton.module.less';
+
 const NavigationButton = kind({
 	name: 'NavigationButton',
 
@@ -14,11 +16,20 @@ const NavigationButton = kind({
 			PropTypes.element,
 			PropTypes.func
 		]),
+		focusIconOnly: PropTypes.bool,
 		onClick: PropTypes.func,
 		visible: PropTypes.bool
 	},
 
-	render: ({component, visible, ...rest}) => {
+	defaultProps: {
+		focusIconOnly: false
+	},
+
+	styles: {
+		css: componentCss
+	},
+
+	render: ({component, focusIconOnly, visible, ...rest}) => {
 
 		if (isValidElement(component)) {
 			extractAriaProps(rest);
@@ -35,7 +46,7 @@ const NavigationButton = kind({
 
 			const Type = component.type;
 			return (
-				<Type {...rest} />
+				<Type css={focusIconOnly ? componentCss : null} {...rest} />
 			);
 		} else if (
 			// Explicitly disabled via false/null or visible is set to false
@@ -49,7 +60,7 @@ const NavigationButton = kind({
 		const Component = (typeof component === 'function') ? component : Button;
 
 		return (
-			<Component {...rest} />
+			<Component css={focusIconOnly ? componentCss : null} {...rest} />
 		);
 	}
 });

--- a/internal/Panels/NavigationButton.js
+++ b/internal/Panels/NavigationButton.js
@@ -25,10 +25,6 @@ const NavigationButton = kind({
 		focusIconOnly: false
 	},
 
-	styles: {
-		css: componentCss
-	},
-
 	render: ({component, focusIconOnly, visible, ...rest}) => {
 
 		if (isValidElement(component)) {

--- a/internal/Panels/NavigationButton.js
+++ b/internal/Panels/NavigationButton.js
@@ -21,10 +21,6 @@ const NavigationButton = kind({
 		visible: PropTypes.bool
 	},
 
-	defaultProps: {
-		focusIconOnly: false
-	},
-
 	render: ({component, focusIconOnly, visible, ...rest}) => {
 
 		if (isValidElement(component)) {

--- a/internal/Panels/NavigationButton.js
+++ b/internal/Panels/NavigationButton.js
@@ -16,12 +16,12 @@ const NavigationButton = kind({
 			PropTypes.element,
 			PropTypes.func
 		]),
-		focusIconOnly: PropTypes.bool,
+		focusEffectIconOnly: PropTypes.bool,
 		onClick: PropTypes.func,
 		visible: PropTypes.bool
 	},
 
-	render: ({component, focusIconOnly, visible, ...rest}) => {
+	render: ({component, focusEffectIconOnly, visible, ...rest}) => {
 
 		if (isValidElement(component)) {
 			extractAriaProps(rest);
@@ -38,7 +38,7 @@ const NavigationButton = kind({
 
 			const Type = component.type;
 			return (
-				<Type css={focusIconOnly ? componentCss : null} {...rest} />
+				<Type css={focusEffectIconOnly ? componentCss : null} {...rest} />
 			);
 		} else if (
 			// Explicitly disabled via false/null or visible is set to false
@@ -52,7 +52,7 @@ const NavigationButton = kind({
 		const Component = (typeof component === 'function') ? component : Button;
 
 		return (
-			<Component css={focusIconOnly ? componentCss : null} {...rest} />
+			<Component css={focusEffectIconOnly ? componentCss : null} {...rest} />
 		);
 	}
 });

--- a/internal/Panels/NavigationButton.module.less
+++ b/internal/Panels/NavigationButton.module.less
@@ -22,12 +22,12 @@
 			.position-start-end(auto, 0);
 		}
 		.icon {
-			.padding-start-end(@sand-wizardpanels-button-icon-text-gap, 0);
+			.margin-start-end(@sand-wizardpanels-button-icon-text-gap, 0);
 		}
 	}
 	&.iconBefore {
 		.icon {
-			.padding-start-end(0, @sand-wizardpanels-button-icon-text-gap);
+			.margin-start-end(0, @sand-wizardpanels-button-icon-text-gap);
 		}
 	}
 	.applySkins({

--- a/internal/Panels/NavigationButton.module.less
+++ b/internal/Panels/NavigationButton.module.less
@@ -1,0 +1,38 @@
+// NavigationButton.module.less
+//
+@import "../../styles/mixins.less";
+@import "../../styles/variables.less";
+@import "../../styles/skin.less";
+
+.button.hasIcon {
+	&.small {
+		padding: @sand-button-icon-small-padding;
+		& .bg {
+			width: @sand-button-small-height;
+		}
+	}
+	&.large {
+		padding: @sand-button-icon-padding;
+		& .bg {
+			width: @sand-button-height;
+		}
+	}
+	&.iconAfter {
+		.bg {
+			.position-start-end(auto, 0);
+		}
+		.icon {
+			.padding-start-end(@sand-wizardpanels-button-icon-text-gap, 0);
+		}
+	}
+	&.iconBefore {
+		.icon {
+			.padding-start-end(0, @sand-wizardpanels-button-icon-text-gap);
+		}
+	}
+	.applySkins({
+		.client :not(.icon) {
+			color: @sand-button-text-color;
+		}
+	});
+}

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -972,3 +972,4 @@
 // ---------------------------------------
 @sand-wizardpanels-content-margin: 0 0 150px 0;
 @sand-wizardpanels-footer-margin: 0 0 (102px - @sand-app-keepout) 0;
+@sand-wizardpanels-button-icon-text-gap: 18px;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -972,4 +972,4 @@
 // ---------------------------------------
 @sand-wizardpanels-content-margin: 0 0 150px 0;
 @sand-wizardpanels-footer-margin: 0 0 (102px - @sand-app-keepout) 0;
-@sand-wizardpanels-button-icon-text-gap: 18px;
+@sand-wizardpanels-button-icon-text-gap: 54px;

--- a/tests/screenshot/apps/components/WizardPanels.js
+++ b/tests/screenshot/apps/components/WizardPanels.js
@@ -1,6 +1,10 @@
+import Button from '../../../../Button';
 import WizardPanels, {Panel} from '../../../../WizardPanels';
 
 import {LongerLoremString, withConfig} from './utils';
+
+const customPrevButton = (<Button>Previous</Button>);
+const customNextButton = (<Button>Next</Button>);
 
 const WizardPanelTests = withConfig({
 	wrapper: {
@@ -50,6 +54,22 @@ const WizardPanelTests = withConfig({
 			<WizardPanels noSteps>
 				<Panel title="My Title" subtitle={LongerLoremString}>View 1</Panel>
 				<Panel>View 2</Panel>
+			</WizardPanels>
+		)
+	},
+	// Test custom buttons
+	<WizardPanels index={1} title="WizardPanel">
+		<Panel>View 1</Panel>
+		<Panel prevButton={customPrevButton} nextButton={customNextButton}>View 2</Panel>
+		<Panel>View 3</Panel>
+	</WizardPanels>,
+	{
+		locale: 'ar-SA',
+		component: (
+			<WizardPanels index={1} title="WizardPanel">
+				<Panel>View 1</Panel>
+				<Panel prevButton={customPrevButton} nextButton={customNextButton}>View 2</Panel>
+				<Panel>View 3</Panel>
 			</WizardPanels>
 		)
 	},


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
GUI requires to show button labels separated from icon buttons.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Resize focus effects' size and update labels' text color on press to match latest designs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-126939

### Comments
