### PR TITLE
PLAT-143843: Fix PopupTabLayout to move focus via 5-way left in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs
 - `sandstone/Slider` to interact by wheel
 
+### Fixed
+
+- `sandstone/PopupTabLayout` to move focus via 5-way left in the header
+
 ## [2.0.0-beta.1] - 2021-05-21
 
 - Enhanced touch support

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -365,19 +365,19 @@ const tabPanelsHandlers = {
 		forward('onKeyDown'),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
-		(ev) => {
-			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
-				ev.stopPropagation();
-				return false;
-			}
-			return true;
-		},
 		({target}) => {
 			const next = getTargetByDirectionFromElement('left', target);
 			if (next === null || (next && !getContainerNode(getContainersForNode(target).pop()).contains(next))) {
 				return true;
 			}
 			return false;
+		},
+		(ev) => {
+			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
+				ev.stopPropagation();
+				return false;
+			}
+			return true;
 		},
 		forward('onBack'),
 		stop

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -208,7 +208,7 @@ export const WithVariousItems = () => {
 							</Cell>
 						</TabPanel>
 						<TabPanel>
-							<Header title="Color Adjust" type="compact" />
+							<Header title="Color Adjust" type="compact" slotAfter={<Button iconOnly icon="help" />} />
 							<Cell>
 								<span>This is the second panel.</span>
 								<Button size="small" disabled>Button1</Button>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When spottable in the PopupTabLayout panels's header, the focus is not moving by 5-way left.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Re-order the handler's condition to fix the issue.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-143843

### Comments
