### PR TITLE
PLAT-145128: Fix VirtualList snapToCenter issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Picker` value to not marquee when changing `title`
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
 - `sandstone/Scroller` and `sandstone/VirtualList` to focus elements at scroll boundaries when `hoverToScroll` is `true`
+- `sandstone/VirtualList` to scroll properly when `snapToCenter`
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -6,8 +6,6 @@ import utilEvent from '@enact/ui/useScroll/utilEvent';
 import clamp from 'ramda/src/clamp';
 import {useCallback, useEffect, useLayoutEffect, useRef} from 'react';
 
-import ImageItemCss from '../ImageItem/ImageItem.module.less';
-
 const
 	isDown = is('down'),
 	isEnter = is('enter'),

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -238,8 +238,9 @@ const useEventKey = (props, instances, context) => {
 	};
 };
 
-const useEventFocus = (props, instances) => {
+const useEventFocus = (props, instances, context) => {
 	const {scrollContainerRef, scrollContentHandle} = instances;
+	const {removeScaleEffect} = context;
 
 	useLayoutEffect(() => {
 		function handleFocus (ev) {
@@ -248,10 +249,7 @@ const useEventFocus = (props, instances) => {
 			// We need to find out the general solution for multiple spottable inside of one item
 			if (ev.target && scrollContentHandle.current && scrollContentHandle.current.isItemSized) {
 				ev.target.parentNode.style.setProperty('z-index', 1);
-				if (scrollContentHandle.current.scaledTarget) {
-					scrollContentHandle.current.scaledTarget.classList.remove(ImageItemCss.scaled);
-					scrollContentHandle.current.scaledTarget = null;
-				}
+				removeScaleEffect();
 			}
 		}
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -370,7 +370,6 @@ const useThemeVirtualList = (props) => {
 
 	props.setThemeScrollContentHandle(handle);
 
-
 	function getAffordance () {
 		// To add space for the last item margin bottom
 		return props.noAffordance ? 0 : ri.scale(30);

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -238,7 +238,6 @@ const useSpottable = (props, instances) => {
 			} else {
 				returnVal = focusOnNode(itemNode);
 			}
-
 			mutableRef.current.isScrolledBy5way = false;
 			mutableRef.current.isScrolledByJump = false;
 			if (!waiting) {

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -235,6 +235,7 @@ const useSpottable = (props, instances) => {
 			} else {
 				returnVal = focusOnNode(itemNode);
 			}
+
 			mutableRef.current.isScrolledBy5way = false;
 			mutableRef.current.isScrolledByJump = false;
 			if (!waiting) {
@@ -302,6 +303,10 @@ const useSpottable = (props, instances) => {
 		mutableRef.current.lastFocusedIndex = node.dataset && getNumberValue(node.dataset.index);
 	}
 
+	function resetSnapToCenterStatus() {
+		mutableRef.current.isScrollingBySnapToCenter = false;
+	}
+
 	function getScrollBounds () {
 		return scrollContentHandle.current.getScrollBounds();
 	}
@@ -316,6 +321,7 @@ const useSpottable = (props, instances) => {
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		pauseSpotlight,
+		resetSnapToCenterStatus,
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventOverscrollEffect,
@@ -339,6 +345,7 @@ const useThemeVirtualList = (props) => {
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		pauseSpotlight,
+		resetSnapToCenterStatus,
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventOverscrollEffect,
@@ -354,6 +361,7 @@ const useThemeVirtualList = (props) => {
 		focusOnNode,
 		getScrollBounds,
 		pauseSpotlight,
+		resetSnapToCenterStatus,
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventOverscrollEffect,

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -303,7 +303,7 @@ const useSpottable = (props, instances) => {
 		mutableRef.current.lastFocusedIndex = node.dataset && getNumberValue(node.dataset.index);
 	}
 
-	function resetSnapToCenterStatus() {
+	function resetSnapToCenterStatus () {
 		mutableRef.current.isScrollingBySnapToCenter = false;
 	}
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -13,6 +13,8 @@ import {useEventKey, useEventFocus} from './useEvent';
 import usePreventScroll from './usePreventScroll';
 import {useSpotlightConfig, useSpotlightRestore} from './useSpotlight';
 
+import ImageItemCss from '../ImageItem/ImageItem.module.less';
+
 const SpotlightAccelerator = new Accelerator();
 const SpotlightPlaceholder = Spottable('div');
 
@@ -41,7 +43,8 @@ const useSpottable = (props, instances) => {
 		isScrollingBySnapToCenter: false,
 		isWrappedBy5way: false,
 		lastFocusedIndex: null,
-		pause: new Pause('VirtualListBasic')
+		pause: new Pause('VirtualListBasic'),
+		scaledTarget: null
 	});
 
 	const {pause} = mutableRef.current;
@@ -84,7 +87,7 @@ const useSpottable = (props, instances) => {
 		}
 	});
 
-	useEventFocus(props, instances);
+	useEventFocus(props, instances, {removeScaleEffect: removeScaleEffect.bind(this)});
 
 	const {
 		handlePlaceholderFocus,
@@ -307,6 +310,17 @@ const useSpottable = (props, instances) => {
 		mutableRef.current.isScrollingBySnapToCenter = false;
 	}
 
+	function addScaleEffect (elem) {
+		elem.classList.add(ImageItemCss.scaled);
+		mutableRef.current.scaledTarget = elem;
+	}
+
+	function removeScaleEffect () {
+		if (mutableRef.current.scaledTarget) {
+			mutableRef.current.scaledTarget.classList.remove(ImageItemCss.scaled);
+		}
+	}
+
 	function getScrollBounds () {
 		return scrollContentHandle.current.getScrollBounds();
 	}
@@ -314,6 +328,7 @@ const useSpottable = (props, instances) => {
 	// Return
 
 	return {
+		addScaleEffect,
 		calculatePositionOnFocus,
 		focusByIndex,
 		focusOnNode,
@@ -321,6 +336,7 @@ const useSpottable = (props, instances) => {
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		pauseSpotlight,
+		removeScaleEffect,
 		resetSnapToCenterStatus,
 		setContainerDisabled,
 		setLastFocusedNode,
@@ -338,6 +354,7 @@ const useThemeVirtualList = (props) => {
 	const instance = {itemRefs, scrollContainerRef, scrollContentHandle, scrollContentRef};
 
 	const {
+		addScaleEffect,
 		calculatePositionOnFocus,
 		focusByIndex,
 		focusOnNode,
@@ -345,6 +362,7 @@ const useThemeVirtualList = (props) => {
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		pauseSpotlight,
+		removeScaleEffect,
 		resetSnapToCenterStatus,
 		setContainerDisabled,
 		setLastFocusedNode,
@@ -356,11 +374,13 @@ const useThemeVirtualList = (props) => {
 	usePreventScroll(props, instance);
 
 	const handle = {
+		addScaleEffect,
 		calculatePositionOnFocus,
 		focusByIndex,
 		focusOnNode,
 		getScrollBounds,
 		pauseSpotlight,
+		removeScaleEffect,
 		resetSnapToCenterStatus,
 		setContainerDisabled,
 		setLastFocusedNode,

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -113,9 +113,6 @@ const useEventFocus = (props, instances) => {
 				spottable.current.animateOnFocus = false;
 			}
 		}
-		if (themeScrollContentHandle.current.resetSnapToCenterStatus) {
-			themeScrollContentHandle.current.resetSnapToCenterStatus();
-		}
 
 		if (!(shouldPreventScrollByFocus || Spotlight.getPointerMode() || scrollContainerHandle.current.isDragging || spottable.current.indexToFocus)) {
 			const
@@ -690,6 +687,10 @@ const useEventWheel = (props, instances) => {
 							// Save the target to reset the style
 							scrollContentHandle.current.scaledTarget = target;
 						}
+					}
+
+					if (themeScrollContentHandle.current.resetSnapToCenterStatus) {
+						themeScrollContentHandle.current.resetSnapToCenterStatus();
 					}
 
 					scrollContainerHandle.current.scrollTo({

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -113,6 +113,9 @@ const useEventFocus = (props, instances) => {
 				spottable.current.animateOnFocus = false;
 			}
 		}
+		if (themeScrollContentHandle.current.resetSnapToCenterStatus) {
+			themeScrollContentHandle.current.resetSnapToCenterStatus();
+		}
 
 		if (!(shouldPreventScrollByFocus || Spotlight.getPointerMode() || scrollContainerHandle.current.isDragging || spottable.current.indexToFocus)) {
 			const

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -49,7 +49,7 @@ const useEventFocus = (props, instances) => {
 					scrollContainerHandle.current.start({
 						targetX: left,
 						targetY: top,
-						animate: spottable.current.animateOnFocus || snapToCenter,
+						animate: snapToCenter ? snapToCenter : spottable.current.animateOnFocus,
 						overscrollEffect: props.overscrollEffectOn[scrollContainerHandle.current.lastInputType] &&
 							(!themeScrollContentHandle.current.shouldPreventOverscrollEffect || !themeScrollContentHandle.current.shouldPreventOverscrollEffect())
 					});

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -10,8 +10,6 @@ import utilEvent from '@enact/ui/useScroll/utilEvent';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
-import ImageItemCss from '../ImageItem/ImageItem.module.less';
-
 const {animationDuration, epsilon, isPageDown, isPageUp, overscrollTypeOnce, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;
 let lastPointer = {x: 0, y: 0};
 
@@ -675,18 +673,12 @@ const useEventWheel = (props, instances) => {
 
 				if (nextIndex > 0 && nextIndex < dataSize - 1) {
 					if (typeof document === 'object') {
-						const currentTarget = document.querySelector(`[data-index="${currentIndex}"] div`);
 						const target = document.querySelector(`[data-index="${nextIndex}"] div`);
 
-						if (currentTarget) {
-							currentTarget.classList.remove(ImageItemCss.scaled);
-						}
-						if (target) {
-							target.classList.add(ImageItemCss.scaled);
-
-							// Save the target to reset the style
-							scrollContentHandle.current.scaledTarget = target;
-						}
+						// remove effect
+						themeScrollContentHandle.current.removeScaleEffect();
+						// add effect
+						themeScrollContentHandle.current.addScaleEffect(target);
 					}
 
 					if (themeScrollContentHandle.current.resetSnapToCenterStatus) {

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -16,7 +16,7 @@ const {animationDuration, epsilon, isPageDown, isPageUp, overscrollTypeOnce, pag
 let lastPointer = {x: 0, y: 0};
 
 const useEventFocus = (props, instances) => {
-	const {scrollMode} = props;
+	const {scrollMode, snapToCenter} = props;
 	const {scrollContainerHandle, scrollContainerRef, scrollContentRef, spottable, themeScrollContentHandle} = instances;
 
 	// Functions
@@ -51,7 +51,7 @@ const useEventFocus = (props, instances) => {
 					scrollContainerHandle.current.start({
 						targetX: left,
 						targetY: top,
-						animate: spottable.current.animateOnFocus,
+						animate: spottable.current.animateOnFocus || snapToCenter,
 						overscrollEffect: props.overscrollEffectOn[scrollContainerHandle.current.lastInputType] &&
 							(!themeScrollContentHandle.current.shouldPreventOverscrollEffect || !themeScrollContentHandle.current.shouldPreventOverscrollEffect())
 					});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Sometimes, 5way down/up doesn't work.
- If the user wheels down and up repeatedly, the focused effect stays at some items.
- Sometimes, scrolls to jump by 5way without animation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Sometimes, 5way down/up doesn't work. : Reset internal flag that is critical to 5way behavior.
- If the user wheels down and up repeatedly, the focused effect stays at some items. : Added and cleared logic related scaled effect
- Sometimes, scrolls to jump by 5way without animation. : Always on `animateOnFocus` option when `snapToCenter`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-145128

### Comments
