### PR TITLE
PLAT-140745: Refine logic to handle the last input type

### DIFF
--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -26,6 +26,8 @@ import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {createContext, Fragment} from 'react';
 
+import {getLastInputType} from '../ThemeDecorator';
+
 import RefocusDecorator, {getNavigableFilter, getTabsSpotlightId} from './RefocusDecorator';
 import TabGroup from './TabGroup';
 import Tab from './Tab';
@@ -38,8 +40,7 @@ const TabLayoutContext = createContext(null);
 const TouchableCell = Touchable(Cell);
 
 const isTouchMode = () => {
-	const rootContainer = document.querySelector('#root > div');
-	return rootContainer && rootContainer.classList.contains('spotlight-input-touch');
+	return getLastInputType() === 'touch';
 };
 
 /**

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {createContext, Fragment} from 'react';
 
-import {getLastInputType} from '../ThemeDecorator';
+import {getInputType as getLastInputType} from '../ThemeDecorator';
 
 import RefocusDecorator, {getNavigableFilter, getTabsSpotlightId} from './RefocusDecorator';
 import TabGroup from './TabGroup';
@@ -39,9 +39,7 @@ const TabLayoutContext = createContext(null);
 
 const TouchableCell = Touchable(Cell);
 
-const isTouchMode = () => {
-	return getLastInputType() === 'touch';
-};
+const isTouchMode = () => (getLastInputType() === 'touch');
 
 /**
  * Tabbed Layout component.

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {createContext, Fragment} from 'react';
 
-import {getInputType as getLastInputType} from '../ThemeDecorator';
+import {getLastInputType} from '../ThemeDecorator';
 
 import RefocusDecorator, {getNavigableFilter, getTabsSpotlightId} from './RefocusDecorator';
 import TabGroup from './TabGroup';

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -14,7 +14,7 @@ import {Component} from 'react';
 import classNames from 'classnames';
 import {ResolutionDecorator} from '@enact/ui/resolution';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
-import SpotlightRootDecorator, {activateInputType, getInputType, setInputType} from '@enact/spotlight/SpotlightRootDecorator';
+import SpotlightRootDecorator, {activateInputType, getInputType as getLastInputType, setInputType} from '@enact/spotlight/SpotlightRootDecorator';
 import LS2Request from '@enact/webos/LS2Request';
 
 import Skinnable from '../Skinnable';
@@ -177,7 +177,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		[css.bg]: !overlay
 	});
 
-	const spotlightInputType = {request: null};
+	let requestInputType = null;
 
 	let App = Wrapped;
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
@@ -248,7 +248,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		componentDidMount () {
 			if (spotlight && platform.webos) {
 				activateInputType(true);
-				spotlightInputType.request = new LS2Request().send({
+				requestInputType = new LS2Request().send({
 					service: 'luna://com.webos.surfacemanager',
 					method: 'getLastInputType',
 					subscribe: true,
@@ -263,8 +263,8 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
-			if (spotlightInputType.request) {
-				spotlightInputType.request.cancel();
+			if (requestInputType) {
+				requestInputType.cancel();
 			}
 		}
 
@@ -284,4 +284,4 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 });
 
 export default ThemeDecorator;
-export {ThemeDecorator, getInputType};
+export {ThemeDecorator, getLastInputType};

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -284,4 +284,4 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 });
 
 export default ThemeDecorator;
-export {ThemeDecorator, getInputType as getLastInputType};
+export {ThemeDecorator, getInputType};

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -14,7 +14,7 @@ import {Component} from 'react';
 import classNames from 'classnames';
 import {ResolutionDecorator} from '@enact/ui/resolution';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
-import SpotlightRootDecorator from '@enact/spotlight/SpotlightRootDecorator';
+import SpotlightRootDecorator, {activateInputType, getInputType, setInputType} from '@enact/spotlight/SpotlightRootDecorator';
 import LS2Request from '@enact/webos/LS2Request';
 
 import Skinnable from '../Skinnable';
@@ -177,7 +177,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		[css.bg]: !overlay
 	});
 
-	let spotlightInputType = {};
+	const spotlightInputType = {request: null};
 
 	let App = Wrapped;
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
@@ -200,19 +200,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			)
 		);
 	}
-	if (spotlight) {
-		App = SpotlightRootDecorator({
-			getInputTypeSetter: (setInputType, activateInputType) => {
-				spotlightInputType = {
-					set: setInputType,
-					activate: activateInputType,
-					request: null
-				};
-			},
-			noAutoFocus,
-			rootId // set the DOM node ID of the React DOM tree root
-		}, App);
-	}
+	if (spotlight) App = SpotlightRootDecorator({noAutoFocus}, App);
 	if (skin) App = Skinnable({defaultSkin: 'neutral'}, App);
 	if (accessible) App = AccessibilityDecorator(App);
 
@@ -259,16 +247,16 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		componentDidMount () {
 			if (spotlight && platform.webos) {
-				spotlightInputType.activate(true);
+				activateInputType(true);
 				spotlightInputType.request = new LS2Request().send({
 					service: 'luna://com.webos.surfacemanager',
 					method: 'getLastInputType',
 					subscribe: true,
 					onSuccess: function (res) {
-						spotlightInputType.set(res.lastInputType);
+						setInputType(res.lastInputType);
 					},
 					onFailure: function () {
-						spotlightInputType.activate(false);
+						activateInputType(false);
 					}
 				});
 			}
@@ -296,4 +284,4 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 });
 
 export default ThemeDecorator;
-export {ThemeDecorator};
+export {ThemeDecorator, getInputType as getLastInputType};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The current API to handle the last input type imported by callback prop for `SpotlightRootDecorator` and it will be better to be imported in a normal way.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated to import key APIs from the module, not through callback function prop.
Also, updated TabLayout to use the API without querying a specific node to get the type info.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-140745

### Comments
