### PR TITLE
WRN-929: Scroller: fix to show scroll animation when pressing 5-way key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
+- `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
 
 ## [2.0.0-rc.3] - 2021-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
+
 ## [2.0.0-rc.3] - 2021-07-02
 
 ### Added

--- a/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-GT-28454-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-GT-28454-specs.js
@@ -17,9 +17,10 @@ describe('Navigate with 5-way', function () {
 		Page.numPad(4);
 		Page.numPad(0);
 		Page.numPad(0);
+		Page.spotlightRight();
 
 		// Adjust MinHeight
-		Page.spotlightRight();
+		Page.inputMinHeight.moveTo();
 		Page.spotlightSelect();
 		Page.backSpace();
 		Page.backSpace();
@@ -40,6 +41,10 @@ describe('Navigate with 5-way', function () {
 		// Step 4: Focus on the last item.
 		Page.item(Number(Page.bottomRightVisibleItemId().slice(4))).moveTo();
 		Page.spotlightDown();
+
+		// Wait for scroll animation
+		Page.delay(300);
+
 		// check if the previous item partially cut off.
 		expect(Page.itemOffsetBottomById(10)).to.be.below(Page.getItemSize().height);
 		// Step 4 Verify: Spotlight is on the last item.

--- a/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-GT-28584-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-GT-28584-specs.js
@@ -81,6 +81,10 @@ describe('Navigate with 5-way', function () {
 			Page.spotlightDown();
 			// Step 6-3 Verify: Spotlight is on Image 16(In case, 13).
 			expectFocusedItem(13);
+
+			// Wait for scroll animation
+			Page.delay(300);
+
 			// check if the previous item partially cut off.
 			expect(Page.itemOffsetBottomById(8)).to.be.below(Page.getItemSize().height);
 		});

--- a/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-GT-28584-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-GT-28584-specs.js
@@ -35,6 +35,10 @@ describe('Navigate with 5-way', function () {
 		Page.spotlightDown();
 		// Step 4-3 Verify: Spotlight is on Image 16(In case, 13).
 		expectFocusedItem(13);
+
+		// Wait for scroll animation
+		Page.delay(300);
+
 		// check if the previous item partially cut off.
 		expect(Page.itemOffsetBottomById(8)).to.be.below(Page.getItemSize().height);
 	});

--- a/tests/ui/specs/VirtualList/VirtualGridList/qa-VirtualGridList/VirtualGridList-GT-28990-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/qa-VirtualGridList/VirtualGridList-GT-28990-specs.js
@@ -22,6 +22,10 @@ describe('qa-VirtualGridList', function () {
 		}
 		// Step 3-1 Verify: Spotlight is on the 101th item with 'Image 100'.
 		expectFocusedItem(100);
+
+		// Wait for scroll animation
+		Page.delay(300);
+
 		expect(Page.scrollThumbPosition()).to.equal('1');
 		// Step 3-2 Verify: The 101th item with 'Image 100' sticks to the bottom in the list.
 		Page.spotlightDown();

--- a/tests/ui/specs/VirtualList/VirtualList/Samples/VirtualList-GT-32197-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList/Samples/VirtualList-GT-32197-specs.js
@@ -22,6 +22,9 @@ describe('VirtualList Samples', function () {
 		Page.buttonLeft.moveTo();
 		Page.spotlightRight();
 
+		// Wait for scroll animation
+		Page.delay(300);
+
 		// Verify Spotlight displays on the 21st item ('Itme 20');
 		expectFocusedItem(Number((Page.bottomVisibleItemId().slice(4))));
 	});

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -14,7 +14,7 @@ const {animationDuration, epsilon, isPageDown, isPageUp, overscrollTypeOnce, pag
 let lastPointer = {x: 0, y: 0};
 
 const useEventFocus = (props, instances) => {
-	const {scrollMode, snapToCenter} = props;
+	const {scrollMode} = props;
 	const {scrollContainerHandle, scrollContainerRef, scrollContentRef, spottable, themeScrollContentHandle} = instances;
 
 	// Functions

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -49,7 +49,7 @@ const useEventFocus = (props, instances) => {
 					scrollContainerHandle.current.start({
 						targetX: left,
 						targetY: top,
-						animate: snapToCenter ? snapToCenter : spottable.current.animateOnFocus,
+						animate: spottable.current.animateOnFocus,
 						overscrollEffect: props.overscrollEffectOn[scrollContainerHandle.current.lastInputType] &&
 							(!themeScrollContentHandle.current.shouldPreventOverscrollEffect || !themeScrollContentHandle.current.shouldPreventOverscrollEffect())
 					});

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -69,7 +69,7 @@ const useThemeScroll = (props, instances) => {
 	// Mutable value
 
 	const mutableRef = useRef({
-		animateOnFocus: false,
+		animateOnFocus: true,
 		indexToFocus: null,
 		isWheeling: false,
 		lastScrollPositionOnFocus: null,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Sandstone Touch: VirtualGridList> No animation when an item scrolls into a view

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set `animateOnFocus`=true by default. 
on the Moonstone, `animateOnFocus` was `undefined` by default. so scrollTo show animation by default.  

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I fixed some ui-test to wait animation.
and Fix GT-28454-specs.js to avoid intermittent failed. (Sometimes spotlight right doesn't move the focus to inputMinHeight.)

### Links
[//]: # (Related issues, references)
PLAT-125066, WRN-929

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
