### PR TITLE
Add default value for Input component's `text` prop

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -453,7 +453,8 @@ const InputBase = kind({
 	},
 
 	defaultProps: {
-		placeholder: '-'
+		placeholder: '-',
+		type: 'text'
 	},
 
 	handlers: {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unit test fails due to missing default prop value

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add default value for Input component's `text` prop

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
