### PR TITLE
WRN-5464: Fixed Scroller to move focus via up/down keys from scroll thumb when the content is short but the scrollbar is visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to move focus via up/down keys from scroll thumb when the content is short but the scrollbar is visible
+
 ## [2.0.0-rc.7] - 2021-08-09
 
 ### Fixed

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -278,26 +278,29 @@ export const WithSpottableComponents = () => (
 WithSpottableComponents.storyName = 'With Spottable Components';
 
 export const WithShortContents = () => (
-	<Scroller
-		direction={select('direction', prop.direction, Config)}
-		focusableScrollbar={
-			prop.focusableScrollbarOption[
-				select('focusableScrollbar', ['false', 'true', '"byEnter"'], Config)
-			]
-		}
-		horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
-		key={select('scrollMode', prop.scrollModeOption, Config)}
-		noScrollByWheel={boolean('noScrollByWheel', Config)}
-		onKeyDown={action('onKeyDown')}
-		onScrollStart={action('onScrollStart')}
-		onScrollStop={action('onScrollStop')}
-		scrollMode={select('scrollMode', prop.scrollModeOption, Config)}
-		spotlightDisabled={boolean('spotlightDisabled', Config, false)}
-		style={{height: ri.scaleToRem(600)}}
-		verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
-	>
-		Text
-	</Scroller>
+	<>
+		<Scroller
+			direction={select('direction', prop.direction, Config)}
+			focusableScrollbar={
+				prop.focusableScrollbarOption[
+					select('focusableScrollbar', ['false', 'true', '"byEnter"'], Config)
+				]
+			}
+			horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, Config)}
+			key={select('scrollMode', prop.scrollModeOption, Config)}
+			noScrollByWheel={boolean('noScrollByWheel', Config)}
+			onKeyDown={action('onKeyDown')}
+			onScrollStart={action('onScrollStart')}
+			onScrollStop={action('onScrollStop')}
+			scrollMode={select('scrollMode', prop.scrollModeOption, Config)}
+			spotlightDisabled={boolean('spotlightDisabled', Config, false)}
+			style={{height: ri.scaleToRem(600)}}
+			verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, Config)}
+		>
+			Text
+		</Scroller>
+		<Button>Button</Button>
+	</>
 );
 
 WithShortContents.storyName = 'With short contents';

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -83,7 +83,7 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 					);
 				}
 
-				if (ev.repeat || (scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0)) {
+				if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
 					consumeEventWithScroll(scrollParam, ev);
 				}
 			}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the Scroller has short content and the scrollbar is visible, the focus is not moving via up down key from the scroll thumb. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When the content is short, the `--scrollbar-thumb-progress-ratio` is NaN since the client size and scrollable size is the same.
We didn't care about this case when we move the focus from scroll thumb. I've added a guard to care about this case.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-5464

### Comments
