### PR TITLE
WRN-3473: FixedPopupPanels, PopupTabLayout: Prevent left key navigation when popup opened inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to not move to the previous panel by left key on popup
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to not go back to the previous panel by left key on popup opened inside
 - `sandstone/MediaPlayer` to work trick play via key
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
 - `sandstone/Scroller` to not focus the body at the initial rendering when `focusableScrollbar` prop is `byEnter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to not move to the previous panel by left key on popup
 - `sandstone/Scroller` and `sandstone/VirtualList` to show scroll animation properly with 5-way directional keys
 - `sandstone/Scroller` to not focus the body at the initial rendering when `focusableScrollbar` prop is `byEnter`
 

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -12,7 +12,6 @@
 import {forKey, forProp, forward, handle, stop} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
-import {getContainersForNode, getContainerNode} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import compose from 'ramda/src/compose';
 
@@ -47,7 +46,7 @@ const fixedPopupPanelsHandlers = {
 		forProp('rtl', false),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
-		({target}) => (getContainerNode(getContainersForNode(target).pop()).tagName !== 'HEADER'),
+		({target}) => (document.querySelector(`section.${css.body}`).contains(target)),
 		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forward('onBack'),
 		stop

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -381,7 +381,7 @@ const tabPanelsHandlers = {
 				ev.stopPropagation();
 				return false;
 			}
-			return true;
+			return document.querySelector(`section.${css.body}`).contains(ev.target);
 		},
 		forward('onBack'),
 		stop

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
-import {is} from '@enact/core/keymap';
+import {add, is} from '@enact/core/keymap';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
@@ -10,7 +10,9 @@ import Button from '@enact/sandstone/Button';
 import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels';
 import Dropdown from '@enact/sandstone/Dropdown';
 import Icon from '@enact/sandstone/Icon';
+import Input from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
+import Popup from '@enact/sandstone/Popup';
 import Scroller from '@enact/sandstone/Scroller';
 import Slider from '@enact/sandstone/Slider';
 import {VirtualList} from '@enact/sandstone/VirtualList';
@@ -19,9 +21,11 @@ import Pause from '@enact/spotlight/Pause';
 import {Column, Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
-import {Component, useState} from 'react';
+import {Component, useCallback, useState} from 'react';
 import compose from 'ramda/src/compose';
 
+add('cancel', 27);
+const isCancel = is('cancel');
 const Config = mergeComponentMetadata('FixedPopupPanels', FixedPopupPanels);
 Config.defaultProps.position = 'right';
 Config.defaultProps.scrimType = 'translucent';
@@ -273,6 +277,7 @@ WithScroller.parameters = {
 const WithVariousItemsSamplesBase = ({rtl}) => {
 	const defaultOpen = true;
 	const [open, setOpenState] = useState(defaultOpen);
+	const [popupOpen, setPopupOpenState] = useState(false);
 	const toggleOpen = () => setOpenState(!open);
 	const handleClose = compose(toggleOpen, action('onClose'));
 
@@ -282,6 +287,12 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 	const nextPanel = () => setPanelIndexState(Math.min(index + 1, 3));
 	const prevPanel = () => setPanelIndexState(Math.max(index - 1, 0));
 	const handleBack = compose(prevPanel, action('onBack'));
+	const handleOpenPopup = useCallback(() => {
+		setPopupOpenState(true);
+	}, [setPopupOpenState]);
+	const handleClosePopup = useCallback(() => {
+		setPopupOpenState(false);
+	}, [setPopupOpenState]);
 
 	// Navigate menus with the right key. The left key is handled by framework.
 	const handleKeyDown = (ev) => {
@@ -290,6 +301,14 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 			nextPanel();
 		}
 	};
+
+	const handleKeyUpOnPopup = useCallback((ev) => {
+		if ((isCancel(ev.keyCode)) && popupOpen) {
+			setPopupOpenState(false);
+			ev.stopPropagation();
+			ev.preventDefault();
+		}
+	}, [popupOpen, setPopupOpenState]);
 
 	return (
 		<div>
@@ -393,8 +412,12 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 							<br />
 							<Button size="small" disabled>Button2</Button>
 							<br />
-							<br />
-							<Slider />
+							<Input size="small" value="Input" noBackButton />
+							<Button onClick={handleOpenPopup} size="small">open</Button>
+							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
+								<Button onClick={handleClosePopup}>Close</Button>
+								<Button>Dummy</Button>
+							</Popup>
 							<br />
 							<br />
 						</Cell>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -24,14 +24,14 @@ import PropTypes from 'prop-types';
 import {Component, useCallback, useState} from 'react';
 import compose from 'ramda/src/compose';
 
-add('cancel', 27);
-const isCancel = is('cancel');
 const Config = mergeComponentMetadata('FixedPopupPanels', FixedPopupPanels);
 Config.defaultProps.position = 'right';
 Config.defaultProps.scrimType = 'translucent';
 Config.defaultProps.spotlightRestrict = 'self-only';
 Config.defaultProps.width = 'narrow';
 
+add('cancel', 27);
+const isCancel = is('cancel');
 const isRight = is('right');
 
 class FixedPopupPanelsWithPause extends Component {
@@ -305,8 +305,8 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 	const handleKeyUpOnPopup = useCallback((ev) => {
 		if ((isCancel(ev.keyCode)) && popupOpen) {
 			setPopupOpenState(false);
-			ev.stopPropagation();
 			ev.preventDefault();
+			ev.stopPropagation();
 		}
 	}, [popupOpen, setPopupOpenState]);
 
@@ -413,7 +413,7 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 							<Button size="small" disabled>Button2</Button>
 							<br />
 							<Input size="small" value="Input" noBackButton />
-							<Button onClick={handleOpenPopup} size="small">open</Button>
+							<Button onClick={handleOpenPopup} size="small">Open</Button>
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
 								<Button onClick={handleClosePopup}>Close</Button>
 								<Button>Dummy</Button>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -1,4 +1,4 @@
-import {is} from '@enact/core/keymap';
+import {add, is} from '@enact/core/keymap';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
@@ -8,6 +8,7 @@ import Icon from '@enact/sandstone/Icon';
 import Input from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import {Panel, Header} from '@enact/sandstone/Panels';
+import Popup from '@enact/sandstone/Popup';
 import PopupTabLayout, {Tab, TabPanels, TabPanel} from '@enact/sandstone/PopupTabLayout';
 import Scroller from '@enact/sandstone/Scroller';
 import Slider from '@enact/sandstone/Slider';
@@ -15,11 +16,13 @@ import SwitchItem from '@enact/sandstone/SwitchItem';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
 import compose from 'ramda/src/compose';
 
 PopupTabLayout.displayName = 'PopupTabLayout';
 
+add('cancel', 27);
+const isCancel = is('cancel');
 const isRight = is('right');
 
 const navPrev = (callback, value, actionName) => () => {
@@ -157,6 +160,7 @@ WithoutIcon.storyName = 'without icon';
 const WithVariousItemsSamplesBase = ({rtl}) => {
 	const defaultOpen = true;
 	const [open, setOpenState] = useState(defaultOpen);
+	const [popupOpen, setPopupOpenState] = useState(false);
 	const toggleOpen = () => setOpenState(!open);
 	const handleClose = compose(toggleOpen, action('onClose'));
 
@@ -167,6 +171,12 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 	const handleDisplayPrev = navPrev(setIndexDisplay, indexDisplay, 'onBack');
 	const handleSoundNext = navNext(setIndexSound, indexSound, 'onNext');
 	const handleSoundPrev = navPrev(setIndexSound, indexSound, 'onBack');
+	const handleOpenPopup = useCallback(() => {
+		setPopupOpenState(true);
+	}, [setPopupOpenState]);
+	const handleClosePopup = useCallback(() => {
+		setPopupOpenState(false);
+	}, [setPopupOpenState]);
 
 	// Navigate menus with the right key. The left key is handled by framework.
 	const handleKeyDown = (setState, state) => (ev) => {
@@ -176,6 +186,14 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 			navNext(setState, state, 'onNext')();
 		}
 	};
+
+	const handleKeyUpOnPopup = useCallback((ev) => {
+		if ((isCancel(ev.keyCode)) && popupOpen) {
+			setPopupOpenState(false);
+			ev.stopPropagation();
+			ev.preventDefault();
+		}
+	}, [popupOpen, setPopupOpenState]);
 
 	return (
 		<div>
@@ -237,6 +255,12 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 						<TabPanel>
 							<Header title="Advanced Audio" type="compact" />
 							<Item>Balance</Item>
+							<Input size="small" value="Input" noBackButton />
+							<Button onClick={handleOpenPopup} size="small" >open</Button>
+							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
+								<Button onClick={handleClosePopup}>Close</Button>
+								<Button>Dummy</Button>
+							</Popup>
 						</TabPanel>
 					</TabPanels>
 				</Tab>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -190,8 +190,8 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 	const handleKeyUpOnPopup = useCallback((ev) => {
 		if ((isCancel(ev.keyCode)) && popupOpen) {
 			setPopupOpenState(false);
-			ev.stopPropagation();
 			ev.preventDefault();
+			ev.stopPropagation();
 		}
 	}, [popupOpen, setPopupOpenState]);
 
@@ -256,7 +256,7 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 							<Header title="Advanced Audio" type="compact" />
 							<Item>Balance</Item>
 							<Input size="small" value="Input" noBackButton />
-							<Button onClick={handleOpenPopup} size="small" >open</Button>
+							<Button onClick={handleOpenPopup} size="small" >Open</Button>
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
 								<Button onClick={handleClosePopup}>Close</Button>
 								<Button>Dummy</Button>


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
FixedPopupPanels: onBack is called during key navigation in additional popup

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a guard for the case

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I'm not sure we need to handle cancel key on sandstone to prevent onBack.
In this PR, I just add handler on sampler side.

### Links
[//]: # (Related issues, references)
WRN-3473

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)