### PR TITLE
PLAT-142955: Fix error when `value` prop of `Input` is 0

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -514,14 +514,14 @@ const InputBase = kind({
 		buttonAriaLabel: ({placeholder, type, value}) => {
 			if (value || value === 0) {
 				type = isPasswordType(type) ? 'password' : type;
-				return calcAriaLabel('', type, type === 'number' ? value.split('') : value);
+				return calcAriaLabel('', type, type === 'number' ? value.toString().split('') : value.toString());
 			}
 
 			return calcAriaLabel('', null, placeholder);
 		},
 		buttonLabel: ({placeholder, type, value}) => {
 			if (value || value === 0) {
-				return isPasswordType(type) ? convertToPasswordFormat(value) : value.toString();
+				return isPasswordType(type) ? convertToPasswordFormat(value.toString()) : value.toString();
 			} else {
 				return placeholder;
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The error occurs when `value` prop of `Input` is 0 due to `split` function call for number type value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The logic is to manipulate string value, so `toString` is added to handle it properly.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-142955

### Comments
