### PR TITLE
WRN-1347: Migrate ContextualPopupDecorator unit tests to Testing Library

### DIFF
--- a/ContextualPopupDecorator/tests/ContextualPopupDecorator-specs.js
+++ b/ContextualPopupDecorator/tests/ContextualPopupDecorator-specs.js
@@ -1,77 +1,95 @@
-import {mount} from 'enzyme';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import {ContextualPopupDecorator} from '../ContextualPopupDecorator';
 import Button from '../../Button';
 
 const ContextualButton = ContextualPopupDecorator(Button);
+
 describe('ContextualPopupDecorator Specs', () => {
-	test('should bind callback to instance', () => {
-		let called = false;
-		// Create a context with a prop on it we can use to detect access to this prop inside the
-		// instance method.
-		class CallbackInterceptor {
-			get containerNode () {
-				called = true;
-				return null;
-			}
-		}
-
-		const subject = mount(
-			<ContextualButton
-				popupComponent={Button}
-			>
-				Button
-			</ContextualButton>
+	test('should emit onClose event when clicking on contextual button', () => {
+		const handleClose = jest.fn();
+		const Root = FloatingLayerDecorator('div');
+		const message = 'goodbye';
+		const {getByRole} = render(
+			<Root>
+				<ContextualButton onClose={handleClose} open popupComponent={() => message}>
+					Hello
+				</ContextualButton>
+			</Root>
 		);
+		const contextualButton = getByRole('button');
 
-		// Call `positionContextualPopup` setting `this` to our interceptor.  Bound function should
-		// ignore the value of `this` we pass in.  If not, it will access `containerNode` above.
-		Reflect.apply(subject.instance().positionContextualPopup, new CallbackInterceptor(), []);
+		userEvent.click(contextualButton);
 
-		const expected = false;
-		const actual = called;
-
-		expect(actual).toBe(expected);
+		expect(handleClose).toHaveBeenCalled();
 	});
 
 	test('should render component into FloatingLayer if open', () => {
 		const Root = FloatingLayerDecorator('div');
 		const message = 'goodbye';
-
-		const subject = mount(
+		const {getByRole} = render(
 			<Root>
-				<ContextualButton
-					open
-					popupComponent={() => <div>{message}</div>}
-				>
+				<ContextualButton open popupComponent={() => message}>
 					Hello
 				</ContextualButton>
 			</Root>
 		);
+		const contextualPopup = getByRole('alert');
 
-		const expected = message;
-		const actual = subject.find('FloatingLayer').text();
-
-		expect(actual).toBe(expected);
+		expect(contextualPopup.children.item(0)).toHaveTextContent(message);
 	});
 
 	test('should not render into FloatingLayer if not open', () => {
 		const Root = FloatingLayerDecorator('div');
 		const message = 'goodbye';
 
-		const subject = mount(
+		render(
 			<Root>
-				<ContextualButton
-					popupComponent={() => <div>{message}</div>}
-				>
+				<ContextualButton popupComponent={() => message}>
 					Hello
 				</ContextualButton>
 			</Root>
 		);
 
-		const expected = '';
-		const actual = subject.find('FloatingLayer').text();
+		const popup = screen.queryByText(message);
 
-		expect(actual).toBe(expected);
+		expect(popup).toBeNull();
+	});
+
+	test('should not close popup when clicking outside if noAutoDismiss is true', () => {
+		const handleClose = jest.fn();
+		const Root = FloatingLayerDecorator('div');
+		const message = 'goodbye';
+		const {getByTestId} = render(
+			<Root data-testid="outsideArea">
+				<ContextualButton noAutoDismiss onClose={handleClose} open popupComponent={() => message}>
+					Hello
+				</ContextualButton>
+			</Root>
+		);
+		const outsideArea = getByTestId('outsideArea');
+
+		userEvent.click(outsideArea);
+
+		expect(handleClose).not.toHaveBeenCalled();
+	});
+
+	test('should have "below right" className when direction is set to "below right"', () => {
+		const handleClose = jest.fn();
+		const Root = FloatingLayerDecorator('div');
+		const message = 'goodbye';
+		const {getByRole} = render(
+			<Root>
+				<ContextualButton direction="below right" onClose={handleClose} open popupComponent={() => message}>
+					Hello
+				</ContextualButton>
+			</Root>
+		);
+		const contextualPopup = getByRole('alert');
+
+		expect(contextualPopup.children.item(0).className).toContain('below right');
 	});
 });

--- a/ContextualPopupDecorator/tests/ContextualPopupDecorator-specs.js
+++ b/ContextualPopupDecorator/tests/ContextualPopupDecorator-specs.js
@@ -39,7 +39,10 @@ describe('ContextualPopupDecorator Specs', () => {
 		);
 		const contextualPopup = getByRole('alert');
 
-		expect(contextualPopup.children.item(0)).toHaveTextContent(message);
+		const expected = message;
+		const actual = contextualPopup.children.item(0);
+
+		expect(actual).toHaveTextContent(expected);
 	});
 
 	test('should not render into FloatingLayer if not open', () => {
@@ -90,6 +93,9 @@ describe('ContextualPopupDecorator Specs', () => {
 		);
 		const contextualPopup = getByRole('alert');
 
-		expect(contextualPopup.children.item(0).className).toContain('below right');
+		const expected = 'below right';
+		const actual = contextualPopup.children.item(0).className;
+
+		expect(actual).toContain(expected);
 	});
 });


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated unit tests from Enzyme to Testing Library for ContextualPopupDecorator component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-1347

### Comments
