### PR TITLE
PLAT-143413: [Screenshot test] Set default input-type class for focus

### DIFF
--- a/tests/screenshot/apps/Sandstone-View.js
+++ b/tests/screenshot/apps/Sandstone-View.js
@@ -2,7 +2,7 @@ import classnames from 'classnames/bind';
 import {objectify} from '@enact/ui/Skinnable/util';
 import {generateDate, urlParamsToObject} from '@enact/ui-test-utils/utils';
 import spotlight from '@enact/spotlight';
-import {Component as ReactComponent, cloneElement} from 'react';
+import {Component as ReactComponent, cloneElement, useEffect} from 'react';
 
 import ThemeDecorator from '../../../ThemeDecorator';
 
@@ -172,6 +172,11 @@ const ExportedApp = (props) => {
 	}
 
 	const WrappedApp = ThemeDecorator({noAutoFocus}, App);
+
+	useEffect(() => {
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		document.querySelector('#root > div').classList.add('spotlight-input-key');
+	}, []);
 
 	return (
 		<WrappedApp {...props} skin={skin} highContrast={highContrast} locale={locale} textSize={textSize} />

--- a/tests/screenshot/apps/components/FormCheckboxItem.js
+++ b/tests/screenshot/apps/components/FormCheckboxItem.js
@@ -16,6 +16,19 @@ const slotBeforeFormCheckboxItemTests = [
 	<FormCheckboxItem disabled indeterminate><Icon slot="slotBefore">home</Icon>FormCheckboxItem</FormCheckboxItem>
 ];
 
+const slotBeforeFocusedFormCheckboxItemTests = [
+	<FormCheckboxItem><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem</FormCheckboxItem>,
+	<FormCheckboxItem disabled><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem</FormCheckboxItem>,
+	<FormCheckboxItem inline><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem</FormCheckboxItem>,
+	<FormCheckboxItem disabled inline><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem</FormCheckboxItem>,
+	<FormCheckboxItem selected><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem Checked</FormCheckboxItem>,
+	<FormCheckboxItem disabled selected><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem Checked</FormCheckboxItem>,
+	<FormCheckboxItem selected inline><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem Checked</FormCheckboxItem>,
+	<FormCheckboxItem disabled selected inline><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem Checked</FormCheckboxItem>,
+	<FormCheckboxItem indeterminate><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem</FormCheckboxItem>,
+	<FormCheckboxItem disabled indeterminate><Icon slot="slotBefore">home</Icon>Focused FormCheckboxItem</FormCheckboxItem>
+];
+
 const FormCheckboxItemTests = [
 	<FormCheckboxItem />,
 	<FormCheckboxItem>FormCheckboxItem</FormCheckboxItem>, 					// not selected
@@ -39,7 +52,7 @@ const FormCheckboxItemTests = [
 
 	// Icon slotBefore
 	...slotBeforeFormCheckboxItemTests,
-	...withConfig({focus: true}, slotBeforeFormCheckboxItemTests),
+	...withConfig({focus: true}, slotBeforeFocusedFormCheckboxItemTests),
 
 	// Centered
 	<FormCheckboxItem centered>Hello FormCheckboxItem</FormCheckboxItem>,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is screenshot test fail on Sansdstone release/2.0.0-beta.1 about focus

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set default input-type class for focus.
Fix wrong  TC on `FormCheckboxItem` (regression from https://github.com/enactjs/sandstone/pull/856)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-143413

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)