### PR TITLE
WRN-792: Fix testcases for latest chrome driver

### DIFF
--- a/tests/ui/specs/Popup/Popup-specs.js
+++ b/tests/ui/specs/Popup/Popup-specs.js
@@ -695,7 +695,8 @@ describe('Popup', function () {
 
 				Page.showPointerByKeycode();
 				// Position the pointer inside popup to the right of the Cancel button (step 4)
-				$('#buttonCancel').moveTo({xOffset: 200, yOffset: 200});
+				$('#popup6').moveTo({xOffset: 800, yOffset: 200});
+
 				// 5-way to the Cancel button
 				Page.spotlightLeft();
 
@@ -727,7 +728,7 @@ describe('Popup', function () {
 				// Wave the pointer to change to cursor mode (step 5)
 				Page.showPointerByKeycode();
 				// Position the pointer on the right of the Cancel button inside popup
-				$('#buttonCancel').moveTo({xOffset: 200, yOffset: 200});
+				$('#popup6').moveTo({xOffset: 800, yOffset: 200});
 
 				// Spotlight on button in popup is blur (verify step 5)
 				expect(popup.buttonOK.isFocused()).to.be.false();
@@ -909,7 +910,7 @@ describe('Popup', function () {
 				// Position the pointer inside popup to the right of the Cancel button (step 4-1).
 				$('#popup7').moveTo({xOffset: popupSize.width - 1, yOffset: popupSize.height - 1});
 				// Click on the blank area to change to 5-way.
-				browser.positionClick();
+				$('#popup7').click();
 				Page.spotlightLeft();
 				expect(popup.buttonCancel.isFocused()).to.be.true();
 

--- a/tests/ui/specs/Popup/PopupPage.js
+++ b/tests/ui/specs/Popup/PopupPage.js
@@ -98,7 +98,7 @@ class PopupPage extends Page {
 	}
 
 	clickPopupFloatLayer () {
-		$('#floatLayer').click();
+		$('#floatLayer>div').click();
 	}
 
 	clickPopupMain () {

--- a/tests/ui/specs/Scroller/ListOfThings/Scroller-GT-28390-specs.js
+++ b/tests/ui/specs/Scroller/ListOfThings/Scroller-GT-28390-specs.js
@@ -23,7 +23,7 @@ describe('Scroller List Of Things', function () {
 		expectNoFocusedItem();
 
 		// Step 5: Click item 0.
-		browser.positionClick();
+		$('#item0').click();
 		// Step 5's Verify: Spotlight is not on the 'Item 0'.
 		expectNoFocusedItem();
 	});

--- a/tests/ui/specs/Scroller/Scroller-nativeScroll-specs.js
+++ b/tests/ui/specs/Scroller/Scroller-nativeScroll-specs.js
@@ -216,27 +216,23 @@ describe('Scroller', function () {
 			ScrollerPage.spotlightDown();
 			ScrollerPage.spotlightSelect();
 			// Step 4: Click on the Left Padding area of the verticalScrollbar and below the Scroll thumb.
-			ScrollerPage.moveToScrollTrack('vertical', 'Down');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('vertical', 'Down');
 			ScrollerPage.delay(1000);
 			// Step 4-1 Verify: The Scroller scrolls Down.
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('1');
 			// Step 5: Click on the Right Padding area of the verticalScrollbar and above the Scroll thumb.
-			ScrollerPage.moveToScrollTrack('vertical', 'Up');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('vertical', 'Up');
 			ScrollerPage.delay(1000);
 			// Step 5-1 Verify: The Scroller scrolls Down.
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('0');
 			// Step 6: Click on the Top Padding area of the horizontalScrollbar and to the Right of the Scroll thumb.
 			const initialHorizontalScrollThumbPosition = ScrollerPage.getScrollThumbPosition().horizontal;
-			ScrollerPage.moveToScrollTrack('horizontal', 'Right');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('horizontal', 'Right');
 			ScrollerPage.delay(1000);
 			// Step 6-1 Verify: The Scroller scrolls Left to Right.
 			expect(ScrollerPage.getScrollThumbPosition().horizontal > initialHorizontalScrollThumbPosition).to.be.true();
 			// Step 7: Click on the Bottom Padding area of the horizontalScrollbar and to the Left of the Scroll thumb.
-			ScrollerPage.moveToScrollTrack('horizontal', 'Left');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('horizontal', 'Left');
 			ScrollerPage.delay(1000);
 			// Step 7-1 Verify: The Scroller scrolls Right to Left.
 			expect(ScrollerPage.getScrollThumbPosition().horizontal).to.equal('0');
@@ -257,18 +253,16 @@ describe('Scroller', function () {
 			// Since the visual part of UI Test cannot be checked, it is judged by the position of the scrollbar.
 			expect(ScrollerPage.getHorizontalScrollOffsetTop()).to.equal(ScrollerPage.getScrollerRect().height);
 			// Step 5: Click on the verticalScrollbar below the scroll thumb a few times until the bottom text displays.
-			for (let i; i < 3; i++) {
-				ScrollerPage.moveToScrollTrack('vertical', 'Down');
-				browser.positionClick();
+			for (let i = 0; i < 3; i++) {
+				ScrollerPage.clickScrollTrack('vertical', 'Down');
 				ScrollerPage.delay(1000);
 			}
 			// Step 5-1 Verify: The Scroller does not scroll Up.
 			// Step 5-2 Verify: The top text still displays.
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('0');
 			// Step 6: Click on the horizontalScrollbar on the left of the scroll thumb a few times (some text still displays).
-			for (let i; i < 3; i++) {
-				ScrollerPage.moveToScrollTrack('horizontal', 'Left');
-				browser.positionClick();
+			for (let i = 0; i < 3; i++) {
+				ScrollerPage.clickScrollTrack('horizontal', 'Left');
 				ScrollerPage.delay(1000);
 			}
 			// Step 6 Verify: The scroller does not scroll Left to Right.
@@ -293,14 +287,12 @@ describe('Scroller', function () {
 			// Step 4-5 Verify: Upon hover, Spotlight is on the horizontalScroll thumb.
 			expect(ScrollerPage.horizontalScrollThumb.isFocused()).to.be.true();
 			// Step 5: Click on the verticalScrollbar below the scroll thumb a few times until the bottom text displays.
-			ScrollerPage.moveToScrollTrack('vertical', 'Down');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('vertical', 'Down');
 			ScrollerPage.delay(1000);
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('1');
 			// Step 6: Click on the horizontalScrollbar on the left of the scroll thumb a few times (some text still displays).
 			const initialHorizontalScrollThumbPosition = ScrollerPage.getScrollThumbPosition().horizontal;
-			ScrollerPage.moveToScrollTrack('horizontal', 'Left');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('horizontal', 'Left');
 			ScrollerPage.delay(1000);
 			// Step 6 Verify: The scroller Scrolls Left to Right.
 			expect(ScrollerPage.getScrollThumbPosition().horizontal > initialHorizontalScrollThumbPosition).to.be.true();

--- a/tests/ui/specs/Scroller/Scroller-translateScroll-specs.js
+++ b/tests/ui/specs/Scroller/Scroller-translateScroll-specs.js
@@ -157,27 +157,22 @@ describe('Scroller', function () {
 			ScrollerPage.spotlightDown();
 			ScrollerPage.spotlightSelect();
 			// Step 4: Click on the Left Padding area of the verticalScrollbar and below the Scroll thumb.
-			ScrollerPage.moveToScrollTrack('vertical', 'Down');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('vertical', 'Down');
 			ScrollerPage.delay(1000);
 			// Step 4-1 Verify: The Scroller scrolls Down.
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('1');
 			// Step 5: Click on the Right Padding area of the verticalScrollbar and above the Scroll thumb.
-			ScrollerPage.moveToScrollTrack('vertical', 'Up');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('vertical', 'Up');
 			ScrollerPage.delay(1000);
 			// Step 5-1 Verify: The Scroller scrolls Down.
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('0');
 			// Step 6: Click on the Top Padding area of the horizontalScrollbar and to the Right of the Scroll thumb.
 			const initialHorizontalScrollThumbPosition = ScrollerPage.getScrollThumbPosition().horizontal;
-			ScrollerPage.moveToScrollTrack('horizontal', 'Right');
-			browser.positionClick();
-			ScrollerPage.delay(1000);
+			ScrollerPage.clickScrollTrack('horizontal', 'Right');
 			// Step 6-1 Verify: The Scroller scrolls Left to Right.
 			expect(ScrollerPage.getScrollThumbPosition().horizontal > initialHorizontalScrollThumbPosition).to.be.true();
 			// Step 7: Click on the Bottom Padding area of the horizontalScrollbar and to the Left of the Scroll thumb.
-			ScrollerPage.moveToScrollTrack('horizontal', 'Left');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('horizontal', 'Left');
 			ScrollerPage.delay(1000);
 			// Step 7-1 Verify: The Scroller scrolls Right to Left.
 			expect(ScrollerPage.getScrollThumbPosition().horizontal).to.equal('0');
@@ -201,8 +196,7 @@ describe('Scroller', function () {
 			expect(ScrollerPage.getHorizontalScrollOffsetTop()).to.equal(ScrollerPage.getScrollerRect().height);
 			// Step 5: Click on the verticalScrollbar below the scroll thumb a few times until the bottom text displays.
 			for (let i; i < 3; i++) {
-				ScrollerPage.moveToScrollTrack('vertical', 'Down');
-				browser.positionClick();
+				ScrollerPage.clickScrollTrack('vertical', 'Down');
 				ScrollerPage.delay(1000);
 			}
 			// Step 5-1 Verify: The Scroller does not scroll Up.
@@ -210,8 +204,7 @@ describe('Scroller', function () {
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('0');
 			// Step 6: Click on the horizontalScrollbar on the left of the scroll thumb a few times (some text still displays).
 			for (let i; i < 3; i++) {
-				ScrollerPage.moveToScrollTrack('horizontal', 'Left');
-				browser.positionClick();
+				ScrollerPage.clickScrollTrack('horizontal', 'Left');
 				ScrollerPage.delay(1000);
 			}
 			// Step 6 Verify: The scroller does not scroll Left to Right.
@@ -236,15 +229,13 @@ describe('Scroller', function () {
 			// Step 4-5 Verify: Upon hover, Spotlight is on the horizontalScroll thumb.
 			expect(ScrollerPage.horizontalScrollThumb.isFocused()).to.be.true();
 			// Step 5: Click on the verticalScrollbar below the scroll thumb a few times until the bottom text displays.
-			ScrollerPage.moveToScrollTrack('vertical', 'Down');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('vertical', 'Down');
 			ScrollerPage.delay(1000);
 			// Step 5 Verify: The Scroller Scrolls Up.
 			expect(ScrollerPage.getScrollThumbPosition().vertical).to.equal('1');
 			// Step 6: Click on the horizontalScrollbar on the left of the scroll thumb a few times (some text still displays).
 			const initialHorizontalScrollThumbPosition = ScrollerPage.getScrollThumbPosition().horizontal;
-			ScrollerPage.moveToScrollTrack('horizontal', 'Left');
-			browser.positionClick();
+			ScrollerPage.clickScrollTrack('horizontal', 'Left');
 			ScrollerPage.delay(1000);
 			// Step 6 Verify: The scroller Scrolls Left to Right.
 			expect(ScrollerPage.getScrollThumbPosition().horizontal > initialHorizontalScrollThumbPosition).to.be.true();

--- a/tests/ui/specs/Scroller/ScrollerPage.js
+++ b/tests/ui/specs/Scroller/ScrollerPage.js
@@ -119,6 +119,17 @@ class ScrollerPage extends Page {
 			$(`${horizontalscrollbarSelector}`).moveTo({xOffset: Math.round(horizontalScroll), yOffset: 0});
 		}
 	}
+
+	clickScrollTrack (direction, way) {
+		if (direction === 'vertical') {
+			const clickPositionFromCenter = way === 'Down' ? 300 : -300;
+			$(`${verticalscrollbarSelector}`).click({y: clickPositionFromCenter});
+		} else if (direction === 'horizontal') {
+			const clickPositionFromCenter = way === 'Left' ? -500 : 500;
+			$(`${horizontalscrollbarSelector}`).click({x: clickPositionFromCenter});
+		}
+	}
+
 	getVerticalScrollOffsetLeft () {
 		return browser.execute(function (_verticalscrollbarSelector) {
 			const verticalscrollbar = document.querySelector(_verticalscrollbarSelector);

--- a/tests/ui/specs/VirtualList/VirtualGridList/ScrollTo/VirtualGridListScrollTo-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/ScrollTo/VirtualGridListScrollTo-specs.js
@@ -18,7 +18,7 @@ describe('Focus after calling scrollTo()', function () {
 		Page.showPointerByKeycode();
 		Page.item(20).moveTo();
 		// Step 3: Click 'Click me' item.
-		browser.positionClick();
+		Page.item(20).click();
 		Page.delay(500);
 		// Step 3-1 Verify: list is scrolled to first item.
 		expect(Page.topLeftVisibleItemId()).to.equal('item0');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When we use latest chrome driver not 2.44, some test cases are failed due to api change.

1.
element not interactable: element has zero size
[chrome 87.0.4280.141 linux #0-15]   (Session info: headless chrome=87.0.4280.141)
[chrome 87.0.4280.141 linux #0-15]     at processTicksAndRejections (internal/process/task_queues.js:97:5)
[chrome 87.0.4280.141 linux #0-15]     at Element.<anonymous> (/home/jenkins/workspace/enact-ui-tests/ui-test-utils/node_modules/@wdio/utils/build/shim.js:219:24)
[chrome 87.0.4280.141 linux #0-15]     at PopupPage.clickPopupFloatLayer (/home/jenkins/workspace/enact-ui-tests/sandstone/tests/ui/specs/Popup/PopupPage.js:101:20)
[chrome 87.0.4280.141 linux #0-15]     at Context.<anonymous> (/home/jenkins/workspace/enact-ui-tests/sandstone/tests/ui/specs/Popup/Popup-specs.js:276:10)
[chrome 87.0.4280.141 linux #0-15]

2.
move target out of bounds
  (Session info: headless chrome=87.0.4280.141)
[chrome 87.0.4280.141 linux #0-15] move target out of bounds
[chrome 87.0.4280.141 linux #0-15]   (Session info: headless chrome=87.0.4280.141)
[chrome 87.0.4280.141 linux #0-15]     at runMicrotasks (<anonymous>)
[chrome 87.0.4280.141 linux #0-15]     at processTicksAndRejections (internal/process/task_queues.js:97:5)
[chrome 87.0.4280.141 linux #0-15]     at Element.<anonymous> (/home/jenkins/workspace/enact-ui-tests/ui-test-utils/node_modules/@wdio/utils/build/shim.js:219:24)
[chrome 87.0.4280.141 linux #0-15]     at Context.<anonymous> (/home/jenkins/workspace/enact-ui-tests/sandstone/tests/ui/specs/Popup/Popup-specs.js:730:24)

3.
browser.positionClick is not a function
[chrome 87.0.4280.141 linux #0-15] TypeError: browser.positionClick is not a function
[chrome 87.0.4280.141 linux #0-15]     at Context.<anonymous> (/home/jenkins/workspace/enact-ui-tests/sandstone/tests/ui/specs/Popup/Popup-specs.js:912:13)
[chrome 87.0.4280.141 linux #0-15]

-> https://github.com/webdriverio/webdriverio/issues/4171#issuecomment-510153142

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
WRN-792

### Links
[//]: # (Related issues, references)


### Comments
