### PR TITLE
PLAT-145554: Fix to focus elements at scroll boundaries by hover when `hoverToScroll` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Picker` value to not marquee when changing `title`
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
+- `sandstone/Scroller` and `sandstone/VirtualList` to focus elements on scroll edges when `hoverToScroll` is `true`
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Picker` value to not marquee when changing `title`
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
-- `sandstone/Scroller` and `sandstone/VirtualList` to focus elements on scroll edges when `hoverToScroll` is `true`
+- `sandstone/Scroller` and `sandstone/VirtualList` to focus elements at scroll boundaries when `hoverToScroll` is `true`
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -52,7 +52,7 @@ const HoverToScrollBase = (props) => {
 	const {
 		direction,
 		scrollContainerHandle: {current: scrollContainer},
-		scrollObserver: {addObserverOnScroll = nop, removeObserverOnScroll = nop} = {}
+		scrollObserver: {addObserverOnScroll, removeObserverOnScroll}
 	} = props;
 
 	// Mutable value

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -52,7 +52,7 @@ const HoverToScrollBase = (props) => {
 	const {
 		direction,
 		scrollContainerHandle: {current = null} = {},
-		scrollWatcher: {addWatcherOnScroll = nop, removeWatcherOnScroll = nop} = {}
+		scrollObserver: {addObserverOnScroll = nop, removeObserverOnScroll = nop} = {}
 	} = props;
 
 	// Mutable value
@@ -172,11 +172,11 @@ const HoverToScrollBase = (props) => {
 	// Hooks
 
 	useLayoutEffect(() => {
-		addWatcherOnScroll(activate);
+		addObserverOnScroll(activate);
 		return () => {
-			removeWatcherOnScroll(activate);
+			removeObserverOnScroll(activate);
 		};
-	}, [activate, addWatcherOnScroll, removeWatcherOnScroll]);
+	}, [activate, addObserverOnScroll, removeObserverOnScroll]);
 
 	useLayoutEffect(() => {
 		const scrollContainer = mutableRef.current.scrollContainer;

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -146,14 +146,11 @@ const HoverToScrollBase = (props) => {
 		const {[canScrollFunc]: canScroll, getScrollBounds, [scrollPosition]: currentPosition} = scrollContainer;
 		const bounds = getScrollBounds();
 		const position = mutableRef.current.hoveredPosition;
-		let curAfter, curBefore;
+		let curAfter = false, curBefore = false;
 
 		if (canScroll(bounds)) {
 			curAfter = currentPosition < bounds[maxPosition] - epsilon;
 			curBefore = currentPosition > 0;
-		} else {
-			curAfter = false;
-			curBefore = false;
 		}
 
 		if (after !== curAfter && position === 'after' || before !== curBefore && position === 'before') {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -408,7 +408,7 @@ const useScroll = (props) => {
 		isHorizontalScrollbarVisible,
 		isVerticalScrollbarVisible,
 		scrollContentWrapper,
-		scrollWatcher
+		scrollObserver
 	} = useScrollBase({
 		...rest,
 		...scrollProps,
@@ -486,7 +486,7 @@ const useScroll = (props) => {
 
 	assignProperties('hoverToScrollProps', {
 		scrollContainerHandle,
-		scrollWatcher
+		scrollObserver
 	});
 
 	return {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -405,9 +405,10 @@ const useScroll = (props) => {
 	}
 
 	const {
-		scrollContentWrapper,
 		isHorizontalScrollbarVisible,
-		isVerticalScrollbarVisible
+		isVerticalScrollbarVisible,
+		scrollContentWrapper,
+		scrollWatcher
 	} = useScrollBase({
 		...rest,
 		...scrollProps,
@@ -484,7 +485,8 @@ const useScroll = (props) => {
 	});
 
 	assignProperties('hoverToScrollProps', {
-		scrollContainerHandle
+		scrollContainerHandle,
+		scrollWatcher
 	});
 
 	return {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Elements on scroll edges don't get focus by hover when `hoverToScroll` is `true`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The cause of this bug is that a DOM node to catch hovering blocks mouse events on elements.
This PR shows and hides the DOM node along with scroll status.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-145554
enactjs/enact/pull/2930

### Comments
