### PR TITLE
WRN-2465: Date/TimePicker: add prop to hide label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/ImageItem` public classname `imageIcon`
 - `sandstone/DatePicker` and `sandstone/TimePicker` prop `noLabel` to hide label
+- `sandstone/ImageItem` public classname `imageIcon`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/ImageItem` public classname `imageIcon`
+- `sandstone/DatePicker` and `sandstone/TimePicker` prop `noLabel` to hide label
 
 ### Fixed
 

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -62,14 +62,6 @@ const DatePickerBase = kind({
 		 */
 		month: PropTypes.number.isRequired,
 
-		/**
-		 * Hides the label that displays the date.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		noLabel: PropTypes.bool,
 
 		/**
 		 * The order in which the component pickers are displayed.
@@ -155,6 +147,15 @@ const DatePickerBase = kind({
 		 * @public
 		 */
 		monthAriaLabel: PropTypes.string,
+
+		/**
+		 * Hides the label that displays the date.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		 noLabel: PropTypes.bool,
 
 		/**
 		 * Called when the `date` component of the Date changes.
@@ -277,7 +278,7 @@ const DatePickerBase = kind({
 			dayAccessibilityHint = $L('day'),
 			monthAccessibilityHint = $L('month'),
 			yearAccessibilityHint = $L('year');
-		
+
 		if (noLabel) {
 			delete rest.label;
 		}

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -155,7 +155,7 @@ const DatePickerBase = kind({
 		 * @default false
 		 * @public
 		 */
-		 noLabel: PropTypes.bool,
+		noLabel: PropTypes.bool,
 
 		/**
 		 * Called when the `date` component of the Date changes.

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -62,7 +62,6 @@ const DatePickerBase = kind({
 		 */
 		month: PropTypes.number.isRequired,
 
-
 		/**
 		 * The order in which the component pickers are displayed.
 		 *

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -63,6 +63,15 @@ const DatePickerBase = kind({
 		month: PropTypes.number.isRequired,
 
 		/**
+		 * Hides the label that displays the date.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		noLabel: PropTypes.bool,
+
+		/**
 		 * The order in which the component pickers are displayed.
 		 *
 		 * The value should be an array of 3 strings containing one of `'m'`, `'d'`, and `'y'`.
@@ -250,6 +259,7 @@ const DatePickerBase = kind({
 		minYear,
 		month,
 		monthAriaLabel,
+		noLabel,
 		onChangeDate,
 		onChangeMonth,
 		onChangeYear,
@@ -267,6 +277,10 @@ const DatePickerBase = kind({
 			dayAccessibilityHint = $L('day'),
 			monthAccessibilityHint = $L('month'),
 			yearAccessibilityHint = $L('year');
+		
+		if (noLabel) {
+			delete rest.label;
+		}
 
 		return (
 			<DateTime {...rest}>

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -148,6 +148,9 @@ const DatePickerBase = kind({
 		monthAriaLabel: PropTypes.string,
 
 		/**
+		 * Hides the label that displays the date.
+		 *
+		 * @type {Boolean}
 		 * @public
 		 */
 		noLabel: PropTypes.bool,

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -148,10 +148,6 @@ const DatePickerBase = kind({
 		monthAriaLabel: PropTypes.string,
 
 		/**
-		 * Hides the label that displays the date.
-		 *
-		 * @type {Boolean}
-		 * @default false
 		 * @public
 		 */
 		noLabel: PropTypes.bool,

--- a/DatePicker/tests/DatePicker-specs.js
+++ b/DatePicker/tests/DatePicker-specs.js
@@ -174,4 +174,16 @@ describe('DatePicker', () => {
 
 		expect(actual).toBe(expected);
 	});
+
+	test('should not display Heading', () => {
+		const date = new Date(2000, 0, 1);
+		const subject = mount(
+			<DatePicker value={date} locale="en-US" noLabel />
+		);
+
+		const expected = false;
+		const actual = subject.find('Heading').exists();
+
+		expect(actual).toBe(expected);
+	});
 });

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -108,7 +108,6 @@ const TimePickerBase = kind({
 		 */
 		minute: PropTypes.number.isRequired,
 
-
 		/**
 		 * The order in which the component pickers are displayed.
 		 *

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -195,10 +195,6 @@ const TimePickerBase = kind({
 		minuteAriaLabel: PropTypes.string,
 
 		/**
-		 * Hides the label that displays the time.
-		 *
-		 * @type {Boolean}
-		 * @default false
 		 * @public
 		 */
 		noLabel: PropTypes.bool,

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -195,6 +195,9 @@ const TimePickerBase = kind({
 		minuteAriaLabel: PropTypes.string,
 
 		/**
+		 * Hides the label that displays the time.
+		 *
+		 * @type {Boolean}
 		 * @public
 		 */
 		noLabel: PropTypes.bool,

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -108,14 +108,6 @@ const TimePickerBase = kind({
 		 */
 		minute: PropTypes.number.isRequired,
 
-		/**
-		 * Hides the label that displays the time.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		 noLabel: PropTypes.bool,
 
 		/**
 		 * The order in which the component pickers are displayed.
@@ -202,6 +194,15 @@ const TimePickerBase = kind({
 		 * @public
 		 */
 		minuteAriaLabel: PropTypes.string,
+
+		/**
+		 * Hides the label that displays the time.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		 noLabel: PropTypes.bool,
 
 		/**
 		 * Called on changes in the `hour` component of the time.
@@ -315,7 +316,7 @@ const TimePickerBase = kind({
 		const
 			hourAccessibilityHint = $L('hour'),
 			minuteAccessibilityHint = $L('minute');
-		
+
 		if (noLabel) {
 			delete rest.label;
 		}

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -202,7 +202,7 @@ const TimePickerBase = kind({
 		 * @default false
 		 * @public
 		 */
-		 noLabel: PropTypes.bool,
+		noLabel: PropTypes.bool,
 
 		/**
 		 * Called on changes in the `hour` component of the time.

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -109,6 +109,15 @@ const TimePickerBase = kind({
 		minute: PropTypes.number.isRequired,
 
 		/**
+		 * Hides the label that displays the time.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		 noLabel: PropTypes.bool,
+
+		/**
 		 * The order in which the component pickers are displayed.
 		 *
 		 * Should be an array of 2 or 3 strings containing one of `'h'`, `'k'`, `'m'`, and `'a'`.
@@ -291,6 +300,7 @@ const TimePickerBase = kind({
 		meridiems,
 		minute,
 		minuteAriaLabel,
+		noLabel,
 		onChangeHour,
 		onChangeMeridiem,
 		onChangeMinute,
@@ -305,6 +315,10 @@ const TimePickerBase = kind({
 		const
 			hourAccessibilityHint = $L('hour'),
 			minuteAccessibilityHint = $L('minute');
+		
+		if (noLabel) {
+			delete rest.label;
+		}
 
 		return (
 			<DateTime {...rest} css={css}>

--- a/TimePicker/tests/TimePicker-specs.js
+++ b/TimePicker/tests/TimePicker-specs.js
@@ -146,4 +146,16 @@ describe('TimePicker', () => {
 
 		expect(actual).toBe(expected);
 	});
+
+	test('should not display Heading', () => {
+		const time = new Date(2000, 0, 1, 12, 30);
+		const subject = mount(
+			<TimePicker value={time} locale="en-US" noLabel />
+		);
+
+		const expected = false;
+		const actual = subject.find('Heading').exists();
+
+		expect(actual).toBe(expected);
+	});
 });

--- a/internal/DateTime/DateTime.js
+++ b/internal/DateTime/DateTime.js
@@ -37,7 +37,7 @@ const DateTimeBase = kind({
 
 	render: ({children, css, label, ...rest}) => (
 		<div {...rest}>
-			<Heading className={css.heading}>{label}</Heading>
+			{label ? <Heading className={css.heading}>{label}</Heading> : null}
 			<div className={css.pickers}>
 				{children}
 			</div>

--- a/samples/sampler/stories/default/DatePicker.js
+++ b/samples/sampler/stories/default/DatePicker.js
@@ -19,6 +19,7 @@ export const _DatePicker = () => (
 	<DatePicker
 		disabled={boolean('disabled', Config)}
 		spotlightDisabled={boolean('spotlightDisabled', Config)}
+		noLabel={boolean('noLabel', Config)}
 		monthAriaLabel={text('monthAriaLabel', Config)}
 		dayAriaLabel={text('dayAriaLabel', Config)}
 		yearAriaLabel={text('yearAriaLabel', Config)}

--- a/samples/sampler/stories/default/TimePicker.js
+++ b/samples/sampler/stories/default/TimePicker.js
@@ -15,6 +15,7 @@ export const _TimePicker = () => (
 	<TimePicker
 		disabled={boolean('disabled', Config)}
 		spotlightDisabled={boolean('spotlightDisabled', Config)}
+		noLabel={boolean('noLabel', Config)}
 		hourAriaLabel={text('hourAriaLabel', Config, '')}
 		minuteAriaLabel={text('minuteAriaLabel', Config, '')}
 		meridiemAriaLabel={text('meridiemAriaLabel', Config, '')}

--- a/tests/screenshot/apps/components/DatePicker.js
+++ b/tests/screenshot/apps/components/DatePicker.js
@@ -7,6 +7,7 @@ const jan31 = generateDate('2019-01-31');
 const DatePickerTests = [
 	<DatePicker defaultValue={jan31} />,
 	<DatePicker defaultValue={jan31} disabled />,
+	<DatePicker defaultValue={jan31} noLabel />,
 	// *************************************************************
 	// locale = 'ar-SA'
 	{

--- a/tests/screenshot/apps/components/TimePicker.js
+++ b/tests/screenshot/apps/components/TimePicker.js
@@ -3,6 +3,7 @@ import TimePicker from '../../../../TimePicker';
 const TimePickerTests = [
 	<TimePicker defaultValue={new Date(2009, 5, 6)} />,
 	<TimePicker defaultValue={new Date(2009, 5, 6)} disabled />,
+	<TimePicker defaultValue={new Date(2009, 5, 6)} noLabel />,
 	// RTL
 	{
 		locale: 'ar-SA',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The GUI requirement is to display the Date/TimePicker without a label.
There are several scenarios for hiding time/date labels.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It Added prop `noLabel`  to DatePicker and TimePicker.
And then, if `label` is not valid, not displays Heading.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-2465

### Comments
