### PR TITLE
WRN-3773: Fix 5-way navigation of list items when item's internal content is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/VirtualList` 5-way navigation between items properly when item's content is updated
+
 ## [2.0.0-rc.6] - 2021-08-03
 
 ### Added

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -31,8 +31,12 @@ const useSpottable = (props, instances) => {
 	const {noAffordance, scrollMode, snapToCenter} = props;
 	const {itemRefs, scrollContainerRef, scrollContentHandle} = instances;
 	const getItemNode = (index) => {
-		const itemNode = itemRefs.current[index % scrollContentHandle.current.state.numOfItems];
-		return (itemNode && parseInt(itemNode.dataset.index) === index) ? itemNode : null;
+		const itemContainerRef = itemRefs.current[index % scrollContentHandle.current.state.numOfItems];
+		if (itemContainerRef) {
+			const itemNode = itemContainerRef.children[0];
+			return (parseInt(itemNode.dataset.index) === index) ? itemNode : itemContainerRef.querySelector(`[data-index="${index}"]`);
+		}
+		return null;
 	};
 
 	// Mutable value

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -206,6 +206,47 @@ class VirtualListWithCBScrollTo extends Component {
 	}
 }
 
+const randomKey = () => (Math.random().toString(36).substr(2, 10));
+
+class UpdatableItem extends Component {
+	static propTypes = {
+		index: PropTypes.number
+	};
+
+	constructor (props) {
+		super(props);
+
+		this.state = {
+			key: randomKey(),
+			updated: false
+		};
+	}
+
+	componentDidMount () {
+		if (this.props.index % 3 === 1) { // Update condition
+			setTimeout(() => {
+				this.setState(() => ({
+					key: randomKey(),
+					updated: true
+				}));
+			}, 0);
+		}
+	}
+
+	render () {
+		const props = Object.assign({}, this.props);
+		const {key, updated} = this.state;
+		delete props.children;
+		delete props.index;
+
+		return (
+			<Item {...props} key={key}>
+				{this.props.children + (updated ? ' : key updated after mounting' : '')}
+			</Item>
+		);
+	}
+}
+
 export default {
 	title: 'Sandstone/VirtualList',
 	component: 'VirtualList'
@@ -433,5 +474,34 @@ export const WithContainerItemsHaveSpottableControls = () => {
 
 WithContainerItemsHaveSpottableControls.storyName = 'with container items have spottable controls';
 WithContainerItemsHaveSpottableControls.parameters = {
+	propTables: [Config]
+};
+
+export const WithUpdatableItems = () => {
+	return (
+		<VirtualList
+			overscrollEffectOn={{
+				arrowKey: false,
+				drag: false,
+				pageKey: true,
+				track: false,
+				wheel: false
+			}}
+			dataSize={updateDataSize(number('dataSize', Config, defaultDataSize))}
+			itemRenderer={renderItem(
+				UpdatableItem,
+				ri.scale(number('itemSize', Config, 156)),
+				true
+			)}
+			itemSize={ri.scale(number('itemSize', Config, 156))}
+			key={select('scrollMode', prop.scrollModeOption, Config)}
+			scrollMode={select('scrollMode', prop.scrollModeOption, Config)}
+			wrap={wrapOption[select('wrap', ['false', 'true', '"noAnimation"'], Config)]}
+		/>
+	);
+};
+
+WithUpdatableItems.storyName = 'with updatable items';
+WithUpdatableItems.parameters = {
 	propTables: [Config]
 };


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
5-way navigation to an *updated (re-rendered)* item fails when item's content is updated without updating a list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs due to an invalid DOM node info which is used to target 5-way navigation.
`enact/ui`'s logic is updated in enactjs/enact/pull/2937 to provide safe item container nodes rather than item nodes which could be invalidated by item-internal rendering, and this PR updates `VirtualList` to use the item container nodes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-3773
enactjs/enact/pull/2937

### Comments
