### PR TITLE
PLAT-132844: Support touch for opening action guide

### DIFF
--- a/ActionGuide/ActionGuide.js
+++ b/ActionGuide/ActionGuide.js
@@ -12,6 +12,7 @@
 
 import kind from '@enact/core/kind';
 import Pure from '@enact/ui/internal/Pure';
+import Touchable from '@enact/ui/Touchable';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 
@@ -20,6 +21,8 @@ import {Marquee} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './ActionGuide.module.less';
+
+const TouchableDiv = Touchable('div');
 
 /**
  * An Action Guide component.
@@ -79,10 +82,10 @@ const ActionGuideBase = kind({
 
 	render: ({icon, children, css, ...rest}) => {
 		return (
-			<div {...rest}>
+			<TouchableDiv {...rest}>
 				<Icon size="small" className={css.icon}>{icon}</Icon>
 				<Marquee className={css.label} marqueeOn="render" alignment="center">{children}</Marquee>
-			</div>
+			</TouchableDiv>
 		);
 	}
 });

--- a/ActionGuide/ActionGuide.module.less
+++ b/ActionGuide/ActionGuide.module.less
@@ -6,8 +6,7 @@
 
 .actionGuide {
 	text-align: center;
-	max-width: @sand-actionguide-max-width;
-	margin: 0 auto;
+	width: 100%;
 	line-height: 0;
 
 	.label {
@@ -16,7 +15,9 @@
 		});
 		font-size: @sand-actionguide-label-font-size;
 		height: @sand-actionguide-label-height;
+		max-width: @sand-actionguide-label-max-width;
 		line-height: @sand-actionguide-label-height;
+		margin: 0 auto;
 	}
 
 	.icon {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Changed
 
+- `sandstone/MediaPlayer.MediaControls` to show more components when a user flicks on action guide
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs
 - `sandstone/Slider` to interact by wheel
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -306,6 +306,7 @@ const MediaControlsBase = kind({
 		mediaDisabled,
 		moreComponentsSpotlightId,
 		noJumpButtons,
+		onFlickFromActionGuide,
 		onJumpBackwardButtonClick,
 		onJumpForwardButtonClick,
 		onKeyDownFromMediaButtons,
@@ -332,7 +333,7 @@ const MediaControlsBase = kind({
 					{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 				</Container>
 				{actionGuideShowing ?
-					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} css={css} className={actionGuideClassName} icon="arrowsmalldown">{actionGuideLabel}</ActionGuide> :
+					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} css={css} className={actionGuideClassName} icon="arrowsmalldown" onFlick={onFlickFromActionGuide}>{actionGuideLabel}</ActionGuide> :
 					null
 				}
 				{moreComponentsRendered ?
@@ -643,10 +644,18 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			this.bottomComponentsHeight = bottomElement ? bottomElement.scrollHeight : 0;
 		};
 
+		ableToShowMoreComponents = () => (!this.props.moreActionDisabled && !this.state.showMoreComponents);
+
 		handleKeyDownFromMediaButtons = (ev) => {
-			if (is('down', ev.keyCode) && !this.state.showMoreComponents && !this.props.moreActionDisabled) {
+			if (is('down', ev.keyCode) && this.ableToShowMoreComponents()) {
 				this.showMoreComponents();
 				ev.stopPropagation();
+			}
+		};
+
+		handleFlickFromActionGuide = ({direction, velocityY}) => {
+			if (direction === 'vertical' && velocityY < 0 && this.ableToShowMoreComponents()) {
+				this.showMoreComponents();
 			}
 		};
 
@@ -707,7 +716,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 		};
 
 		handleWheel = (ev) => {
-			if (!this.state.showMoreComponents && this.props.visible && !this.props.moreActionDisabled && ev.deltaY > 0) {
+			if (this.ableToShowMoreComponents() && this.props.visible && ev.deltaY > 0) {
 				this.showMoreComponents();
 			}
 		};
@@ -818,6 +827,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 					{...props}
 					moreComponentsRendered={this.state.moreComponentsRendered}
 					onClose={this.handleClose}
+					onFlickFromActionGuide={this.handleFlickFromActionGuide}
 					onKeyDownFromMediaButtons={this.handleKeyDownFromMediaButtons}
 					onPlayButtonClick={this.handlePlayButtonClick}
 					onTransitionEnd={this.handleTransitionEnd}

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -164,6 +164,14 @@ const MediaControlsBase = kind({
 		onClose: PropTypes.func,
 
 		/**
+		 * Called when the user flicks on the action guide.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onFlickFromActionGuide: PropTypes.func,
+
+		/**
 		 * Called when the user clicks the JumpBackward button
 		 *
 		 * @type {Function}

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -298,7 +298,7 @@
 
 // ActionGuide
 // ---------------------------------------
-@sand-actionguide-max-width: 1500px;
+@sand-actionguide-label-max-width: 1500px;
 @sand-actionguide-label-height: 60px;
 @sand-actionguide-icon-margin: -24px 0 -18px 0;
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In a touch-only environment, there is no way to open the action guide to show more components.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Support flicking input for opening the action guide

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The mandatory requirement is to support touch-based flicking. Pointer(mouse)-based flicking is not a mandatory requirement as it looks hard for users to perform but it is a nice-to-have feature.

### Links
[//]: # (Related issues, references)
PLAT-132844

### Comments
