### PR TITLE
PLAT-123715: Sampler: Fix global knob setting resets when component changes

### DIFF
--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -133,6 +133,8 @@ const StorybookDecorator = (story, config = {}) => {
 	// Executing `story` here allows the story knobs to register and render before the global knobs below.
 	const sample = story();
 
+	const {globals} = config;
+
 	const Config = {
 		defaultProps: {
 			locale: 'en-US',
@@ -167,18 +169,24 @@ const StorybookDecorator = (story, config = {}) => {
 		classes.debug = true;
 	}
 
+	globals.locale = select('locale', locales, Config, globals.locale);
+	globals.largeText = boolean('large text', Config, getKnobFromArgs(args, 'large text', globals.largeText));
+	globals.highContrast = boolean('high contrast', Config, getKnobFromArgs(args, 'high contrast', globals.highContrast));
+	globals.background = select('background', backgroundLabels, Config, getKnobFromArgs(args, 'background', globals.background));
+	globals.skin = select('skin', skins, Config, getKnobFromArgs(args, 'skin', globals.skin));
+
 	return (
 		<Theme
 			className={classnames(classes)}
 			title={`${config.kind}`.replace(/\//g, ' ').trim()}
 			description={hasInfoText ? config.parameters.info.text : null}
-			locale={select('locale', locales, Config)}
-			textSize={boolean('large text', Config, getKnobFromArgs(args, 'large text')) ? 'large' : 'normal'}
-			highContrast={boolean('high contrast', Config, getKnobFromArgs(args, 'high contrast'))}
+			locale={globals.locale}
+			textSize={globals.largeText ? 'large' : 'normal'}
+			highContrast={globals.highContrast}
 			style={{
-				'--sand-env-background': backgroundLabelMap[select('background', backgroundLabels, Config, getKnobFromArgs(args, 'background'))]
+				'--sand-env-background': backgroundLabelMap[globals.background]
 			}}
-			skin={select('skin', skins, Config, getKnobFromArgs(args, 'skin'))}
+			skin={globals.skin}
 			{...hasProps ? config.parameters.props : null}
 		>
 			{sample}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
The global knob setting stays even if the story changes.


### Resolution
The storybook offers object 'globals' in the decorator and story.
I added properties that need to be worked globally to the object.
(Referred link: https://storybook.js.org/docs/react/essentials/toolbars-and-globals#globals)


### Additional Considerations



### Links
PLAT-123715


### Comments
