### PR TITLE
PLAT-142878: Disable left and right keys navigation in FixedPopupPanels and PopupTabLayout when locale is RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Picker` props `reverse` and `type` to support for number list
 
 ### Changed
-
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to disable left key handler to go to the previous panel in RTL locales
 - `sandstone/MediaPlayer.MediaControls` to show more components when a user flicks on action guide
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs
 - `sandstone/Slider` to interact by wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Picker` props `reverse` and `type` to support for number list
 
 ### Changed
+
 - `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to disable left key handler to go to the previous panel in RTL locales
 - `sandstone/MediaPlayer.MediaControls` to show more components when a user flicks on action guide
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -27,7 +27,6 @@ import css from './FixedPopupPanels.module.less';
  *
  * @class FixedPopupPanelsDecorator
  * @memberof sandstone/FixedPopupPanels
- * @mixes i18n/I18nDecorator.I18nContextDecorator
  * @hoc
  * @public
  */

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -3,6 +3,8 @@
  *
  * @module sandstone/FixedPopupPanels
  * @exports FixedPopupPanels
+ * @exports FixedPopupPanelsBase
+ * @exports FixedPopupPanelsDecorator
  * @exports Panel
  * @exports Header
  */
@@ -20,6 +22,15 @@ import DefaultHeader from '../Panels/Header';
 
 import css from './FixedPopupPanels.module.less';
 
+/**
+ * Adds popup functionality and `rtl` prop to [`FixedPopupPanels`]{@link sandstone/FixedPopupPanels}.
+ *
+ * @class FixedPopupPanelsDecorator
+ * @memberof sandstone/FixedPopupPanels
+ * @mixes i18n/I18nDecorator.I18nContextDecorator
+ * @hoc
+ * @public
+ */
 const FixedPopupPanelsDecorator = compose(
 	I18nContextDecorator({rtlProp: 'rtl'}),
 	PopupDecorator({
@@ -44,6 +55,15 @@ const fixedPopupPanelsHandlers = {
 	)
 };
 
+/**
+ * A base panels component for [`FixedPopupPanels`]{@link sandstone/FixedPopupPanels} that has
+ * left key handler to navigate panels.
+ *
+ * @class FixedPopupPanelsBase
+ * @memberof sandstone/FixedPopupPanels
+ * @ui
+ * @public
+ */
 const FixedPopupPanelsBase = (props) => {
 	const handlers = useHandlers(fixedPopupPanelsHandlers, props);
 	return <Viewport {...props} {...handlers} />;
@@ -56,7 +76,8 @@ const FixedPopupPanelsBase = (props) => {
  *
  * @class FixedPopupPanels
  * @memberof sandstone/FixedPopupPanels
- * @mixes i18n/I18nDecorator.I18nContextDecorator
+ * @extends sandstone/FixedPopupPanels.FixedPopupPanelsBase
+ * @mixes sandstone/FixedPopupPanels.FixedPopupPanelsDecorator
  * @ui
  * @public
  */
@@ -119,6 +140,8 @@ FixedPopupPanels.Header = Header;
 export default FixedPopupPanels;
 export {
 	FixedPopupPanels,
+	FixedPopupPanelsBase,
+	FixedPopupPanelsDecorator,
 	Header,
 	Panel
 };

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -7,7 +7,7 @@
  * @exports Header
  */
 
-import {forKey, forward, handle, stop} from '@enact/core/handle';
+import {forKey, forProp, forward, handle, stop} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
@@ -21,6 +21,7 @@ import DefaultHeader from '../Panels/Header';
 import css from './FixedPopupPanels.module.less';
 
 const FixedPopupPanelsDecorator = compose(
+	I18nContextDecorator({rtlProp: 'rtl'}),
 	PopupDecorator({
 		className: 'fixedPopupPanels',
 		css,
@@ -30,11 +31,10 @@ const FixedPopupPanelsDecorator = compose(
 	})
 );
 
-const FixedPopupPanelsBase = FixedPopupPanelsDecorator(Viewport);
-
 const fixedPopupPanelsHandlers = {
 	onKeyDown: handle(
 		forward('onKeyDown'),
+		forProp('rtl', false),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
 		({target}) => (getContainerNode(getContainersForNode(target).pop()).tagName !== 'HEADER'),
@@ -44,6 +44,11 @@ const fixedPopupPanelsHandlers = {
 	)
 };
 
+const FixedPopupPanelsBase = (props) => {
+	const handlers = useHandlers(fixedPopupPanelsHandlers, props);
+	return <Viewport {...props} {...handlers} />;
+};
+
 /**
  * An instance of [`Panels`]{@link sandstone/Panels.Panels} which restricts the `Panel` to the right
  * or left side of the screen inside a popup. Typically used for overlaying panels over other
@@ -51,16 +56,11 @@ const fixedPopupPanelsHandlers = {
  *
  * @class FixedPopupPanels
  * @memberof sandstone/FixedPopupPanels
+ * @mixes i18n/I18nDecorator.I18nContextDecorator
  * @ui
  * @public
  */
-const FixedPopupPanels = I18nContextDecorator(
-	{rtlProp: 'rtl'},
-	(props) => {
-		const handlers = props.rtl ? null : useHandlers(fixedPopupPanelsHandlers, props);
-		return <FixedPopupPanelsBase {...props} {...handlers} />;
-	}
-);
+const FixedPopupPanels = FixedPopupPanelsDecorator(FixedPopupPanelsBase);
 
 /**
  * Size of the popup.

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -9,6 +9,7 @@
 
 import {forKey, forward, handle, stop} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import compose from 'ramda/src/compose';
@@ -53,11 +54,13 @@ const fixedPopupPanelsHandlers = {
  * @ui
  * @public
  */
-const FixedPopupPanels = (props) => {
-	const handlers = useHandlers(fixedPopupPanelsHandlers, props);
-
-	return <FixedPopupPanelsBase {...props} {...handlers} />;
-};
+const FixedPopupPanels = I18nContextDecorator(
+	{rtlProp: 'rtl'},
+	(props) => {
+		const handlers = props.rtl ? null : useHandlers(fixedPopupPanelsHandlers, props);
+		return <FixedPopupPanelsBase {...props} {...handlers} />;
+	}
+);
 
 /**
  * Size of the popup.

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -385,14 +385,6 @@ const tabPanelsHandlers = {
 	)
 };
 
-/**
- * A customized version of Panels for use inside this component.
- *
- * @class
- * @memberof sandstone/PopupTabLayout
- * @extends sandstone/Panels.Panels
- * @ui
- */
 const TabPanelsBase = (props) => {
 	const {rtl, ...rest} = props;
 	const tabPanelsHandlersRef = Object.assign({}, tabPanelsHandlers);
@@ -408,6 +400,14 @@ TabPanelsBase.propTypes = {
 	rtl: PropTypes.bool
 };
 
+/**
+ * A customized version of Panels for use inside this component.
+ *
+ * @class
+ * @memberof sandstone/PopupTabLayout
+ * @extends sandstone/Panels.Panels
+ * @ui
+ */
 const TabPanels = I18nContextDecorator(
 	{rtlProp: 'rtl'},
 	TabPanelsBase

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -12,6 +12,7 @@ import {forKey, forward, handle, stop} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Spotlight from '@enact/spotlight';
 import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
@@ -392,12 +393,25 @@ const tabPanelsHandlers = {
  * @extends sandstone/Panels.Panels
  * @ui
  */
-const TabPanels = (props) => {
+const TabPanelsBase = (props) => {
+	const {rtl, ...rest} = props;
+	const tabPanelsHandlersRef = Object.assign({}, tabPanelsHandlers);
 	const onTransition = useContext(TabLayoutContext);
-	const handlers = useHandlers(tabPanelsHandlers, props, {onTransition});
-
-	return <Panels noCloseButton {...props} css={css} {...handlers} />;
+	if (rtl) {
+		delete tabPanelsHandlersRef.onKeyDown;
+	}
+	const handlers = useHandlers(tabPanelsHandlersRef, rest, {onTransition});
+	return <Panels noCloseButton {...rest} css={css} {...handlers} />;
 };
+
+TabPanelsBase.propTypes = {
+	rtl: PropTypes.bool
+};
+
+const TabPanels = I18nContextDecorator(
+	{rtlProp: 'rtl'},
+	TabPanelsBase
+);
 
 /**
  * Omits the close button.

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -411,7 +411,6 @@ const TabPanelsBase = (props) => {
  * @class TabPanels
  * @memberof sandstone/PopupTabLayout
  * @extends sandstone/PopupTabLayout.TabPanelsBase
- * @mixes i18n/I18nDecorator.I18nContextDecorator
  * @ui
  * @public
  */

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -5,6 +5,7 @@
  * @exports PopupTabLayout
  * @exports Tab
  * @exports TabPanels
+ * @exports TabPanelsBase
  * @exports TabPanel
  */
 
@@ -290,9 +291,10 @@ const PopupTabLayoutBase = kind({
 /**
  * Add behaviors to PopupTabLayout.
  *
- * @hoc
+ * @class PopupTabLayoutDecorator
  * @memberof sandstone/PopupTabLayout
  * @mixes sandstone/Skinnable.Skinnable
+ * @hoc
  * @public
  */
 const PopupTabLayoutDecorator = compose(
@@ -387,7 +389,8 @@ const tabPanelsHandlers = {
 };
 
 /**
- * A customized version of Panels for use inside this component.
+ * A base component for [`TabPanels`]{@link sandstone/PopupTabLayout.TabPanels} which has
+ * left key handler to navigate panels.
  *
  * @class TabPanelsBase
  * @memberof sandstone/PopupTabLayout
@@ -398,17 +401,19 @@ const tabPanelsHandlers = {
 const TabPanelsBase = (props) => {
 	const onTransition = useContext(TabLayoutContext);
 	const handlers = useHandlers(tabPanelsHandlers, props, {onTransition});
+
 	return <Panels noCloseButton {...props} css={css} {...handlers} />;
 };
 
 /**
- * A customized version of Panels for use inside this component, I18nDecorator applied.
+ * A customized version of Panels for use inside this component.
  *
- * @class
+ * @class TabPanels
  * @memberof sandstone/PopupTabLayout
  * @extends sandstone/PopupTabLayout.TabPanelsBase
  * @mixes i18n/I18nDecorator.I18nContextDecorator
  * @ui
+ * @public
  */
 const TabPanels = I18nContextDecorator(
 	{rtlProp: 'rtl'},
@@ -435,10 +440,11 @@ const TabPanels = I18nContextDecorator(
 /**
  * A customized version of Panel for use inside this component.
  *
- * @class
+ * @class TabPanel
  * @memberof sandstone/PopupTabLayout
  * @extends sandstone/Panels.Panel
  * @ui
+ * @public
  */
 const TabPanel = ({spotlightId, ...rest}) => {
 	useEffect(() => {

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -8,7 +8,7 @@
  * @exports TabPanel
  */
 
-import {forKey, forward, handle, stop} from '@enact/core/handle';
+import {forKey, forProp, forward, handle, stop} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
@@ -364,6 +364,7 @@ const tabPanelsHandlers = {
 	),
 	onKeyDown: handle(
 		forward('onKeyDown'),
+		forProp('rtl', false),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
 		({target}) => {
@@ -385,27 +386,28 @@ const tabPanelsHandlers = {
 	)
 };
 
-const TabPanelsBase = (props) => {
-	const {rtl, ...rest} = props;
-	const tabPanelsHandlersRef = Object.assign({}, tabPanelsHandlers);
-	const onTransition = useContext(TabLayoutContext);
-	if (rtl) {
-		delete tabPanelsHandlersRef.onKeyDown;
-	}
-	const handlers = useHandlers(tabPanelsHandlersRef, rest, {onTransition});
-	return <Panels noCloseButton {...rest} css={css} {...handlers} />;
-};
-
-TabPanelsBase.propTypes = {
-	rtl: PropTypes.bool
-};
-
 /**
  * A customized version of Panels for use inside this component.
  *
- * @class
+ * @class TabPanelsBase
  * @memberof sandstone/PopupTabLayout
  * @extends sandstone/Panels.Panels
+ * @ui
+ * @public
+ */
+const TabPanelsBase = (props) => {
+	const onTransition = useContext(TabLayoutContext);
+	const handlers = useHandlers(tabPanelsHandlers, props, {onTransition});
+	return <Panels noCloseButton {...props} css={css} {...handlers} />;
+};
+
+/**
+ * A customized version of Panels for use inside this component, I18nDecorator applied.
+ *
+ * @class
+ * @memberof sandstone/PopupTabLayout
+ * @extends sandstone/PopupTabLayout.TabPanelsBase
+ * @mixes i18n/I18nDecorator.I18nContextDecorator
  * @ui
  */
 const TabPanels = I18nContextDecorator(
@@ -466,5 +468,6 @@ export {
 	PopupTabLayoutDecorator,
 	Tab,
 	TabPanels,
+	TabPanelsBase,
 	TabPanel
 };

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 
 import {is} from '@enact/core/keymap';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select} from '@enact/storybook-utils/addons/knobs';
@@ -12,6 +13,7 @@ import {Header} from '@enact/sandstone/Panels';
 import Scroller from '@enact/sandstone/Scroller';
 import TabLayout, {TabLayoutBase} from '@enact/sandstone/TabLayout';
 import Group from '@enact/ui/Group';
+import PropTypes from 'prop-types';
 import {useState} from 'react';
 import compose from 'ramda/src/compose';
 
@@ -39,7 +41,7 @@ export default {
 	component: 'PopupTabLayout'
 };
 
-export const _PopupTabLayout = () => {
+const PopupTabLayoutSamplesBase = ({rtl}) => {
 	const includeIcons = boolean('include icons', Config, true);
 
 	const [open, setOpenState] = useState(false);
@@ -64,7 +66,7 @@ export const _PopupTabLayout = () => {
 	const handleKeyDown = (setState, state) => (ev) => {
 		const {keyCode} = ev;
 
-		if (isRight(keyCode)) {
+		if (!rtl && isRight(keyCode)) {
 			navNext(setState, state, 'onNext')();
 		}
 	};
@@ -194,6 +196,16 @@ export const _PopupTabLayout = () => {
 		</div>
 	);
 };
+
+PopupTabLayoutSamplesBase.propTypes = {
+	rtl: PropTypes.bool
+};
+
+const PopupTabLayoutSamples = I18nContextDecorator(
+	{rtlProp: 'rtl'},
+	PopupTabLayoutSamplesBase
+);
+export const _PopupTabLayout = () => <PopupTabLayoutSamples />;
 
 _PopupTabLayout.storyName = 'PopupTabLayout';
 _PopupTabLayout.parameters = {

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 
 import {is} from '@enact/core/keymap';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select} from '@enact/storybook-utils/addons/knobs';
@@ -17,6 +18,7 @@ import Spotlight from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import {Column, Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
+import PropTypes from 'prop-types';
 import {Component, useState} from 'react';
 import compose from 'ramda/src/compose';
 
@@ -78,7 +80,7 @@ export default {
 	component: 'FixedPopupPanels'
 };
 
-export const WithVirtualList = () => {
+const WithVirtualListSamplesBase = ({rtl}) => {
 	const defaultOpen = true;
 	const [open, setOpenState] = useState(defaultOpen);
 	const toggleOpen = () => setOpenState(!open);
@@ -95,7 +97,7 @@ export const WithVirtualList = () => {
 	const handleKeyDown = (ev) => {
 		const {keyCode} = ev;
 
-		if (isRight(keyCode)) {
+		if (!rtl && isRight(keyCode)) {
 			nextPanel();
 		}
 	};
@@ -198,6 +200,16 @@ export const WithVirtualList = () => {
 	);
 };
 
+WithVirtualListSamplesBase.propTypes = {
+	rtl: PropTypes.bool
+};
+
+const WithVirtualListSamples = I18nContextDecorator(
+	{rtlProp: 'rtl'},
+	WithVirtualListSamplesBase
+);
+export const WithVirtualList = () => <WithVirtualListSamples />;
+
 WithVirtualList.storyName = 'with VirtualList';
 WithVirtualList.parameters = {
 	info: {
@@ -258,7 +270,7 @@ WithScroller.parameters = {
 	}
 };
 
-export const WithVariousItems = () => {
+const WithVariousItemsSamplesBase = ({rtl}) => {
 	const defaultOpen = true;
 	const [open, setOpenState] = useState(defaultOpen);
 	const toggleOpen = () => setOpenState(!open);
@@ -274,8 +286,7 @@ export const WithVariousItems = () => {
 	// Navigate menus with the right key. The left key is handled by framework.
 	const handleKeyDown = (ev) => {
 		const {keyCode} = ev;
-
-		if (isRight(keyCode) && ev.target && !ev.target.hasAttribute('disabled')) {
+		if (!rtl && isRight(keyCode) && ev.target && !ev.target.hasAttribute('disabled')) {
 			nextPanel();
 		}
 	};
@@ -397,6 +408,16 @@ export const WithVariousItems = () => {
 		</div>
 	);
 };
+
+WithVariousItemsSamplesBase.propTypes = {
+	rtl: PropTypes.bool
+};
+
+const WithVariousItemsSamples = I18nContextDecorator(
+	{rtlProp: 'rtl'},
+	WithVariousItemsSamplesBase
+);
+export const WithVariousItems = () => <WithVariousItemsSamples />;
 
 WithVariousItems.storyName = 'with various items';
 WithVariousItems.parameters = {

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 
 import {is} from '@enact/core/keymap';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Dropdown from '@enact/sandstone/Dropdown';
@@ -15,6 +16,7 @@ import Slider from '@enact/sandstone/Slider';
 import SwitchItem from '@enact/sandstone/SwitchItem';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {Cell} from '@enact/ui/Layout';
+import PropTypes from 'prop-types';
 import {useState} from 'react';
 import compose from 'ramda/src/compose';
 
@@ -154,7 +156,7 @@ export const WithoutIcon = () => {
 
 WithoutIcon.storyName = 'without icon';
 
-export const WithVariousItems = () => {
+const WithVariousItemsSamplesBase = ({rtl}) => {
 	const defaultOpen = true;
 	const [open, setOpenState] = useState(defaultOpen);
 	const toggleOpen = () => setOpenState(!open);
@@ -172,7 +174,7 @@ export const WithVariousItems = () => {
 	const handleKeyDown = (setState, state) => (ev) => {
 		const {keyCode} = ev;
 
-		if (isRight(keyCode) && ev.target && !ev.target.hasAttribute('disabled')) {
+		if (!rtl && isRight(keyCode) && ev.target && !ev.target.hasAttribute('disabled')) {
 			navNext(setState, state, 'onNext')();
 		}
 	};
@@ -244,6 +246,16 @@ export const WithVariousItems = () => {
 		</div>
 	);
 };
+
+WithVariousItemsSamplesBase.propTypes = {
+	rtl: PropTypes.bool
+};
+
+const WithVariousItemsSamples = I18nContextDecorator(
+	{rtlProp: 'rtl'},
+	WithVariousItemsSamplesBase
+);
+export const WithVariousItems = () => <WithVariousItemsSamples />;
 
 WithVariousItems.storyName = 'with various items';
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Disable left key handler to go to previous panel in `FixedPopupPanels` and `PopupTabLayout` in RTL locales

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use `I18nContextDecorator` to get `rtl` props in `FixedPopupPanels` and `PopupTabLayout` and disable left key handler 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-142878

### Comments
