### PR TITLE
PLAT-140537: Add spotlightId in InputField to support VKB reopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Picker` and `sandstone/RangePicker` public class names `title` and `inlineTitle`
 - `sandstone/Scroller` and `sandstone/VirtualList` prop `hoverToScroll` to scroll by hover
 - `sandstone/VirtualList` prop `snapToCenter`
-- `sandstone/Input` spotlightId in `InputField` to support VKB reopen
+- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` in `InputField`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` in `InputField`
+- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` of `InputField`
 - `sandstone/Picker` props `reverse` and `type` to support for number list
 - `sandstone/Picker` and `sandstone/RangePicker` public class names `title` and `inlineTitle`
 - `sandstone/Scroller` and `sandstone/VirtualList` prop `hoverToScroll` to scroll by hover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Picker` and `sandstone/RangePicker` public class names `title` and `inlineTitle`
 - `sandstone/Scroller` and `sandstone/VirtualList` prop `hoverToScroll` to scroll by hover
 - `sandstone/VirtualList` prop `snapToCenter`
+- `sandstone/Input` spotlightId in `InputField` to support VKB reopen
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` in `InputField`
 - `sandstone/Picker` props `reverse` and `type` to support for number list
 - `sandstone/Picker` and `sandstone/RangePicker` public class names `title` and `inlineTitle`
 - `sandstone/Scroller` and `sandstone/VirtualList` prop `hoverToScroll` to scroll by hover
 - `sandstone/VirtualList` prop `snapToCenter`
-- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` in `InputField`
 
 ### Changed
 

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -425,6 +425,7 @@ const InputPopupBase = kind({
 								placeholder={placeholder}
 								onBeforeChange={onBeforeChange}
 								onKeyDown={onInputKeyDown}
+								spotlightId='inputField'
 							/>
 						}
 					</Cell>

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -74,7 +74,7 @@ const InputPopupBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
-		 * Set spotlightId in InputField
+		 * Set spotlightId to InputField.
 		 *
 		 * @type {String}
 		 * @public

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -74,7 +74,7 @@ const InputPopupBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
-		 * Set spotlightId to InputField.
+		 * Sets spotlightId to InputField.
 		 *
 		 * @type {String}
 		 * @public

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -74,6 +74,14 @@ const InputPopupBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
+		 * Set spotlightId in InputField
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		inputFieldSpotlightId: PropTypes.string,
+
+		/**
 		 * Indicates [value]{@link sandstone/Input.InputPopupBase.value} is invalid and shows
 		 * [invalidMessage]{@link sandstone/Input.InputPopupBase.invalidMessage}, if set.
 		 *
@@ -334,6 +342,7 @@ const InputPopupBase = kind({
 		backButtonAriaLabel,
 		children,
 		css,
+		inputFieldSpotlightId,
 		noBackButton,
 		numberInputField,
 		onBeforeChange,
@@ -425,7 +434,7 @@ const InputPopupBase = kind({
 								placeholder={placeholder}
 								onBeforeChange={onBeforeChange}
 								onKeyDown={onInputKeyDown}
-								spotlightId='inputField'
+								spotlightId={inputFieldSpotlightId}
 							/>
 						}
 					</Cell>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
InputField has to re-focused by app when "show password" checkbox is clicked in Input component

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add spotlightId to InputField

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-140537

### Comments
N/A