### PR TITLE
WRN-1539: ImageItem: add `imageIcon` to publicClassNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Imageitem` public classname `imageIcon`
+
 ## [2.0.0-rc.3] - 2021-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Imageitem` public classname `imageIcon`
+- `sandstone/ImageItem` public classname `imageIcon`
 
 ### Fixed
 

--- a/ImageItem/ImageItem.js
+++ b/ImageItem/ImageItem.js
@@ -223,7 +223,7 @@ const ImageItemBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['imageItem', 'caption', 'fullImage', 'horizontal', 'image', 'label', 'selected', 'selectionIcon', 'vertical']
+		publicClassNames: ['imageItem', 'caption', 'fullImage', 'horizontal', 'image', 'imageIcon', 'label', 'selected', 'selectionIcon', 'vertical']
 	},
 
 	computed: {

--- a/tests/screenshot/apps/components/ImageItem.js
+++ b/tests/screenshot/apps/components/ImageItem.js
@@ -6,6 +6,8 @@ import img from '../../images/600x600.png';
 
 import {withConfig} from './utils';
 
+import css from './ImageItem.module.less';
+
 // vertical ImageItem doesn't render well without defined styles right now.
 const verticalStyle = {height: ri.scale(540), width: ri.scale(640)};
 
@@ -18,6 +20,7 @@ const ImageItemTests = [
 	<ImageItem src={img} style={verticalStyle} orientation="vertical" label="Short" imageIconSrc={img}>Short</ImageItem>,
 	<ImageItem src={img} style={verticalStyle} orientation="vertical" label="Short" showSelection>Short</ImageItem>,
 	<ImageItem src={img} style={verticalStyle} orientation="vertical" label="Short" selected showSelection>Short</ImageItem>,
+	<ImageItem src={img} style={verticalStyle} orientation="vertical" label="Short" imageIconSrc={img} css={css}>Short</ImageItem>,
 
 	<ImageItem src={img} orientation="horizontal" />,
 	<ImageItem src={img} orientation="horizontal">Short</ImageItem>,

--- a/tests/screenshot/apps/components/ImageItem.module.less
+++ b/tests/screenshot/apps/components/ImageItem.module.less
@@ -1,0 +1,8 @@
+.imageItem {
+	&.vertical {
+		.imageIcon {
+			width: 36px;
+			height: 36px;
+		}
+	}
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
It is already stated that it supports imageIcon css override.
CSS override for imageIcon class is not supported.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added ImageItem publicClass `imageIcon`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-1539

### Comments
