### PR TITLE
PLAT-139778: Scroller: Fix Spotlight moves to wrong target with PageUp/Down key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` button label when default value is `0`
 - `sandstone/Panels.Header` to remeasure marquee metrics when the size of slots changed
 - `sandstone/Scroller` and `sandstone/VirtualList` to activate voice control intent when only scrollable
+- `sandstone/Scroller` and `sandstone/VirtualList` to move focus properly via page key
 - `sandstone/VideoPlayer` to show the knob when mediaSlider gets focused with 5-way
 - horizontal `sandstone/VirtualList` to align items well when navigating with 5-way
 - `sandstone/WizardPanels` to not show focus effect on the wrong element in `footer`

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -196,7 +196,9 @@ const useEventKey = (props, instances, context) => {
 			isUp = direction === 'up',
 			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier;
-		let scrollPossible = false;
+		let
+			computedDirection = direction,
+			scrollPossible = false;
 
 		if (scrollMode === 'translate') {
 			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop > scrollTop;
@@ -226,7 +228,7 @@ const useEventKey = (props, instances, context) => {
 
 					if (bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance) {
 						y = contentRect[isUp ? 'top' : 'bottom'] + yAdjust;
-						direction = isUp ? 'down' : 'up'; // Change direction to find target in the content
+						computedDirection = isUp ? 'down' : 'up'; // Change direction to find target in the content
 					} else {
 						y = clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 					}
@@ -241,10 +243,10 @@ const useEventKey = (props, instances, context) => {
 						themeScrollContentHandle.current.pauseSpotlight(true);
 					}
 
-					spottable.current.pointToFocus = {direction, x, y};
+					spottable.current.pointToFocus = {direction: computedDirection, x, y};
 				}
 			} else {
-				spottable.current.pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
+				spottable.current.pointToFocus = {direction: computedDirection, x: lastPointer.x, y: lastPointer.y};
 			}
 
 			scrollContainerHandle.current.scrollToAccumulatedTarget(pageDistance, true, props.overscrollEffectOn.pageKey);

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -596,11 +596,15 @@ const useEventWheel = (props, instances) => {
 			positiveDelta = eventDelta > 0,
 			negativeDelta = eventDelta < 0,
 			{scrollTop, scrollLeft} = scrollContainerHandle.current;
-		let delta = 0;
+		let
+			delta = 0,
+			needToHideScrollbarTrack = false;
 
 		if (typeof window !== 'undefined') {
 			window.document.activeElement.blur();
 		}
+
+		scrollContainerHandle.current.showScrollbarTrack(bounds);
 
 		// FIXME This routine is a temporary support for horizontal wheel scroll.
 		// FIXME If web engine supports horizontal wheel, this routine should be refined or removed.
@@ -613,6 +617,7 @@ const useEventWheel = (props, instances) => {
 				// If ev.target is a descendant of scrollContent, the event will be handled on scroll event handler.
 				if (!utilDOM.containsDangerously(scrollContentRef.current, ev.target)) {
 					delta = scrollContainerHandle.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientHeight * scrollWheelPageMultiplierForMaxPixel);
+					needToHideScrollbarTrack = !delta;
 
 					ev.preventDefault();
 				} else if (overscrollEffectRequired) {
@@ -620,8 +625,12 @@ const useEventWheel = (props, instances) => {
 				}
 
 				ev.stopPropagation();
-			} else if (overscrollEffectRequired && (negativeDelta && scrollTop <= 0 || positiveDelta && scrollTop >= bounds.maxTop)) {
-				scrollContainerHandle.current.applyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, 1);
+			} else {
+				if (overscrollEffectRequired && (negativeDelta && scrollTop <= 0 || positiveDelta && scrollTop >= bounds.maxTop)) {
+					scrollContainerHandle.current.applyOverscrollEffect('vertical', positiveDelta ? 'after' : 'before', overscrollTypeOnce, 1);
+				}
+
+				needToHideScrollbarTrack = true;
 			}
 		} else if (canScrollHorizontally) { // this routine handles wheel events on any children for horizontal scroll.
 			if (negativeDelta && scrollLeft > 0 || positiveDelta && scrollLeft < bounds.maxLeft) {
@@ -630,11 +639,16 @@ const useEventWheel = (props, instances) => {
 				}
 
 				delta = scrollContainerHandle.current.calculateDistanceByWheel(eventDeltaMode, eventDelta, bounds.clientWidth * scrollWheelPageMultiplierForMaxPixel);
+				needToHideScrollbarTrack = !delta;
 
 				ev.preventDefault();
 				ev.stopPropagation();
-			} else if (overscrollEffectRequired && (negativeDelta && scrollLeft <= 0 || positiveDelta && scrollLeft >= bounds.maxLeft)) {
-				scrollContainerHandle.current.applyOverscrollEffect('horizontal', positiveDelta ? 'after' : 'before', overscrollTypeOnce, 1);
+			} else {
+				if (overscrollEffectRequired && (negativeDelta && scrollLeft <= 0 || positiveDelta && scrollLeft >= bounds.maxLeft)) {
+					scrollContainerHandle.current.applyOverscrollEffect('horizontal', positiveDelta ? 'after' : 'before', overscrollTypeOnce, 1);
+				}
+
+				needToHideScrollbarTrack = true;
 			}
 		}
 
@@ -651,6 +665,10 @@ const useEventWheel = (props, instances) => {
 			}
 
 			scrollContainerHandle.current.scrollToAccumulatedTarget(delta, canScrollVertically, overscrollEffectRequired);
+		}
+
+		if (needToHideScrollbarTrack) {
+			scrollContainerHandle.current.startHidingScrollbarTrack();
 		}
 	}
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -188,17 +188,16 @@ const useEventKey = (props, instances, context) => {
 		}
 	}
 
-	function scrollByPage (direction) {
+	function scrollByPage (pageKeyDirection) {
 		const
 			{scrollTop} = scrollContainerHandle.current,
 			focusedItem = Spotlight.getCurrent(),
 			bounds = scrollContainerHandle.current.getScrollBounds(),
-			isUp = direction === 'up',
+			isUp = pageKeyDirection === 'up',
 			directionFactor = isUp ? -1 : 1,
 			pageDistance = directionFactor * bounds.clientHeight * paginationPageMultiplier;
-		let
-			computedDirection = direction,
-			scrollPossible = false;
+		let direction = pageKeyDirection;
+		let scrollPossible = false;
 
 		if (scrollMode === 'translate') {
 			scrollPossible = isUp ? scrollTop > 0 : bounds.maxTop > scrollTop;
@@ -228,7 +227,7 @@ const useEventKey = (props, instances, context) => {
 
 					if (bounds.maxTop - epsilon < scrollTop + pageDistance || epsilon > scrollTop + pageDistance) {
 						y = contentRect[isUp ? 'top' : 'bottom'] + yAdjust;
-						computedDirection = isUp ? 'down' : 'up'; // Change direction to find target in the content
+						direction = isUp ? 'down' : 'up'; // Change direction to find target in the content
 					} else {
 						y = clamp(contentRect.top, contentRect.bottom, (clientRect.bottom + clientRect.top) / 2);
 					}
@@ -243,10 +242,10 @@ const useEventKey = (props, instances, context) => {
 						themeScrollContentHandle.current.pauseSpotlight(true);
 					}
 
-					spottable.current.pointToFocus = {direction: computedDirection, x, y};
+					spottable.current.pointToFocus = {direction, x, y};
 				}
 			} else {
-				spottable.current.pointToFocus = {direction: computedDirection, x: lastPointer.x, y: lastPointer.y};
+				spottable.current.pointToFocus = {direction, x: lastPointer.x, y: lastPointer.y};
 			}
 
 			scrollContainerHandle.current.scrollToAccumulatedTarget(pageDistance, true, props.overscrollEffectOn.pageKey);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In VirtualList > 'with extra items' qa-sampler Spotlight moves to wrong target with PageDown key. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change direction to find target in the content

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`epsilon` is 1. so the" translated" and "native" code is equivalent.
So I cleaned the if condition.

### Links
PLAT-139778


### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
