### PR TITLE
WRN-1351: Migrate ActionGuide and RadioItem unit tests to Testing Library

### DIFF
--- a/ActionGuide/tests/ActionGuide-specs.js
+++ b/ActionGuide/tests/ActionGuide-specs.js
@@ -30,7 +30,7 @@ describe('ActionGuide', () => {
 			const expected = css.actionGuide;
 			const actual = getByTestId('actionGuide');
 
-			expect(actual.className).toContain(expected);
+			expect(actual).toHaveClass(expected);
 		});
 	});
 });

--- a/ActionGuide/tests/ActionGuide-specs.js
+++ b/ActionGuide/tests/ActionGuide-specs.js
@@ -1,50 +1,36 @@
-import {shallow} from 'enzyme';
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+
 import {ActionGuideBase} from '../ActionGuide';
 
 describe('ActionGuide', () => {
 
-	test(
-		'should render `icon`',
-		() => {
-			const subject = shallow(
-				<ActionGuideBase icon="star" />
-			);
+	test('should render `icon`', () => {
+		const {getByTestId} = render(<ActionGuideBase data-testid="actionGuide" icon="star" />);
 
-			const expected = 'star';
-			const actual = subject.find('.icon').prop('children');
+		const expected = 983080; // decimal converted charCode of Unicode 'star' character
+		const actual = getByTestId('actionGuide').children.item(0).textContent.codePointAt();
 
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(actual).toBe(expected);
+	});
 
-	test(
-		'should render `children`',
-		() => {
-			const subject = shallow(
-				<ActionGuideBase>content</ActionGuideBase>
-			);
+	test('should render `children`', () => {
+		const {getByText} = render(<ActionGuideBase data-testid="actionGuide">content</ActionGuideBase>);
 
-			const expected = 'content';
-			const actual = subject.find('.label').prop('children');
+		const actual = getByText('content');
 
-			expect(actual).toBe(expected);
-		}
-	);
+		expect(actual).toBeInTheDocument();
+	});
 
 	describe('CSS override', () => {
-		test(
-			'should allow `actionGuide` to be augmented',
-			() => {
-				const css = {actionGuide: 'test-action-guide'};
-				const subject = shallow(
-					<ActionGuideBase css={css}>content</ActionGuideBase>
-				);
+		test('should allow `actionGuide` to be augmented', () => {
+			const css = {actionGuide: 'test-action-guide'};
+			const {getByTestId} = render(<ActionGuideBase data-testid="actionGuide" css={css}>content</ActionGuideBase>);
 
-				const expected = css.actionGuide;
-				const actual = subject.prop('className');
+			const expected = css.actionGuide;
+			const actual = getByTestId('actionGuide');
 
-				expect(actual).toContain(expected);
-			}
-		);
+			expect(actual.className).toContain(expected);
+		});
 	});
 });

--- a/RadioItem/tests/RadioItem-specs.js
+++ b/RadioItem/tests/RadioItem-specs.js
@@ -25,8 +25,9 @@ describe('RadioItem Specs', () => {
 
 	test('should render a disabled RadioItem when `disabled` is true', () => {
 		const {getByRole} = render(<RadioItemBase disabled>Hello RadioItem</RadioItemBase>);
+		const radioItem = getByRole('checkbox');
 
-		expect(getByRole('checkbox', {disabled: true}));
+		expect(radioItem).toHaveAttribute('disabled');
 	});
 
 	test('should render a `slot before`', () => {

--- a/RadioItem/tests/RadioItem-specs.js
+++ b/RadioItem/tests/RadioItem-specs.js
@@ -45,7 +45,7 @@ describe('RadioItem Specs', () => {
 
 		const expected = 'selected';
 
-		expect(radioItem[0].className).toContain(expected);
+		expect(radioItem[0]).toHaveClass(expected);
 	});
 
 	test('should not select RadioItem with click when disabled', () => {
@@ -56,6 +56,6 @@ describe('RadioItem Specs', () => {
 
 		const expected = 'selected';
 
-		expect(radioItem[0].className).not.toContain(expected);
+		expect(radioItem[0]).not.toHaveClass(expected);
 	});
 });

--- a/RadioItem/tests/RadioItem-specs.js
+++ b/RadioItem/tests/RadioItem-specs.js
@@ -1,19 +1,61 @@
-import {shallow} from 'enzyme';
+import '@testing-library/jest-dom';
+import {fireEvent, render} from '@testing-library/react';
 
-import {RadioItemBase} from '../RadioItem';
+import RadioItem, {RadioItemBase} from '../RadioItem';
 
 describe('RadioItem Specs', () => {
+
 	test('should support a custom icon', () => {
-		const expected = 'check';
+		const {getByRole} = render(<RadioItemBase icon="check" selected>Hello RadioItem</RadioItemBase>);
+		const radioItemElement = getByRole('checkbox');
 
-		const subject = shallow(
-			<RadioItemBase icon={expected}>
-				Hello RadioItem
-			</RadioItemBase>
-		);
-
-		const actual = subject.find('.icon').prop('children');
+		const expected = '✓';
+		const actual = radioItemElement.children.item(1).textContent;
 
 		expect(actual).toBe(expected);
+	});
+
+	test('should render `children`', () => {
+		const {getByText} = render(<RadioItemBase>Hello RadioItem</RadioItemBase>);
+
+		const actual = getByText('Hello RadioItem');
+
+		expect(actual).toBeInTheDocument();
+	});
+
+	test('should render a disabled RadioItem when `disabled` is true', () => {
+		const {getByRole} = render(<RadioItemBase disabled>Hello RadioItem</RadioItemBase>);
+
+		expect(getByRole('checkbox', {disabled: true}));
+	});
+
+	test('should render a `slot before`', () => {
+		const {getByText} = render(<RadioItemBase slotBefore="arrowup">Hello RadioItem</RadioItemBase>);
+
+		const actual = getByText('arrowup');
+
+		expect(actual).toBeInTheDocument();
+	});
+
+	test('should select RadioItem with click', () => {
+		const {getAllByRole} = render(<RadioItem>Hello RadioItem</RadioItem>);
+		const radioItem = getAllByRole('checkbox');
+
+		fireEvent.click(radioItem[0]);
+
+		const expected = 'selected';
+
+		expect(radioItem[0].className).toContain(expected);
+	});
+
+	test('should not select RadioItem with click when disabled', () => {
+		const {getAllByRole} = render(<RadioItem disabled>Hello RadioItem</RadioItem>);
+		const radioItem = getAllByRole('checkbox');
+
+		fireEvent.click(radioItem[0]);
+
+		const expected = 'selected';
+
+		expect(radioItem[0].className).not.toContain(expected);
 	});
 });


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Migrated `ActionGuide` and `RadioItem` unit tests to react-testing-library

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-1351

### Comments
