### PR TITLE
WRN-2467: Fix wrong initial focus on scroll body when `focusableScrollbar` is `byEnter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
+- `sandstone/Scroller` to not focus the body at the initial rendering when `focusableScrollbar` prop is `byEnter`
 
 ## [2.0.0-rc.4] - 2021-07-08
 

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -21,9 +21,11 @@ const
 	isBody = (elem) => (elem.classList.contains(css.focusableBody));
 
 const getFocusableBodyProps = (scrollContainerRef, contentId, isScrollbarVisible) => {
-	const spotlightId = scrollContainerRef.current && scrollContainerRef.current.dataset.spotlightId;
+	let spotlightId = scrollContainerRef.current && scrollContainerRef.current.dataset.spotlightId;
 
 	const setNavigableFilter = ({filterTarget}) => {
+		spotlightId = scrollContainerRef.current && scrollContainerRef.current.dataset.spotlightId;
+
 		if (spotlightId && filterTarget) {
 			const targetClassName = (filterTarget === 'body') ? css.focusableBody : scrollbarTrackCss.thumb;
 			Spotlight.set(spotlightId, {

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -128,7 +128,15 @@ export const _Panels = () => {
 				/>
 			</Panel>
 			<Panel>
-				<Header title="Panel with TabLayout" />
+				<Header title="Panel with TabLayout" >
+					<Button
+						icon="arrowlargeright"
+						iconFlip="auto"
+						size="small"
+						slot="slotAfter"
+						onClick={forward} // eslint-disable-line react/jsx-no-bind
+					/>
+				</Header>
 				<TabLayout>
 					<TabLayout.Tab title="Home" icon="home">
 						<Icon>home</Icon>Home
@@ -175,6 +183,18 @@ export const _Panels = () => {
 						<Item slotBefore={<Icon>playcircle</Icon>}>Hello Item</Item>
 					</TabLayout.Tab>
 				</TabLayout>
+			</Panel>
+			<Panel>
+				<Header title="Panel with Scroller" />
+				<Scroller focusableScrollbar="byEnter" verticalScrollbar="visible">
+					<div style={{height: ri.scaleToRem(2004)}}>
+						<BodyText>
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+							Aenean id blandit nunc. Donec lacinia nisi vitae mi dictum, eget pulvinar nunc tincidunt.
+							Integer vehicula tempus rutrum. Sed efficitur neque in arcu dignissim cursus.
+						</BodyText>
+					</div>
+				</Scroller>
 			</Panel>
 		</Panels>
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
 When enter to panel, Scroller body get focus 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

This is a problem occurred because the containerId value was not updated even though the ref was updated. 
It was missing from (https://github.com/enactjs/sandstone/pull/900))
So I updated the containerId inside setNavigableFilter.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
In order for the scroll thumb to receive focus, `verticalScrollbar`=`"visible"` is needed on the Scroller.

### Links
[//]: # (Related issues, references)
WRN-2467

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
