### PR TITLE
Removed unintended class names from `InputField`

### DIFF
--- a/Input/InputField.js
+++ b/Input/InputField.js
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import {handle, adaptEvent, forwardCustom, forwardWithPrevent, returnsTrue} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import platform from '@enact/core/platform';
@@ -8,6 +7,7 @@ import {useAnnounce} from '@enact/ui/AnnounceDecorator';
 import Changeable from '@enact/ui/Changeable';
 import Pure from '@enact/ui/internal/Pure';
 import {readAlert} from '@enact/webos/speech';
+import classnames from 'classnames';
 import compose from 'ramda/src/compose';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/Input/InputField.js
+++ b/Input/InputField.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import {handle, adaptEvent, forwardCustom, forwardWithPrevent, returnsTrue} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import platform from '@enact/core/platform';
@@ -277,7 +278,6 @@ const InputFieldBase = kind({
 		},
 		className: ({invalid, size, styler}) => styler.append({invalid}, size),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
-		inputClassName: ({styler, type}) => styler.append('input', {passwordtel: (type === 'passwordtel')}),
 		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.')}) => {
 			if (invalid && invalidMessage) {
 				return (
@@ -291,9 +291,10 @@ const InputFieldBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({css, dir, disabled, iconAfter, iconBefore, inputClassName, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {
+	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {
 		const inputProps = extractInputProps(rest);
 		const voiceProps = extractVoiceProps(rest);
+		const isPasswordtel = type === 'passwordtel';
 		delete rest.announce;
 		delete rest.dismissOnEnter;
 		delete rest.invalid;
@@ -313,14 +314,14 @@ const InputFieldBase = kind({
 				<input
 					{...inputProps}
 					{...voiceProps}
-					aria-hidden={type === 'passwordtel'}
-					className={inputClassName}
+					aria-hidden={isPasswordtel}
+					className={classnames(css.input, {[css.passwordtel]: isPasswordtel})}
 					dir={dir}
 					disabled={disabled}
 					onChange={onChange}
 					placeholder={placeholder}
 					tabIndex={-1}
-					type={type === 'passwordtel' ? 'tel' : type}
+					type={isPasswordtel ? 'tel' : type}
 					value={value}
 				/>
 				<InputFieldDecoratorIcon position="after" size={size}>{iconAfter}</InputFieldDecoratorIcon>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unintended paddings inside `InputField` are added accidentally after #907.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed unintended class names.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
