### PR TITLE
PLAT-145596: Hide submit button in Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` of `InputField`
+- `sandstone/Input` prop `noSubmitButton` to omit submit button of number key pad
+
 ### Fixed
 
 - `sandstone/Picker` value to not marquee when changing `title`
@@ -13,7 +18,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Input` prop `inputFieldSpotlightId` to set `spotlightId` of `InputField`
 - `sandstone/Picker` props `reverse` and `type` to support for number list
 - `sandstone/Picker` and `sandstone/RangePicker` public class names `title` and `inlineTitle`
 - `sandstone/Scroller` and `sandstone/VirtualList` prop `hoverToScroll` to scroll by hover

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -150,6 +150,14 @@ const InputPopupBase = kind({
 		noBackButton: PropTypes.bool,
 
 		/**
+		 * Omits the submit button.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		noSubmitButton: PropTypes.bool,
+
+		/**
 		 * The type of numeric input to use.
 		 *
 		 * The default is to display separated digits when `length` is less than `7`. If `field` is
@@ -344,6 +352,7 @@ const InputPopupBase = kind({
 		css,
 		inputFieldSpotlightId,
 		noBackButton,
+		noSubmitButton,
 		numberInputField,
 		onBeforeChange,
 		onClose,
@@ -419,6 +428,7 @@ const InputPopupBase = kind({
 								showKeypad
 								type={(type === 'passwordnumber') ? 'password' : 'number'}
 								numberInputField={numberInputField}
+								noSubmitButton={noSubmitButton}
 							/> :
 							<InputField
 								{...inputProps}

--- a/Input/NumberField.js
+++ b/Input/NumberField.js
@@ -176,6 +176,7 @@ const NumberFieldBase = kind({
 		delete rest.invalid;
 		delete rest.invalidMessage;
 		delete rest.minLength;
+		delete rest.noSubmitButton;
 		delete rest.onBeforeChange;
 		delete rest.onComplete;
 		delete rest.onSubmit;

--- a/Input/NumberField.js
+++ b/Input/NumberField.js
@@ -31,7 +31,6 @@ const NumberCell = kind({
 		active: PropTypes.bool,
 		children: PropTypes.string,
 		disabled: PropTypes.bool,
-		noSubmitButton: PropTypes.bool,
 		password: PropTypes.bool,
 		passwordIcon: PropTypes.string
 	},
@@ -75,6 +74,7 @@ const NumberFieldBase = kind({
 		invalidMessage: PropTypes.string,
 		maxLength: PropTypes.number,
 		minLength: PropTypes.number,
+		noSubmitButton: PropTypes.bool,
 		numberInputField: PropTypes.string,
 		onBeforeChange: PropTypes.func,
 		onComplete: PropTypes.func,

--- a/Input/NumberField.js
+++ b/Input/NumberField.js
@@ -31,6 +31,7 @@ const NumberCell = kind({
 		active: PropTypes.bool,
 		children: PropTypes.string,
 		disabled: PropTypes.bool,
+		noSubmitButton: PropTypes.bool,
 		password: PropTypes.bool,
 		passwordIcon: PropTypes.string
 	},
@@ -152,10 +153,10 @@ const NumberFieldBase = kind({
 				);
 			}
 		},
-		submitButton: ({css, disabled, invalid, maxLength, minLength, onSubmit, value, numberInputField}) => {
+		submitButton: ({css, disabled, invalid, maxLength, minLength, noSubmitButton, onSubmit, value, numberInputField}) => {
 			const isDisabled = disabled || invalid || (normalizeValue(value, maxLength).toString().length < minLength);
 
-			if (minLength !== maxLength || !getSeparated(numberInputField, maxLength)) {
+			if (!noSubmitButton && (minLength !== maxLength || !getSeparated(numberInputField, maxLength))) {
 				return <Button className={css.submitButton} disabled={isDisabled} onClick={onSubmit}>{$L('Submit')}</Button>;
 			} else {
 				return null;

--- a/Input/tests/Input-specs.js
+++ b/Input/tests/Input-specs.js
@@ -446,4 +446,17 @@ describe('Input specs', () => {
 		const actual = spy.mock.calls.length;
 		expect(actual).toBe(expected);
 	});
+
+	test('should not include a submit button when noSubmitButton is used', () => {
+		const subject = mount(
+			<FloatingLayerController>
+				<Input type="number" length={4} open numberInputField="joined" noSubmitButton />
+			</FloatingLayerController>
+		);
+
+		const expected = 0;
+		const actual = subject.find('.submitButton').first().length;
+
+		expect(actual).toBe(expected);
+	});
 });

--- a/samples/sampler/stories/default/Input.js
+++ b/samples/sampler/stories/default/Input.js
@@ -42,6 +42,7 @@ export const _Input = () => {
 		'aria-label': text('aria-label', ConfigPopup, ''),
 		popupAriaLabel: text('popupAriaLabel', ConfigPopup, ''),
 		noBackButton: boolean('noBackButton', ConfigPopup),
+		noSubmitButton: boolean('noSubmitButton', ConfigPopup),
 		backButtonAriaLabel: select('backButtonAriaLabel', prop.backButtonAriaLabel, ConfigPopup)
 	};
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When number field used as 'joined', submit button show by default.
But some case, app don't want show submit button and use custom button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add prop for hide submit button

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
PLAT-145596

### Comments
N/A