### PR TITLE
PLAT-129853: Support number list in Picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/Picker` props `reverse` and `type` to support for number list
+
 ### Changed
 
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -165,12 +165,46 @@ const PickerBase = kind({
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 
 		/**
+		 * When `true`, the picker buttons operate in the reverse direction such that pressing
+		 * up/left decrements the value and down/right increments the value. This is more natural
+		 * for vertical lists of text options where "up" implies a spatial change rather than
+		 * incrementing the value.
+		 *
+		 * If this prop is omitted, it will be determined by the orientation direction.
+		 * For example, if `orientation` is `vertical`, the `reverse` is true.
+		 * Conversely, if the `orientation` is `horizontal`, `reverse` is false.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		reverse: PropTypes.bool,
+
+		/**
 		 * The primary text of the `Picker`.
 		 *
 		 * @type {String}
 		 * @public
 		 */
 		title: PropTypes.string,
+
+		/**
+		 * The type of picker. It determines the aria-label for the next and previous buttons.
+		 *
+		 * Depending on the `type`, `joined`, `decrementAriaLabel`, and `incrementAriaLabel`,
+		 * the screen readers read out differently when Spotlight is on the next button, the previous button,
+		 * or the picker itself.
+		 *
+		 * For example, if Spotlight is on the next button, the `joined` prop is false,
+		 * and aria label props(`decrementAriaLabel` and `incrementAriaLabel`) are not defined,
+		 * then the screen readers read out as follows.
+		 *	`'string'` type: `'next item'`
+		 * 	`'number'` type: `'press ok button to increase the value'`
+		 *
+		 * @type {('number'|'string')}
+		 * @default 'string'
+		 * @public
+		 */
+		type: PropTypes.oneOf(['number', 'string']),
 
 		/**
 		 * Index of the selected child.
@@ -214,12 +248,13 @@ const PickerBase = kind({
 	},
 
 	defaultProps: {
+		type: 'string',
 		value: 0
 	},
 
 	computed: {
 		max: ({children}) => children && children.length ? children.length - 1 : 0,
-		reverse: ({orientation}) => (orientation === 'vertical'),
+		reverse: ({orientation, reverse}) => (typeof reverse === 'boolean' ? reverse : orientation === 'vertical'),
 		children: ({children, disabled, joined, marqueeDisabled}) => Children.map(children, (child) => {
 			const focusOrHover = !disabled && joined ? 'focus' : 'hover';
 			return (

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -170,9 +170,9 @@ const PickerBase = kind({
 		 * for vertical lists of text options where "up" implies a spatial change rather than
 		 * incrementing the value.
 		 *
-		 * If this prop is omitted, it will be determined by the orientation direction.
-		 * For example, if `orientation` is `vertical`, the `reverse` is true.
-		 * Conversely, if the `orientation` is `horizontal`, `reverse` is false.
+		 * If this prop is omitted, it will be determined by `orientation`.
+		 * For example, if `orientation` is `vertical`, `reverse` is `true`.
+		 * Conversely, if `orientation` is `horizontal`, `reverse` is `false`.
 		 *
 		 * @type {Boolean}
 		 * @public

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -258,7 +258,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		static displayName = 'ThemeDecorator';
 
 		componentDidMount () {
-			if (spotlight && platform.webos) {
+			if (spotlight && platform.webos && spotlightInputType.activate) {
 				spotlightInputType.activate(true);
 				spotlightInputType.request = new LS2Request().send({
 					service: 'luna://com.webos.surfacemanager',

--- a/samples/qa-a11y/src/views/Picker.js
+++ b/samples/qa-a11y/src/views/Picker.js
@@ -17,6 +17,7 @@ const
 		'Tokyo Airport Terminal Gate 3',
 		'נמל התעופה בן גוריון טרמינל הבינלאומי'
 	],
+	irreqularNumbers = ['4', '13', '15', '20', '22'],
 	subjects = ['English', 'Maths', 'Korean', 'Science', 'History'],
 	subjectValue = ['80', '90', '100', '70', '50'];
 
@@ -327,6 +328,25 @@ const PickerView = () => (
 			>
 				{subjects}
 			</CustomPicker>
+		</Section>
+
+		<Section className={appCss.marginTop} title="With irregular numbers">
+			<Picker
+				alt="Vertical"
+				orientation="vertical"
+				reverse={false}
+				type="number"
+			>
+				{irreqularNumbers}
+			</Picker>
+			<Picker
+				alt="Horizontal"
+				orientation="horizontal"
+				reverse={false}
+				type="number"
+			>
+				{irreqularNumbers}
+			</Picker>
 		</Section>
 	</>
 );

--- a/samples/qa-a11y/src/views/Picker.js
+++ b/samples/qa-a11y/src/views/Picker.js
@@ -17,7 +17,7 @@ const
 		'Tokyo Airport Terminal Gate 3',
 		'נמל התעופה בן גוריון טרמינל הבינלאומי'
 	],
-	irreqularNumbers = ['4', '13', '15', '20', '22'],
+	irregularNumbers = ['4', '13', '15', '20', '22'],
 	subjects = ['English', 'Maths', 'Korean', 'Science', 'History'],
 	subjectValue = ['80', '90', '100', '70', '50'];
 
@@ -337,7 +337,7 @@ const PickerView = () => (
 				reverse={false}
 				type="number"
 			>
-				{irreqularNumbers}
+				{irregularNumbers}
 			</Picker>
 			<Picker
 				alt="Horizontal"
@@ -345,7 +345,7 @@ const PickerView = () => (
 				reverse={false}
 				type="number"
 			>
-				{irreqularNumbers}
+				{irregularNumbers}
 			</Picker>
 		</Section>
 	</>

--- a/samples/sampler/stories/default/Picker.js
+++ b/samples/sampler/stories/default/Picker.js
@@ -7,6 +7,12 @@ import {decrementIcons, incrementIcons} from '../helper/icons';
 // Set up some defaults for info and knobs
 const prop = {
 	orientation: ['horizontal', 'vertical'],
+	reverse: {
+		' ': null,
+		false: false,
+		true: true
+	},
+	type: ['number', 'string'],
 	width: [null, 'small', 'medium', 'large']
 };
 
@@ -40,7 +46,9 @@ export const _Picker = () => (
 		noAnimation={boolean('noAnimation', Picker)}
 		onChange={action('onChange')}
 		orientation={select('orientation', prop.orientation, Picker, prop.orientation[0])}
+		reverse={select('reverse', prop.reverse, Picker)} //{boolean('reverse', Picker)}
 		title={text('title', Picker)}
+		type={select('type', prop.type, Picker)}
 		width={select('width', prop.width, Picker, prop.width[3])}
 		wrap={boolean('wrap', Picker)}
 	>

--- a/samples/sampler/stories/default/Picker.js
+++ b/samples/sampler/stories/default/Picker.js
@@ -9,7 +9,7 @@ const prop = {
 	orientation: ['horizontal', 'vertical'],
 	reverse: {
 		' ': null,
-		false: false,
+		false: 'false',
 		true: true
 	},
 	type: ['number', 'string'],
@@ -46,7 +46,7 @@ export const _Picker = () => (
 		noAnimation={boolean('noAnimation', Picker)}
 		onChange={action('onChange')}
 		orientation={select('orientation', prop.orientation, Picker, prop.orientation[0])}
-		reverse={select('reverse', prop.reverse, Picker)} //{boolean('reverse', Picker)}
+		reverse={select('reverse', prop.reverse, Picker) === 'false' ? false : select('reverse', prop.reverse, Picker)}
 		title={text('title', Picker)}
 		type={select('type', prop.type, Picker)}
 		width={select('width', prop.width, Picker, prop.width[3])}

--- a/samples/sampler/stories/default/Picker.js
+++ b/samples/sampler/stories/default/Picker.js
@@ -9,7 +9,7 @@ const prop = {
 	orientation: ['horizontal', 'vertical'],
 	reverse: {
 		' ': null,
-		false: 'false',
+		false: false,
 		true: true
 	},
 	type: ['number', 'string'],
@@ -46,7 +46,7 @@ export const _Picker = () => (
 		noAnimation={boolean('noAnimation', Picker)}
 		onChange={action('onChange')}
 		orientation={select('orientation', prop.orientation, Picker, prop.orientation[0])}
-		reverse={select('reverse', prop.reverse, Picker) === 'false' ? false : select('reverse', prop.reverse, Picker)}
+		reverse={prop.reverse[select('reverse', [' ', 'false', 'true'], Picker)]}
 		title={text('title', Picker)}
 		type={select('type', prop.type, Picker)}
 		width={select('width', prop.width, Picker, prop.width[3])}

--- a/samples/sampler/stories/qa/Picker.js
+++ b/samples/sampler/stories/qa/Picker.js
@@ -40,6 +40,7 @@ const pickerList = {
 		'Spinach contains manganese'
 	],
 	numberList: ['0', '1', '2', '3', '4'],
+	irreqularNumberList: ['4', '13', '15', '20', '22'],
 	oneAirport: ['San Francisco International Airport Terminal 1'],
 	emptyList: [],
 	orderedList: ['A', 'B', 'C', 'D', 'E', 'F'],
@@ -363,6 +364,20 @@ export const KitchenSink = () => (
 		</Row>
 	</Scroller>
 );
+
+
+export const ForIrregularNumbers = () => (
+	<Picker
+		reverse={boolean('reverse', Picker)}
+		type={select('type', ['',], Picker)}
+		joined={boolean('joined', Picker)}
+		orientation={select('orientation', prop.orientation, Picker)}
+	>
+		{pickerList.irreqularNumberList}
+	</Picker>
+);
+
+ForIrregularNumbers.storyName = 'for irregular numbers';
 
 export const InPopupTabLayout = () => <PickerInPopupTabLayout />;
 

--- a/samples/sampler/stories/qa/Picker.js
+++ b/samples/sampler/stories/qa/Picker.js
@@ -40,7 +40,7 @@ const pickerList = {
 		'Spinach contains manganese'
 	],
 	numberList: ['0', '1', '2', '3', '4'],
-	irreqularNumberList: ['4', '13', '15', '20', '22'],
+	irregularNumberList: ['4', '13', '15', '20', '22'],
 	oneAirport: ['San Francisco International Airport Terminal 1'],
 	emptyList: [],
 	orderedList: ['A', 'B', 'C', 'D', 'E', 'F'],
@@ -373,7 +373,7 @@ export const ForIrregularNumbers = () => (
 		reverse={false}
 		type="number"
 	>
-		{pickerList.irreqularNumberList}
+		{pickerList.irregularNumberList}
 	</Picker>
 );
 

--- a/samples/sampler/stories/qa/Picker.js
+++ b/samples/sampler/stories/qa/Picker.js
@@ -368,10 +368,10 @@ export const KitchenSink = () => (
 
 export const ForIrregularNumbers = () => (
 	<Picker
-		reverse={boolean('reverse', Picker)}
-		type={select('type', ['',], Picker)}
 		joined={boolean('joined', Picker)}
 		orientation={select('orientation', prop.orientation, Picker)}
+		reverse={false}
+		type="number"
 	>
 		{pickerList.irreqularNumberList}
 	</Picker>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We need to use Picker for irregular number list.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To support picker with number list properly (increase button position, accessibility) , we added  `reverse` and `type` props

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I added a minor guard code on ThemeDecorator for side loading on webOS

### Links
[//]: # (Related issues, references)
PLAT-129853


### Comments
