### PR TITLE
WRN-3709: Block wheel event in VideoPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Slider` prop `noWheelEvent` to disable wheel event handler
 
-
 ## [2.0.0-rc.5] - 2021-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Slider` prop `noWheelEvent` to disable wheel event handler
+
+
 ## [2.0.0-rc.5] - 2021-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Slider` prop `noWheelEvent` to disable wheel event handler
+- `sandstone/Slider` prop `noWheel` to disable wheel event handler
 
 ## [2.0.0-rc.5] - 2021-07-22
 

--- a/MediaPlayer/MediaSlider.js
+++ b/MediaPlayer/MediaSlider.js
@@ -85,6 +85,7 @@ const MediaSliderBase = kind({
 			<div className={className}>
 				<Slider
 					{...rest}
+					noWheelEvent
 					aria-hidden="true"
 					className={sliderClassName}
 					css={css}

--- a/MediaPlayer/MediaSlider.js
+++ b/MediaPlayer/MediaSlider.js
@@ -85,7 +85,6 @@ const MediaSliderBase = kind({
 			<div className={className}>
 				<Slider
 					{...rest}
-					noWheelEvent
 					aria-hidden="true"
 					className={sliderClassName}
 					css={css}
@@ -94,6 +93,7 @@ const MediaSliderBase = kind({
 					}
 					max={1}
 					min={0}
+					noWheel
 					step={0.00001}
 				/>
 			</div>

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -17,7 +17,7 @@
  * @exports SliderTooltip
  */
 
-import {forKey, forProp, forward, forwardWithPrevent, handle} from '@enact/core/handle';
+import {forKey, forProp, forward, forwardWithPrevent, handle, not} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import {mergeClassNameMaps} from '@enact/core/util';
 import Accelerator from '@enact/spotlight/Accelerator';
@@ -106,7 +106,7 @@ const SliderBase = (props) => {
 	const nativeEventHandlers = useHandlers({
 		onWheel: handle(
 			forProp('disabled', false),
-			forProp('noWheelEvent', false),
+			not(forProp('noWheel', true)),
 			forwardWithPrevent('onWheel'),
 			anyPass([
 				handleIncrementByWheel,
@@ -152,6 +152,7 @@ const SliderBase = (props) => {
 
 	delete rest.activateOnSelect;
 	delete rest.knobStep;
+	delete rest.noWheel;
 	delete rest.onActivate;
 	delete rest.step;
 	delete rest.tooltip;
@@ -291,7 +292,7 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	 * @type {Boolean}
 	 * @public
 	 */
-	noWheelEvent: PropTypes.bool,
+	noWheel: PropTypes.bool,
 
 	/**
 	 * The handler when the knob is activated or deactivated by selecting it via 5-way

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -286,7 +286,7 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	min: PropTypes.number,
 
 	/**
-	 * Block the wheel event.
+	 * Disable wheel event.
 	 *
 	 * @type {Boolean}
 	 * @public

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -105,8 +105,8 @@ const SliderBase = (props) => {
 
 	const nativeEventHandlers = useHandlers({
 		onWheel: handle(
-			forProp('noWheelEvent', false),
 			forProp('disabled', false),
+			forProp('noWheelEvent', false),
 			forwardWithPrevent('onWheel'),
 			anyPass([
 				handleIncrementByWheel,
@@ -284,6 +284,14 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	 * @public
 	 */
 	min: PropTypes.number,
+
+	/**
+	 * Block the wheel event.
+	 *
+	 * @type {Boolean}
+	 * @public
+	 */
+	noWheelEvent: PropTypes.bool,
 
 	/**
 	 * The handler when the knob is activated or deactivated by selecting it via 5-way

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -105,6 +105,7 @@ const SliderBase = (props) => {
 
 	const nativeEventHandlers = useHandlers({
 		onWheel: handle(
+			forProp('noWheelEvent', false),
 			forProp('disabled', false),
 			forwardWithPrevent('onWheel'),
 			anyPass([


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When scrolling wheel in video player, media list should be show up.
But in current status, try to seek media file.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Wheel event handler in Slider is accept event more higher priority than video panel.
For resolve this issue, new prop is added to slider and used in MediaSlider.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
WRN-3709

### Comments
N/A