### PR TITLE
PLAT-126935: Refined overscroll effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/PopupTabLayout` to collapse its tab only when a user enters a menu
 - `sandstone/Scroller` focus rule to match latest UX when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` and `sandstone/VirtualList` to hide the scrollbar after N seconds
+- `sandstone/Scroller` and `sandstone/VirtualList` overscroll style to match latest designs
 
 ### Fixed
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -10,7 +10,7 @@ import utilEvent from '@enact/ui/useScroll/utilEvent';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
-const {animationDuration, epsilon, isPageDown, isPageUp, overscrollDefaultRatio, overscrollTypeOnce, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;
+const {animationDuration, epsilon, isPageDown, isPageUp, overscrollTypeOnce, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;
 let lastPointer = {x: 0, y: 0};
 
 const useEventFocus = (props, instances) => {
@@ -624,13 +624,13 @@ const useEventWheel = (props, instances) => {
 
 					ev.preventDefault();
 				} else if (overscrollEffectRequired) {
-					scrollContainerHandle.current.checkAndApplyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, overscrollDefaultRatio);
+					scrollContainerHandle.current.checkAndApplyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce);
 				}
 
 				ev.stopPropagation();
 			} else {
 				if (overscrollEffectRequired && (negativeDelta && scrollTop <= 0 || positiveDelta && scrollTop >= bounds.maxTop)) {
-					scrollContainerHandle.current.applyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, overscrollDefaultRatio);
+					scrollContainerHandle.current.applyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce);
 				}
 
 				needToHideScrollbarTrack = true;
@@ -648,7 +648,7 @@ const useEventWheel = (props, instances) => {
 				ev.stopPropagation();
 			} else {
 				if (overscrollEffectRequired && (negativeDelta && scrollLeft <= 0 || positiveDelta && scrollLeft >= bounds.maxLeft)) {
-					scrollContainerHandle.current.applyOverscrollEffect('horizontal', positiveDelta ? 'after' : 'before', overscrollTypeOnce, overscrollDefaultRatio);
+					scrollContainerHandle.current.applyOverscrollEffect('horizontal', positiveDelta ? 'after' : 'before', overscrollTypeOnce);
 				}
 
 				needToHideScrollbarTrack = true;

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -10,7 +10,7 @@ import utilEvent from '@enact/ui/useScroll/utilEvent';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
-const {animationDuration, epsilon, isPageDown, isPageUp, overscrollTypeOnce, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;
+const {animationDuration, epsilon, isPageDown, isPageUp, overscrollDefaultRatio, overscrollTypeOnce, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;
 let lastPointer = {x: 0, y: 0};
 
 const useEventFocus = (props, instances) => {
@@ -624,13 +624,13 @@ const useEventWheel = (props, instances) => {
 
 					ev.preventDefault();
 				} else if (overscrollEffectRequired) {
-					scrollContainerHandle.current.checkAndApplyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce);
+					scrollContainerHandle.current.checkAndApplyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, overscrollDefaultRatio);
 				}
 
 				ev.stopPropagation();
 			} else {
 				if (overscrollEffectRequired && (negativeDelta && scrollTop <= 0 || positiveDelta && scrollTop >= bounds.maxTop)) {
-					scrollContainerHandle.current.applyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, 1);
+					scrollContainerHandle.current.applyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, overscrollDefaultRatio);
 				}
 
 				needToHideScrollbarTrack = true;
@@ -648,7 +648,7 @@ const useEventWheel = (props, instances) => {
 				ev.stopPropagation();
 			} else {
 				if (overscrollEffectRequired && (negativeDelta && scrollLeft <= 0 || positiveDelta && scrollLeft >= bounds.maxLeft)) {
-					scrollContainerHandle.current.applyOverscrollEffect('horizontal', positiveDelta ? 'after' : 'before', overscrollTypeOnce, 1);
+					scrollContainerHandle.current.applyOverscrollEffect('horizontal', positiveDelta ? 'after' : 'before', overscrollTypeOnce, overscrollDefaultRatio);
 				}
 
 				needToHideScrollbarTrack = true;

--- a/useScroll/useOverscrollEffect.js
+++ b/useScroll/useOverscrollEffect.js
@@ -4,7 +4,7 @@ import {constants} from '@enact/ui/useScroll';
 import {useCallback, useEffect, useRef} from 'react';
 
 const
-	{overscrollTypeDone, overscrollTypeHold, overscrollTypeNone, overscrollTypeOnce} = constants,
+	{overscrollDefaultRatio, overscrollTypeDone, overscrollTypeHold, overscrollTypeNone, overscrollTypeOnce} = constants,
 	overscrollTransitionPrefix = '--scroll-overscroll-transition-',
 	overscrollTranslatePrefix = '--scroll-overscroll-translate-',
 	overscrollTransitionStart = 'transform 300ms cubic-bezier(0.5, 1, 0.89, 1)',
@@ -90,7 +90,7 @@ const useOverscrollEffect = (props, instances) => {
 				isRtl = scrollContainerHandle.current.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
 
-			scrollContainerHandle.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
+			scrollContainerHandle.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce, overscrollDefaultRatio);
 		}
 	}
 

--- a/useScroll/useOverscrollEffect.js
+++ b/useScroll/useOverscrollEffect.js
@@ -4,7 +4,7 @@ import {constants} from '@enact/ui/useScroll';
 import {useCallback, useEffect, useRef} from 'react';
 
 const
-	{overscrollDefaultRatio, overscrollTypeDone, overscrollTypeHold, overscrollTypeNone, overscrollTypeOnce} = constants,
+	{overscrollTypeDone, overscrollTypeHold, overscrollTypeNone, overscrollTypeOnce} = constants,
 	overscrollTransitionPrefix = '--scroll-overscroll-transition-',
 	overscrollTranslatePrefix = '--scroll-overscroll-translate-',
 	overscrollTransitionStart = 'transform 300ms cubic-bezier(0.5, 1, 0.89, 1)',
@@ -90,7 +90,7 @@ const useOverscrollEffect = (props, instances) => {
 				isRtl = scrollContainerHandle.current.rtl,
 				edge = (direction === 'up' || !isRtl && direction === 'left' || isRtl && direction === 'right') ? 'before' : 'after';
 
-			scrollContainerHandle.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce, overscrollDefaultRatio);
+			scrollContainerHandle.current.checkAndApplyOverscrollEffect(orientation, edge, overscrollTypeOnce);
 		}
 	}
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For better UX, the default overscroll effect factor needs to be refined. From this PR, the default effect factor is 0.5 which is half of the maximum effect (1.0) and the maximum effect factor for flick input is still 1.0 as it shows bigger for the speed of flicking.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change the default effect factor from 1 to 0.5 except for flick input.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-126935

### Comments
