### PR TITLE
ENYO-6332: Fix direction prop bleed in ContextualPopupDecorator

### DIFF
--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -710,6 +710,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				holeBounds = this.clientNode.getBoundingClientRect();
 			}
 
+			delete rest.direction;
 			delete rest.onOpen;
 			delete rest.popupSpotlightId;
 			delete rest.rtl;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix  `direction` prop bleed in `ContextualPopupDecorator`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Delete `direction` prop before passing it down as props to component

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
ENYO-6332

### Comments
