### PR TITLE
WRN-1658: Fixed ContextualPopupDecorator not focusing items in ContextualPopup when spotlightRestrict is self-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/ContextualPopupDecorator` to focus elements in `ContextualPopup` when `spotlightRestrict` is `self-first`
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
 - `sandstone/Scroller` to not focus the body at the initial rendering when `focusableScrollbar` prop is `byEnter`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/ContextualPopupDecorator` to focus elements in `ContextualPopup` when `spotlightRestrict` is `self-first`
+- `sandstone/ContextualPopupDecorator` to focus elements in `ContextualPopup` when `spotlightRestrict` is `self-first` via 5way
 - `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to not go back to the previous panel by left key on popup opened inside
 - `sandstone/MediaPlayer` to work trick play via key
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -624,6 +624,19 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			Spotlight.setPointerMode(false);
 		}
 
+		getFiveWayDirection = () => {
+			const direction = this.adjustedDirection.split(' ')[0];
+
+			switch (direction) {
+				case 'below':
+					return 'down';
+				case 'above':
+					return 'up';
+				default:
+					return direction;
+			}
+		};
+
 		// handle key event from outside (i.e. the activator) to the popup container
 		handleKeyDown = (ev) => {
 			const {activator, containerId} = this.state;
@@ -635,7 +648,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			const hasSpottables = Spotlight.getSpottableDescendants(containerId).length > 0;
 			const spotlessSpotlightModal = spotlightRestrict === 'self-only' && !hasSpottables;
-			const shouldSpotPopup = current === activator && direction === this.adjustedDirection && hasSpottables;
+			const shouldSpotPopup = current === activator && direction === this.getFiveWayDirection() && hasSpottables;
 
 			if (shouldSpotPopup || spotlessSpotlightModal) {
 				this.handleDirectionalKey(ev);

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -27,6 +27,13 @@ import HolePunchScrim from './HolePunchScrim';
 
 import css from './ContextualPopupDecorator.module.less';
 
+const PositionToDirection = {
+	above: 'up',
+	below: 'down',
+	left: 'left',
+	right: 'right'
+};
+
 /**
  * Default config for {@link sandstone/ContextualPopupDecorator.ContextualPopupDecorator}
  *
@@ -624,19 +631,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			Spotlight.setPointerMode(false);
 		}
 
-		getFiveWayDirection = () => {
-			const direction = this.adjustedDirection.split(' ')[0];
-
-			switch (direction) {
-				case 'below':
-					return 'down';
-				case 'above':
-					return 'up';
-				default:
-					return direction;
-			}
-		};
-
 		// handle key event from outside (i.e. the activator) to the popup container
 		handleKeyDown = (ev) => {
 			const {activator, containerId} = this.state;
@@ -648,7 +642,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			const hasSpottables = Spotlight.getSpottableDescendants(containerId).length > 0;
 			const spotlessSpotlightModal = spotlightRestrict === 'self-only' && !hasSpottables;
-			const shouldSpotPopup = current === activator && direction === this.getFiveWayDirection() && hasSpottables;
+			const shouldSpotPopup = current === activator && direction === PositionToDirection[this.adjustedDirection.split(' ')[0]] && hasSpottables;
 
 			if (shouldSpotPopup || spotlessSpotlightModal) {
 				this.handleDirectionalKey(ev);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed `ContextualPopupDecorator` not focusing items in `ContextualPopup` with 5WaySelector when `spotlightRestrict` is `self-first` 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`ContextualPopup` prop `direction` was changed compared to moonstone. For example, `down` to `below` and `up` to `above`.

As `ContextualPopup` direction (e.g., below, above) cannot be directly compared to the key event direction (e.g., up, down, right, left), convert direction of `ContextualPopup`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-1658

### Comments
