### PR TITLE
PLAT-142531: MediaPlayer: cannot show media controls with wheel event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/InputField` cursor not to jump unexpectedly when mouse down
+- `sandstone/MediaPlayer` to show `MediaControls` via wheel properly when isomorphic build
 - `sandstone/PopupTabLayout` to move focus via 5-way left in the header
-- `sandstone/MediaPlayer` to show `MediaControls` via wheel
-
 
 ## [2.0.0-beta.1] - 2021-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/InputField` cursor not to jump unexpectedly when mouse down
 - `sandstone/PopupTabLayout` to move focus via 5-way left in the header
+- `sandstone/MediaPlayer` to show `MediaControls` via wheel
+
 
 ## [2.0.0-beta.1] - 2021-05-21
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -564,7 +564,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			on('keydown', this.handleKeyDown);
 			on('keyup', this.handleKeyUp);
 			on('blur', this.handleBlur, window);
-			on('wheel', this.handleWheel);
+			on('wheel', this.handleWheel, document);
 		}
 
 		componentDidUpdate (prevProps, prevState) {
@@ -619,7 +619,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {	// eslint-disable-line
 			off('keydown', this.handleKeyDown);
 			off('keyup', this.handleKeyUp);
 			off('blur', this.handleBlur, window);
-			off('wheel', this.handleWheel);
+			off('wheel', this.handleWheel, document);
 			this.stopListeningForPulses();
 			this.moreComponentsRenderingJob.stop();
 			if (this.animation) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After applying React 17, the React synthetic event root was changed from document to React DOM tree "root".

-Enact/Sandstone changed the dispatcher's on/off to add the event handler to the root of the React DOM tree rather than the document accordingly.
- In the case of MediaControls' wheel event, the event target must be explicitly designated as document to operate normally. There is no problem when side-loads after doing `enact serve` or `enact pack`, but target designation is required on `isomorphic+snapshot` builds.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It added `document` to `on('wheel')` function in `MediaControls`.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-142531

### Comments
