### PR TITLE
WRN-3543: MediaControls: Fix not working trick play via key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/MediaPlayer` to work trick play via key event
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
 - `sandstone/Scroller` to not focus the body at the initial rendering when `focusableScrollbar` prop is `byEnter`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/MediaPlayer` to work trick play via key event
+- `sandstone/MediaPlayer` to work trick play via key
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
 - `sandstone/Scroller` to not focus the body at the initial rendering when `focusableScrollbar` prop is `byEnter`
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -570,8 +570,8 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 		}
 
 		componentDidMount () {
-			on('keydown', this.handleKeyDown);
-			on('keyup', this.handleKeyUp);
+			on('keydown', this.handleKeyDown, document);
+			on('keyup', this.handleKeyUp, document);
 			on('blur', this.handleBlur, window);
 			on('wheel', this.handleWheel, document);
 		}
@@ -625,8 +625,8 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 		}
 
 		componentWillUnmount () {
-			off('keydown', this.handleKeyDown);
-			off('keyup', this.handleKeyUp);
+			off('keydown', this.handleKeyDown, document);
+			off('keyup', this.handleKeyUp, document);
 			off('blur', this.handleBlur, window);
 			off('wheel', this.handleWheel, document);
 			this.stopListeningForPulses();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Not work trick play via key event. This issue occurs on snapshot build (EPK image).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `document` as event target to on() event method.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-3543

### Comments
