### PR TITLE
PLAT-143483: Fixed Wizardpanel to not re-render the previous panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
 - `sandstone/Scroller` and `sandstone/VirtualList` to focus elements at scroll boundaries when `hoverToScroll` is `true`
 - `sandstone/VirtualList` to scroll properly when `snapToCenter`
-- `sandstone/WizardPanels` to prevent rerendering of previous panel
+- `sandstone/WizardPanels` to prevent re-rendering of previous panel
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Picker` value to not marquee when changing `title`
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
+- `sandstone/WizardPanels` to reduce meaningless rendering
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -21,7 +21,7 @@ function PanelBase ({
 	subtitle,
 	title
 }) {
-	const {setPanel: set, index} = useContext(WizardPanelsContext);
+	const {index, setPanel: set} = useContext(WizardPanelsContext);
 
 	useEffect(() => {
 		if (set) {
@@ -43,12 +43,12 @@ function PanelBase ({
 		ariaLabel,
 		children,
 		footer,
+		index,
 		nextButton,
 		prevButton,
 		subtitle,
 		set,
-		title,
-		index
+		title
 	]);
 	return null;
 }

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -21,13 +21,17 @@ function PanelBase ({
 	subtitle,
 	title
 }) {
-	const set = useContext(WizardPanelsContext);
+	const {setPanel: set, index} = useContext(WizardPanelsContext);
 
 	useEffect(() => {
 		if (set) {
 			set({
 				'aria-label': ariaLabel,
-				children,
+				children: (
+					<div className="enact-fit" data-index={index} key={`panel${index}`}>
+						{children}
+					</div>
+				),
 				footer,
 				nextButton,
 				prevButton,
@@ -43,7 +47,8 @@ function PanelBase ({
 		prevButton,
 		subtitle,
 		set,
-		title
+		title,
+		index
 	]);
 	return null;
 }

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -1,4 +1,7 @@
 import Slottable from '@enact/ui/Slottable';
+import {useContext, useEffect} from 'react';
+
+import {WizardPanelsContext} from './WizardPanels';
 
 /**
  * Panel that sets the children, footer, subtitle, and title for
@@ -9,7 +12,39 @@ import Slottable from '@enact/ui/Slottable';
  * @ui
  * @private
  */
-function PanelBase () {
+function PanelBase ({
+	'aria-label': ariaLabel,
+	children,
+	footer,
+	nextButton,
+	prevButton,
+	subtitle,
+	title
+}) {
+	const set = useContext(WizardPanelsContext);
+
+	useEffect(() => {
+		if (set) {
+			set({
+				'aria-label': ariaLabel,
+				children,
+				footer,
+				nextButton,
+				prevButton,
+				subtitle,
+				title
+			});
+		}
+	}, [
+		ariaLabel,
+		children,
+		footer,
+		nextButton,
+		prevButton,
+		subtitle,
+		set,
+		title
+	]);
 	return null;
 }
 

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -1,7 +1,4 @@
 import Slottable from '@enact/ui/Slottable';
-import {useContext, useEffect} from 'react';
-
-import {WizardPanelsContext} from './WizardPanels';
 
 /**
  * Panel that sets the children, footer, subtitle, and title for
@@ -12,39 +9,7 @@ import {WizardPanelsContext} from './WizardPanels';
  * @ui
  * @private
  */
-function PanelBase ({
-	'aria-label': ariaLabel,
-	children,
-	footer,
-	nextButton,
-	prevButton,
-	subtitle,
-	title
-}) {
-	const set = useContext(WizardPanelsContext);
-
-	useEffect(() => {
-		if (set) {
-			set({
-				'aria-label': ariaLabel,
-				children,
-				footer,
-				nextButton,
-				prevButton,
-				subtitle,
-				title
-			});
-		}
-	}, [
-		ariaLabel,
-		children,
-		footer,
-		nextButton,
-		prevButton,
-		subtitle,
-		set,
-		title
-	]);
+function PanelBase () {
 	return null;
 }
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -11,7 +11,7 @@ import ViewManager from '@enact/ui/ViewManager';
 import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {useEffect, useRef, useState, useCallback, Children} from 'react';
+import {createContext, useEffect, useRef, useState, useCallback, Children} from 'react';
 
 import $L from '../internal/$L';
 import {Header} from '../Panels';
@@ -25,6 +25,7 @@ import useToggleRole from './useToggleRole';
 
 import css from './WizardPanels.module.less';
 
+const WizardPanelsContext = createContext(null);
 const DecoratedPanelBase = FloatingLayerIdProvider(PanelBase);
 const HeaderContainer = SpotlightContainerDecorator(Header);
 
@@ -504,48 +505,30 @@ const WizardPanelsRouter = (Wrapped) => {
 		delete rest.onBack;
 
 		const changedIndex = useIndexChanged(index);
-		if (changedIndex) {
-			const {
-				'aria-label': ariaLabel,
-				children: panelChildren,
-				footer,
-				nextButton,
-				prevButton,
-				subtitle,
-				title: panelTitle
-			} = children[index].props;
-
-			setPanel({
-				'aria-label': ariaLabel,
-				children: panelChildren,
-				footer,
-				nextButton,
-				prevButton,
-				subtitle,
-				title: panelTitle
-			});
-		}
 
 		return (
-			<Wrapped
-				{...rest}
-				{...panel}
-				{...transition}
-				componentRef={ref}
-				data-spotlight-id={spotlightId}
-				index={index}
-				noAnimation={noAnimation}
-				onWillTransition={handleWillTransition}
-				title={currentTitle}
-				totalPanels={totalPanels}
-				reverseTransition={reverseTransition}
-			>
-				{panel && panel.children ? (
-					<div className="enact-fit" key={`panel${index}`}>
-						{panel.children}
-					</div>
-				) : null}
-			</Wrapped>
+			<WizardPanelsContext.Provider value={setPanel}>
+				{Children.toArray(children)[index]}
+				<Wrapped
+					{...rest}
+					{...panel}
+					{...transition}
+					componentRef={ref}
+					data-spotlight-id={spotlightId}
+					index={index}
+					noAnimation={noAnimation}
+					onWillTransition={handleWillTransition}
+					title={currentTitle}
+					totalPanels={totalPanels}
+					reverseTransition={reverseTransition}
+				>
+					{panel && panel.children && (!noAnimation || !changedIndex) ? (
+						<div className="enact-fit" key={`panel${index}`}>
+							{panel.children}
+						</div>
+					) : null}
+				</Wrapped>
+			</WizardPanelsContext.Provider>
 		);
 	};
 
@@ -680,5 +663,6 @@ export default WizardPanels;
 export {
 	WizardPanels,
 	WizardPanelsBase,
+	WizardPanelsContext,
 	WizardPanelsDecorator
 };

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -445,24 +445,18 @@ const WizardPanelsBase = kind({
 // because the index is always 0 from its perspective.
 function useReverseTransition (index = -1, rtl) {
 	const prevIndex = useRef(index);
-	let reverse = rtl;
+	const reverseTransition = useRef(rtl);
+	// If the index was changed, the panel transition is occured on the next cycle by `Panel`
+	let prevTransition = reverseTransition.current;
 
 	if (prevIndex.current !== index) {
-		reverse = rtl ? (index > prevIndex.current) : (index < prevIndex.current);
+		reverseTransition.current = rtl ? (index > prevIndex.current) : (index < prevIndex.current);
 		prevIndex.current = index;
 	}
 
-	return reverse;
+	return prevTransition;
 }
 
-function useIndexChanged (index = -1) {
-	const prevIndex = useRef(-1);
-	const changed = (prevIndex.current !== index);
-	const prev = prevIndex.current;
-	prevIndex.current = index;
-
-	return [changed, prev];
-}
 /**
  * WizardPanelsRouter passes the children, footer, subtitle, and title from
  * [WizardPanel]{@link sandstone/WizardPanels.Panel} to
@@ -489,9 +483,7 @@ const WizardPanelsRouter = (Wrapped) => {
 		const {ref: a11yRef, onWillTransition: a11yOnWillTransition} = useToggleRole();
 		const autoFocus = useAutoFocus({autoFocus: 'default-element', hideChildren: panel == null});
 		const ref = useChainRefs(autoFocus, a11yRef, componentRef);
-		const [changedIndex, prevIndex] = useIndexChanged(index);
-		// If the index was changed, the panel should be updated on the next cycle by `Panel`
-		const reverseTransition = useReverseTransition(changedIndex ? prevIndex : index, rtl);
+		const reverseTransition = useReverseTransition(index, rtl);
 		const {
 			onWillTransition: focusOnWillTransition,
 			...transition

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -25,7 +25,6 @@ import useToggleRole from './useToggleRole';
 
 import css from './WizardPanels.module.less';
 
-const WizardPanelsContext = createContext(null);
 const DecoratedPanelBase = FloatingLayerIdProvider(PanelBase);
 const HeaderContainer = SpotlightContainerDecorator(Header);
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -445,16 +445,16 @@ const WizardPanelsBase = kind({
 // because the index is always 0 from its perspective.
 function useReverseTransition (index = -1, rtl) {
 	const prevIndex = useRef(index);
-	const reverseTransition = useRef(rtl);
+	const reverse = useRef(rtl);
 	// If the index was changed, the panel transition is occured on the next cycle by `Panel`
-	let prevTransition = reverseTransition.current;
+	let prevReverse = reverse.current;
 
 	if (prevIndex.current !== index) {
-		reverseTransition.current = rtl ? (index > prevIndex.current) : (index < prevIndex.current);
+		reverse.current = rtl ? (index > prevIndex.current) : (index < prevIndex.current);
 		prevIndex.current = index;
 	}
 
-	return prevTransition;
+	return prevReverse;
 }
 
 /**

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -11,7 +11,7 @@ import ViewManager from '@enact/ui/ViewManager';
 import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {createContext, useEffect, useRef, useState, useCallback, Children} from 'react';
+import {createContext, useRef, useState, useCallback, Children} from 'react';
 
 import $L from '../internal/$L';
 import {Header} from '../Panels';

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -447,7 +447,7 @@ function useReverseTransition (index = -1, rtl) {
 	const prevIndex = useRef(index);
 	const reverse = useRef(rtl);
 	// If the index was changed, the panel transition is occured on the next cycle by `Panel`
-	let prevReverse = reverse.current;
+	const prevReverse = reverse.current;
 
 	if (prevIndex.current !== index) {
 		reverse.current = rtl ? (index > prevIndex.current) : (index < prevIndex.current);

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -7,7 +7,7 @@ import Icon from '@enact/sandstone/Icon';
 import Item from '@enact/sandstone/Item';
 import {Scroller} from '@enact/sandstone/Scroller';
 import WizardPanels, {Panel, WizardPanelsBase} from '@enact/sandstone/WizardPanels';
-import {Component, PureComponent} from 'react';
+import {Component} from 'react';
 
 WizardPanels.displayName = 'WizardPanels';
 const Config = mergeComponentMetadata('WizardPanels', WizardPanelsBase, WizardPanels);
@@ -181,70 +181,6 @@ export const WithFooterButtons = () => <WizardPanelsWidthFooterButtons />;
 
 WithFooterButtons.storyName = 'with footer buttons';
 WithFooterButtons.parameters = {
-	props: {
-		noPanel: true
-	}
-};
-
-class PureComponentItem extends PureComponent {
-
-	constructor (props) {
-		super(props);
-		action('constructor')(props.children);
-	}
-
-	componentDidMount () {
-		action('componentDidMount')(this.props.children);
-	}
-
-	componentWillUnmount () {
-		action('componentWillUnmount')(this.props.children);
-	}
-
-	render () {
-		action('render')(this.props.children);
-		return (
-			<Item>{this.props.children}</Item>
-		);
-	}
-}
-
-export const WithPureComponent = () => (
-	<WizardPanels
-		current={number('current', Config, 0)}
-		noAnimation={boolean('noAnimation', Config)}
-		noSteps={boolean('noSteps', Config)}
-		nextButtonVisibility={select('nextButtonVisibility', propOptions.buttonVisibility, Config)}
-		onNextClick={action('onNextClick')}
-		onPrevClick={action('onPrevClick')}
-		onTransition={action('onTransition')}
-		onWillTransition={action('onWillTransition')}
-		prevButtonVisibility={select('prevButtonVisibility', propOptions.buttonVisibility, Config)}
-		total={number('total', Config, 0)}
-	>
-		<WizardPanels.Panel
-			footer="Footer in View 1"
-			subtitle="A subtitle for View 1"
-			title="WizardPanel View 1"
-		>
-			<PureComponentItem>Item1</PureComponentItem>
-			<footer>
-				<Button>OK</Button>
-				<Button>Cancel</Button>
-			</footer>
-		</WizardPanels.Panel>
-		<WizardPanels.Panel
-			footer="Footer in View 2"
-			subtitle="A subtitle for View 2"
-			title="WizardPanel View 2"
-		>
-			<PureComponentItem>Item2</PureComponentItem>
-		</WizardPanels.Panel>
-	</WizardPanels>
-);
-
-WithPureComponent.storyName = 'with pure component';
-WithPureComponent.parameters = {
 	props: {
 		noPanel: true
 	}

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -243,8 +243,6 @@ export const WithPureComponent = () => (
 	</WizardPanels>
 );
 
-// export const WithPureComponent = () => <WithPureComponent />;
-
 WithPureComponent.storyName = 'with pure component';
 WithPureComponent.parameters = {
 	props: {

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -7,7 +7,7 @@ import Icon from '@enact/sandstone/Icon';
 import Item from '@enact/sandstone/Item';
 import {Scroller} from '@enact/sandstone/Scroller';
 import WizardPanels, {Panel, WizardPanelsBase} from '@enact/sandstone/WizardPanels';
-import {Component} from 'react';
+import {Component, PureComponent} from 'react';
 
 WizardPanels.displayName = 'WizardPanels';
 const Config = mergeComponentMetadata('WizardPanels', WizardPanelsBase, WizardPanels);
@@ -181,6 +181,72 @@ export const WithFooterButtons = () => <WizardPanelsWidthFooterButtons />;
 
 WithFooterButtons.storyName = 'with footer buttons';
 WithFooterButtons.parameters = {
+	props: {
+		noPanel: true
+	}
+};
+
+class PureComponentItem extends PureComponent {
+
+	constructor (props) {
+		super(props);
+		action('constructor')(props.children);
+	}
+
+	componentDidMount () {
+		action('componentDidMount')(this.props.children);
+	}
+
+	componentWillUnmount () {
+		action('componentWillUnmount')(this.props.children);
+	}
+
+	render () {
+		action('render')(this.props.children);
+		return (
+			<Item>{this.props.children}</Item>
+		);
+	}
+}
+
+export const WithPureComponent = () => (
+	<WizardPanels
+		current={number('current', Config, 0)}
+		noAnimation={boolean('noAnimation', Config)}
+		noSteps={boolean('noSteps', Config)}
+		nextButtonVisibility={select('nextButtonVisibility', propOptions.buttonVisibility, Config)}
+		onNextClick={action('onNextClick')}
+		onPrevClick={action('onPrevClick')}
+		onTransition={action('onTransition')}
+		onWillTransition={action('onWillTransition')}
+		prevButtonVisibility={select('prevButtonVisibility', propOptions.buttonVisibility, Config)}
+		total={number('total', Config, 0)}
+	>
+		<WizardPanels.Panel
+			footer="Footer in View 1"
+			subtitle="A subtitle for View 1"
+			title="WizardPanel View 1"
+		>
+			<PureComponentItem>Item1</PureComponentItem>
+			<footer>
+				<Button>OK</Button>
+				<Button>Cancel</Button>
+			</footer>
+		</WizardPanels.Panel>
+		<WizardPanels.Panel
+			footer="Footer in View 2"
+			subtitle="A subtitle for View 2"
+			title="WizardPanel View 2"
+		>
+			<PureComponentItem>Item2</PureComponentItem>
+		</WizardPanels.Panel>
+	</WizardPanels>
+);
+
+// export const WithPureComponent = () => <WithPureComponent />;
+
+WithPureComponent.storyName = 'with pure component';
+WithPureComponent.parameters = {
 	props: {
 		noPanel: true
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
WizardPanels: Items contained in the panel being removed are rendered twice

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
3 renderings are performed when the Wizard Panel is loaded.

- The 2nd render is called by useReverseTransition so I modified it to use Ref.
- The 3rd render is by `WizardPanels.Panel`, which is difficult to fix due to the current structure. The reported problem occurs in the 3rd render situation, because the key value is updated before the panel contents are updated.
So I fixed the key value is specified on `WizardPanels.Panel` instead of `WizardPanels`


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

The current WizardPanel.panel is returning null and updates the parent state. 
This structure needs long-term fix.

### Links
[//]: # (Related issues, references)
PLAT-143483

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
