### PR TITLE
PLAT-125057: Fix Spotlight exits out of FixedPopupPanels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/MediaPlayer` to show `MediaControls` via wheel properly when isomorphic build
 - `sandstone/PopupTabLayout` to move focus via 5-way left in the header
 
-
 ## [2.0.0-beta.1] - 2021-05-21
 
 - Enhanced touch support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,11 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/FixedPopupPanels` to keep focus inside of popup when pressing 5-way after click
 - `sandstone/InputField` cursor not to jump unexpectedly when mouse down
 - `sandstone/MediaPlayer` to show `MediaControls` via wheel properly when isomorphic build
 - `sandstone/PopupTabLayout` to move focus via 5-way left in the header
 
-### Fixed
-
-- `sandstone/FixedPopupPanels` to keep focus inside of popup when pressing 5-way after click
 
 ## [2.0.0-beta.1] - 2021-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs
 
+### Fixed
+
+- `sandstone/FixedPopupPanels` to keep focus inside of popup with 5-way
+
 ## [2.0.0-beta.1] - 2021-05-21
 
 - Enhanced touch support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/FixedPopupPanels` to keep focus inside of popup with 5-way
+- `sandstone/FixedPopupPanels` to keep focus inside of popup when pressing 5-way after click
 
 ## [2.0.0-beta.1] - 2021-05-21
 

--- a/internal/Panels/useAutoFocus.js
+++ b/internal/Panels/useAutoFocus.js
@@ -42,7 +42,7 @@ function useAutoFocus ({autoFocus = 'last-focused', hideChildren}) {
 			// within the panel using a (currently) private Spotlight API with the enterTo parameter
 			// to influence which configuration is used to find said target.
 			const enterTo = isSelector(autoFocus) || autoFocus === 'default-element' ? 'default-element' : 'last-focused';
-			Spotlight.focus(spotlightId, enterTo);
+			Spotlight.focus(spotlightId, {enterTo});
 		}
 	}, [autoFocus, hideChildren, ref]);
 }

--- a/internal/Panels/useAutoFocus.js
+++ b/internal/Panels/useAutoFocus.js
@@ -2,7 +2,6 @@ import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import useChainRefs from '@enact/core/useChainRefs';
 import Spotlight from '@enact/spotlight';
-import {getTargetByContainer} from '@enact/spotlight/src/target';
 import PropTypes from 'prop-types';
 import {useRef, useCallback} from 'react';
 
@@ -43,11 +42,7 @@ function useAutoFocus ({autoFocus = 'last-focused', hideChildren}) {
 			// within the panel using a (currently) private Spotlight API with the enterTo parameter
 			// to influence which configuration is used to find said target.
 			const enterTo = isSelector(autoFocus) || autoFocus === 'default-element' ? 'default-element' : 'last-focused';
-			const target = getTargetByContainer(spotlightId, enterTo);
-
-			if (target) {
-				Spotlight.focus(target);
-			}
+			Spotlight.focus(spotlightId, enterTo);
 		}
 	}, [autoFocus, hideChildren, ref]);
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Spotlight exits out of FixedPopupPanels when pressing 5-way after click

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Delegate the sequence of finding the target to the spotlight.
- Cause 
It is regression from https://github.com/enactjs/sandstone/pull/667
in the problem cases, the placeholder get focus and be disappeared.
If user press the arrow key afterwards, there is no last focus container information, because the focus was given by
`Spotlight.focus(element)` not `Spotlight.focus(container)`;
To save the last container information, focus target should be found by `Spotlight.focus(container)`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-125057

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)