### PR TITLE
WRN-1663: Add wheelEventInterval in Slider to prevent firing wheel event too frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/ImageItem` public classname `imageIcon`
+- `sandstone/Slider` prop `wheelEventInterval` to control speed of the wheel on the slider
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/ImageItem` public classname `imageIcon`
-- `sandstone/Slider` prop `wheelEventInterval` to control speed of the wheel on the slider
+- `sandstone/Slider` prop `wheelInterval` to throttle the wheel input
 
 ### Fixed
 

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -76,7 +76,7 @@ const SliderBase = (props) => {
 
 	const spotlightAccelerator = useRef();
 	const ref = useRef();
-	const {current} = useRef({lastWheelEventTimeStamp: 0});
+	const {current: context} = useRef({lastWheelTimeStamp: 0});
 
 	const handlers = useHandlers({
 		onBlur: handle(
@@ -112,7 +112,7 @@ const SliderBase = (props) => {
 				handleDecrementByWheel
 			])
 		)
-	}, props, {current});
+	}, props, context);
 
 	// if the props includes a css map, merge them together
 	let mergedCss = componentCss;

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -76,7 +76,7 @@ const SliderBase = (props) => {
 
 	const spotlightAccelerator = useRef();
 	const ref = useRef();
-	const lastWheelEventTimeStamp = useRef(0);
+	const {current} = useRef({lastWheelEventTimeStamp: 0});
 
 	const handlers = useHandlers({
 		onBlur: handle(
@@ -107,20 +107,12 @@ const SliderBase = (props) => {
 		onWheel: handle(
 			forProp('disabled', false),
 			forwardWithPrevent('onWheel'),
-			(ev, {wheelEventInterval}) => {
-				if (ev.timeStamp - lastWheelEventTimeStamp.current < wheelEventInterval) {
-					ev.stopPropagation();
-					return false;
-				}
-				lastWheelEventTimeStamp.current = ev.timeStamp;
-				return true;
-			},
 			anyPass([
 				handleIncrementByWheel,
 				handleDecrementByWheel
 			])
 		)
-	}, props);
+	}, props, {current});
 
 	// if the props includes a css map, merge them together
 	let mergedCss = componentCss;
@@ -162,7 +154,7 @@ const SliderBase = (props) => {
 	delete rest.onActivate;
 	delete rest.step;
 	delete rest.tooltip;
-	delete rest.wheelEventInterval;
+	delete rest.wheelInterval;
 
 	return (
 		<UiSlider
@@ -402,7 +394,7 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	 * @default 0
 	 * @public
 	 */
-	wheelEventInterval: PropTypes.number
+	wheelInterval: PropTypes.number
 };
 
 SliderBase.defaultProps = {
@@ -413,7 +405,7 @@ SliderBase.defaultProps = {
 	max: 100,
 	min: 0,
 	step: 1,
-	wheelEventInterval: 0
+	wheelInterval: 0
 };
 
 /**

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -386,7 +386,7 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	/**
 	 * The interval (in milliseconds) between valid wheel events.
 	 *
-	 * For example, 200 means to ignore wheel events occurred witnin 200ms
+	 * For example, 200 means to ignore wheel events occurred within 200ms
 	 * of the last processed wheel event while 0 means to process all wheel events.
 	 * If the number is large, the slider value changes slowly.
 	 *

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -76,6 +76,7 @@ const SliderBase = (props) => {
 
 	const spotlightAccelerator = useRef();
 	const ref = useRef();
+	const lastWheelEventTimeStamp = useRef(0);
 
 	const handlers = useHandlers({
 		onBlur: handle(
@@ -106,6 +107,14 @@ const SliderBase = (props) => {
 		onWheel: handle(
 			forProp('disabled', false),
 			forwardWithPrevent('onWheel'),
+			(ev, {wheelEventInterval}) => {
+				if (ev.timeStamp - lastWheelEventTimeStamp.current < wheelEventInterval) {
+					ev.stopPropagation();
+					return false;
+				}
+				lastWheelEventTimeStamp.current = ev.timeStamp;
+				return true;
+			},
 			anyPass([
 				handleIncrementByWheel,
 				handleDecrementByWheel
@@ -153,6 +162,7 @@ const SliderBase = (props) => {
 	delete rest.onActivate;
 	delete rest.step;
 	delete rest.tooltip;
+	delete rest.wheelEventInterval;
 
 	return (
 		<UiSlider
@@ -379,7 +389,20 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	 * @type {Number}
 	 * @public
 	 */
-	value: PropTypes.number
+	value: PropTypes.number,
+
+	/**
+	 * The interval (in milliseconds) between valid wheel events.
+	 *
+	 * For example, 200 means to ignore wheel events occurred witnin 200ms
+	 * of the last processed wheel event while 0 means to process all wheel events.
+	 * If the number is large, the slider value changes slowly.
+	 *
+	 * @type {Number}
+	 * @default 0
+	 * @public
+	 */
+	wheelEventInterval: PropTypes.number
 };
 
 SliderBase.defaultProps = {
@@ -389,7 +412,8 @@ SliderBase.defaultProps = {
 	keyFrequency: [1],
 	max: 100,
 	min: 0,
-	step: 1
+	step: 1,
+	wheelEventInterval: 0
 };
 
 /**

--- a/Slider/utils.js
+++ b/Slider/utils.js
@@ -59,11 +59,11 @@ const isNotMin = (ev, {min, value = min}) => {
 	return value !== min;
 };
 
-const checkInterval = (ev, {wheelInterval}, {current}) => {
-	if (ev.timeStamp - current.lastWheelEventTimeStamp < wheelInterval) {
+const checkInterval = (ev, {wheelInterval}, context) => {
+	if (ev.timeStamp - context.lastWheelTimeStamp < wheelInterval) {
 		return false;
 	}
-	current.lastWheelEventTimeStamp = ev.timeStamp;
+	context.lastWheelTimeStamp = ev.timeStamp;
 	return true;
 };
 

--- a/Slider/utils.js
+++ b/Slider/utils.js
@@ -59,6 +59,14 @@ const isNotMin = (ev, {min, value = min}) => {
 	return value !== min;
 };
 
+const checkInterval = (ev, {wheelInterval}, {current}) => {
+	if (ev.timeStamp - current.lastWheelEventTimeStamp < wheelInterval) {
+		return false;
+	}
+	current.lastWheelEventTimeStamp = ev.timeStamp;
+	return true;
+};
+
 const emitChange = (direction) =>  adaptEvent(
 	(ev, {knobStep, max, min, step, value = min}) => {
 		const newValue = clamp(min, max, value + (calcStep(knobStep, step) * direction));
@@ -102,6 +110,7 @@ const handleIncrementByWheel = handle(
 	preventDefault,
 	stop,
 	isNotMax,
+	checkInterval,
 	emitChange(1)
 );
 
@@ -111,6 +120,7 @@ const handleDecrementByWheel = handle(
 	preventDefault,
 	stop,
 	isNotMin,
+	checkInterval,
 	emitChange(-1)
 );
 

--- a/samples/sampler/stories/default/Slider.js
+++ b/samples/sampler/stories/default/Slider.js
@@ -72,6 +72,7 @@ export const _Slider = () => {
 			)}
 			showAnchor={boolean('showAnchor', SliderConfig)}
 			step={number('step', SliderConfig, 1)}
+			wheelEventInterval={number('wheelEventInterval', SliderConfig, 200)}
 		>
 			{tooltip ? <SliderTooltip percent={percent} position={position} /> : null}
 		</Slider>

--- a/samples/sampler/stories/default/Slider.js
+++ b/samples/sampler/stories/default/Slider.js
@@ -72,7 +72,7 @@ export const _Slider = () => {
 			)}
 			showAnchor={boolean('showAnchor', SliderConfig)}
 			step={number('step', SliderConfig, 1)}
-			wheelEventInterval={number('wheelEventInterval', SliderConfig, 200)}
+			wheelInterval={number('wheelInterval', SliderConfig, 200)}
 		>
 			{tooltip ? <SliderTooltip percent={percent} position={position} /> : null}
 		</Slider>

--- a/samples/sampler/stories/default/Slider.js
+++ b/samples/sampler/stories/default/Slider.js
@@ -72,7 +72,7 @@ export const _Slider = () => {
 			)}
 			showAnchor={boolean('showAnchor', SliderConfig)}
 			step={number('step', SliderConfig, 1)}
-			wheelInterval={number('wheelInterval', SliderConfig)} 
+			wheelInterval={number('wheelInterval', SliderConfig)}
 		>
 			{tooltip ? <SliderTooltip percent={percent} position={position} /> : null}
 		</Slider>

--- a/samples/sampler/stories/default/Slider.js
+++ b/samples/sampler/stories/default/Slider.js
@@ -1,9 +1,9 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, object, select} from '@enact/storybook-utils/addons/knobs';
-import Slider, {SliderTooltip} from '@enact/sandstone/Slider';
+import Slider, {SliderBase, SliderTooltip} from '@enact/sandstone/Slider';
 
-const SliderConfig = mergeComponentMetadata('Slider', Slider);
+const SliderConfig = mergeComponentMetadata('Slider', SliderBase, Slider);
 const SliderTooltipConfig = mergeComponentMetadata('SliderTooltip', SliderTooltip);
 Slider.displayName = 'Slider';
 SliderTooltip.displayName = 'SliderTooltip';
@@ -72,7 +72,7 @@ export const _Slider = () => {
 			)}
 			showAnchor={boolean('showAnchor', SliderConfig)}
 			step={number('step', SliderConfig, 1)}
-			wheelInterval={number('wheelInterval', SliderConfig, 200)}
+			wheelInterval={number('wheelInterval', SliderConfig)} 
 		>
 			{tooltip ? <SliderTooltip percent={percent} position={position} /> : null}
 		</Slider>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add `wheelInterval` props in Slider to prevent firing wheel event too frequently

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Ignore wheel events occurred within `wheelInterval`(ms) of the last processed wheel event

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-1663

### Comments