### PR TITLE
WRN-3886: Item: Fix to update marquee when `slotAfter` or `slotBefore` changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Item` to marquee properly when `slotAfter` or `slotBefore` changed
+
 ## [2.0.0-rc.6] - 2021-08-03
 
 ### Added

--- a/Item/Item.js
+++ b/Item/Item.js
@@ -21,13 +21,23 @@ import Pure from '@enact/ui/internal/Pure';
 import compose from 'ramda/src/compose';
 import PropTypes from 'prop-types';
 
-import {Marquee, MarqueeController} from '../Marquee';
+import {MarqueeDecorator, MarqueeController} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './Item.module.less';
 
+const MarqueeBase = ({...rest}) => {
+	// eslint-disable-next-line enact/prop-types
+	delete rest.slotAfter;
+	// eslint-disable-next-line enact/prop-types
+	delete rest.slotBefore;
+
+	return <div {...rest} />;
+};
+const Marquee = MarqueeDecorator({invalidateProps: ['remeasure', 'shrink', 'slotAfter', 'slotBefore']}, MarqueeBase);
+
 // eslint-disable-next-line enact/prop-types
-const ItemContent = ({content, css, label, labelPosition, marqueeOn, ...rest}) => {
+const ItemContent = ({content, css, label, labelPosition, marqueeOn, slotAfter, slotBefore, ...rest}) => {
 	const LabelPositionClassname = {
 		[css.labelAbove]: labelPosition === 'above',
 		[css.labelAfter]: labelPosition === 'after',
@@ -38,18 +48,23 @@ const ItemContent = ({content, css, label, labelPosition, marqueeOn, ...rest}) =
 	const orientation = (labelPosition === 'above' || labelPosition === 'below') ? 'vertical' : 'horizontal';
 
 	const itemContentClasses = classnames(css.itemContent, LabelPositionClassname);
+	const marqueeProps = {
+		marqueeOn: marqueeOn,
+		slotAfter: slotAfter,
+		slotBefore: slotBefore
+	};
 
 	return (!label ? (
-		<Cell {...rest} component={Marquee} className={classnames(itemContentClasses, css.content)} marqueeOn={marqueeOn}>
+		<Cell {...rest} component={Marquee} className={classnames(itemContentClasses, css.content)} {...marqueeProps}>
 			{content}
 		</Cell>
 	) : (
 		<Cell {...rest} className={itemContentClasses}>
 			<Layout orientation={orientation}>
-				<Cell component={Marquee} className={css.content} marqueeOn={marqueeOn} shrink>
+				<Cell component={Marquee} className={css.content} {...marqueeProps} shrink>
 					{content}
 				</Cell>
-				<Cell component={Marquee} className={css.label} marqueeOn={marqueeOn} shrink>
+				<Cell component={Marquee} className={css.label} {...marqueeProps} shrink>
 					{label}
 				</Cell>
 			</Layout>
@@ -64,7 +79,6 @@ ItemContent.propTypes = {
 	label: PropTypes.any,
 	labelPosition: PropTypes.any
 };
-
 
 /**
  * A Sandstone styled item without any behavior.
@@ -238,6 +252,8 @@ const ItemBase = kind({
 					labelPosition={labelPosition}
 					marqueeOn={marqueeOn}
 					shrink={inline}
+					slotAfter={slotAfter}
+					slotBefore={slotBefore}
 				/>
 				{slotAfter ? (
 					<Cell className={css.slotAfter} shrink>
@@ -266,7 +282,7 @@ const ItemDecorator = compose(
 	UiItemDecorator,
 	Slottable({slots: ['label', 'slotAfter', 'slotBefore']}),
 	Spottable,
-	MarqueeController({marqueeOnFocus: true, invalidateProps: ['inline']}),
+	MarqueeController({marqueeOnFocus: true}),
 	Skinnable
 );
 

--- a/samples/sampler/stories/qa/Item.js
+++ b/samples/sampler/stories/qa/Item.js
@@ -7,6 +7,7 @@ import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import {Row} from '@enact/ui/Layout';
 import {scale} from '@enact/ui/resolution';
+import {useState} from 'react';
 
 import icons from '../helper/icons';
 
@@ -260,3 +261,26 @@ export const WithCustomStyle = () => (
 );
 
 WithCustomStyle.storyName = 'with custom style';
+
+export const WithChangingSlots = () => {
+	const [check, setcheck] = useState(false);
+	function handleClick () {
+		setcheck(!check);
+	}
+
+	return (
+		<div className={css.itemContainer}>
+			<Button onClick={handleClick}>Button</Button>
+			<Item
+				onClick={handleClick}
+				slotBefore={<Icon>{'soccer'}</Icon>}
+				slotAfter={check ? <Icon>{'check'}</Icon> : null}
+			>Medium Item Title</Item>
+			<Item
+				onClick={handleClick}
+				slotBefore={<Icon>{'soccer'}</Icon>}
+				slotAfter={check ? <Icon>{'check'}</Icon> : null}
+			>Medium Item Title</Item>
+		</div>
+	);
+};

--- a/samples/sampler/stories/qa/Item.module.less
+++ b/samples/sampler/stories/qa/Item.module.less
@@ -42,3 +42,8 @@
 		});
 	});
 }
+
+.itemContainer {
+	width: 920px;
+	height: 810px;
+}

--- a/samples/sampler/stories/qa/Item.module.less
+++ b/samples/sampler/stories/qa/Item.module.less
@@ -44,6 +44,6 @@
 }
 
 .itemContainer {
-	width: 918px;
+	width: 912px;
 	height: 810px;
 }

--- a/samples/sampler/stories/qa/Item.module.less
+++ b/samples/sampler/stories/qa/Item.module.less
@@ -44,6 +44,6 @@
 }
 
 .itemContainer {
-	width: 920px;
+	width: 918px;
 	height: 810px;
 }


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When changing `slotAfter` or `slotBefore` dynamically, sometimes marquee doesn't update properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The reason why this issue happens is that we don't re-calculate the distance for marquee after `slotAfter` or `slotBefore` changed.
I've added `MarqueeDecorator` to add `invalidateProps` to trigger the re-calculation of the distance for those props.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
When we implement the Item for the first time, in #5, we've changed `MarqueeDecorator` to `MarqueeController` but we didn't care about `invalidateProps` which was there for `inline`. I've also fixed it.

### Links
[//]: # (Related issues, references)
WRN-3886

### Comments
