### PR TITLE
PLAT-127486: Fix Popup to have proper focus when opening with `noAnimation` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Popup` to have proper focus when opening with `noAnimation` is `true`
 - `sandstone/InputField` cursor not to jump unexpectedly when mouse down
+- `sandstone/Popup` to have proper focus when opening with `noAnimation` is `true`
 - `sandstone/PopupTabLayout` to move focus via 5-way left in the header
 
 ## [2.0.0-beta.1] - 2021-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Popup` to have proper focus when opening with `noAnimation` is `true`
 - `sandstone/InputField` cursor not to jump unexpectedly when mouse down
 - `sandstone/PopupTabLayout` to move focus via 5-way left in the header
 

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -435,6 +435,11 @@ class Popup extends Component {
 					prevOpen: props.open
 				};
 			} else {
+				// Disables the spotlight conatiner of popup when `noAnimation` set
+				if (props.noAnimation) {
+					getContainerNode(state.containerId).dataset['spotlightContainerDisabled'] = true;
+				}
+
 				return {
 					popupOpen: OpenState.CLOSED,
 					floatLayerOpen: state.popupOpen === OpenState.OPEN ? !props.noAnimation : false,

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -314,7 +314,7 @@ export const WithVariousItems = () => {
 							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
 							<br />
 							<br />
-							<Button size="small">Button2</Button>
+							<Button size="small" onClick={handleClose}>Button2</Button>
 							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
 							<br />
 							<br />


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The original issue happened in FixedPopupPanels. When FixedPopupPanels opened with `noAnimation` prop is `true`, the last focused element got focused instead of the first element which is the result of `noAnimation` prop is `false`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The difference between the two cases came from `data-spotlight-container-disabled` attribute.
When `noAnimation` prop is `false`, Popup pauses spotlight and so the container of the popup turns to be disabled. But when it's `true`, there is no such step since the node will be destroyed after all.
Spotlight stores the last focus information before the node got destroyed so the last focused element stored since the container is not disabled.
I made the container disabled when `noAnimation` prop is `true` in `getDerivedStateFromProps` phase.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The container node will be destroyed anyway and re-create when it's open again so I don't think it has side-effects.

### Links
[//]: # (Related issues, references)
PLAT-127486

### Comments
