### PR TITLE
PLAT-145625: Fix VideoPlayer to handle playback rate with decimal point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Picker` value to not marquee when changing `title`
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
 - `sandstone/Scroller` and `sandstone/VirtualList` to focus elements at scroll boundaries when `hoverToScroll` is `true`
-- `sandstone/VideoPlayer` to handle playback rate with decimal point
+- `sandstone/VideoPlayer` to handle decimal playback rate
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Picker` value to not marquee when changing `title`
 - `sandstone/Scroller` and `sandstone/VirtualList` to scroll by hover when scrollbar is hidden
+- `sandstone/VideoPlayer` to handle playback rate with decimal point
 
 ## [2.0.0-rc.1] - 2021-06-18
 

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -156,7 +156,7 @@ const AnnounceState = {
  * faster. If it is negative, it will play backward.
  *
  * The order of numbers represents the incremental order of rates that will be used for each
- * operation. Note that rates can be expressed as decimals, strings and also fractions if needed.
+ * operation. Note that rates can be expressed as decimals, strings, and fractions.
  * (e.g.: `0.5`, `'0.5'`, `'1/2'`).
  *
  * @typedef {Object} playbackRateHash
@@ -515,7 +515,7 @@ const VideoPlayerBase = class extends Component {
 		pauseAtEnd: PropTypes.bool,
 
 		/**
-		 * Mapping of keys which are playback rate types to array of playback rate values.
+		 * Mapping of playback rate names to playback rate values that may be set.
 		 *
 		 * @type {sandstone/VideoPlayer.playbackRateHash}
 		 * @default {
@@ -1374,7 +1374,7 @@ const VideoPlayerBase = class extends Component {
 
 	/**
 	 * Step a given amount of time away from the current playback position.
-	 * Like [seek]{@link sandstone/VideoPlayer.VideoPlayer#seek} but relative.
+	 * Like [seek]{@link sandstone/VideoPlayer.VideoPlayerBase.seek} but relative.
 	 *
 	 * @function
 	 * @memberof sandstone/VideoPlayer.VideoPlayerBase.prototype
@@ -1395,7 +1395,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Changes the playback speed via [selectPlaybackRate()]{@link sandstone/VideoPlayer.VideoPlayer#selectPlaybackRate}.
+	 * Changes the playback speed.
 	 *
 	 * @function
 	 * @memberof sandstone/VideoPlayer.VideoPlayerBase.prototype
@@ -1452,7 +1452,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Changes the playback speed via [selectPlaybackRate()]{@link sandstone/VideoPlayer.VideoPlayer#selectPlaybackRate}.
+	 * Changes the playback speed.
 	 *
 	 * @function
 	 * @memberof sandstone/VideoPlayer.VideoPlayerBase.prototype
@@ -1575,17 +1575,17 @@ const VideoPlayerBase = class extends Component {
 	 * Retrieves the playback rate value.
 	 *
 	 * @param {Number} idx - The index of the desired playback rate.
-	 * @returns {Number} The playback rate value.
+	 * @returns {Number|String} The playback rate value.
 	 * @private
 	 */
 	selectPlaybackRate = (idx) => {
-		return calcNumberValueOfPlaybackRate(this.playbackRates[idx]);
+		return this.playbackRates[idx];
 	};
 
 	/**
 	 * Sets [playbackRate]{@link sandstone/VideoPlayer.VideoPlayer#playbackRate}.
 	 *
-	 * @param {Number} rate - The desired playback rate.
+	 * @param {Number|String} rate - The desired playback rate.
 	 * @private
 	 */
 	setPlaybackRate = (rate) => {
@@ -1594,18 +1594,19 @@ const VideoPlayerBase = class extends Component {
 
 		// Make sure rate is a string
 		this.playbackRate = String(rate);
+		const pbNumber = calcNumberValueOfPlaybackRate(this.playbackRate);
 
 		if (!platform.webos) {
 			// ReactDOM throws error for setting negative value for playbackRate
-			this.video.playbackRate = rate < 0 ? 0 : rate;
+			this.video.playbackRate = pbNumber < 0 ? 0 : pbNumber;
 
 			// For supporting cross browser behavior
-			if (rate < 0) {
+			if (pbNumber < 0) {
 				this.beginRewind();
 			}
 		} else {
 			// Set native playback rate
-			this.video.playbackRate = rate;
+			this.video.playbackRate = pbNumber;
 		}
 	};
 

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -113,6 +113,10 @@ class VideoPlayerWithfastForwardMode extends Component {
 		this.videoPlayer.fastForward();
 	};
 
+	rewind = () => {
+		this.videoPlayer.rewind();
+	};
+
 	render () {
 		return (
 			<div>
@@ -131,7 +135,11 @@ class VideoPlayerWithfastForwardMode extends Component {
 					<Video>
 						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
 					</Video>
-					<MediaControls actionGuideLabel="Press down button to fastforward">
+					<MediaControls actionGuideLabel="Press Down Button">
+						<Button
+							icon="backward"
+							onClick={this.rewind}
+						/>
 						<Button
 							icon="forward"
 							onClick={this.fastforward}

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -1,5 +1,7 @@
-import {button} from '@enact/storybook-utils/addons/knobs';
+import Button from '@enact/sandstone/Button';
+import {MediaControls} from '@enact/sandstone/MediaPlayer';
 import VideoPlayer, {Video} from '@enact/sandstone/VideoPlayer';
+import {button} from '@enact/storybook-utils/addons/knobs';
 import {Component} from 'react';
 
 const videoTabLabel = 'VideoPlayer';
@@ -97,3 +99,50 @@ export default {
 export const PreloadVideos = () => <VideoSourceSwap />;
 
 PreloadVideos.storyName = 'Preload Videos';
+
+class VideoPlayerWithfastForwardMode extends Component {
+	constructor (props) {
+		super(props);
+	}
+
+	setVideoPlayer = (node) => {
+		this.videoPlayer = node;
+	};
+
+	fastforward = () => {
+		this.videoPlayer.fastForward();
+	};
+
+	render () {
+		return (
+			<div>
+				<VideoPlayer
+					feedbackHideDelay={0}
+					muted
+					playbackRateHash={{
+						fastForward: [1.25, '3/2', '2', '2.5', '4', '8'],
+						rewind: ['-2', '-4', '-8', '-16'],
+						slowForward: ['1/4', '1/2'],
+						slowRewind: ['-1/2', '-1']
+					}}
+					ref={this.setVideoPlayer}
+					title={'Big Buck Bunny'}
+				>
+					<Video>
+						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
+					</Video>
+					<MediaControls actionGuideLabel="Press down button to fastforward">
+						<Button
+							icon="forward"
+							onClick={this.fastforward}
+						/>
+					</MediaControls>
+				</VideoPlayer>
+			</div>
+		);
+	}
+}
+
+export const FastForwardWithVariousPlaybackRates = () => <VideoPlayerWithfastForwardMode />;
+
+FastForwardWithVariousPlaybackRates.storyName = 'Fastforward with various playback rates';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix `VideoPlayer` to handle playback rate with decimal point 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use parseFloat instead of parseInt in `calcNumberValueOfPlaybackRate` func

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-145625

### Comments
