### PR TITLE
WRN-5513: TimePicker: Fixed abnormal minute animation in some locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/TimePicker` abnormal minute animation in some locales
+
 ## [2.0.0-rc.7] - 2021-08-09
 
 ### Fixed

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -265,7 +265,7 @@ const RangePickerBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'rangePicker',
-		publicClassNames: ['inlineTitle', 'title']
+		publicClassNames: ['inlineTitle', 'sizingPlaceholder', 'title']
 	},
 
 	computed: {

--- a/RangePicker/RangePicker.module.less
+++ b/RangePicker/RangePicker.module.less
@@ -28,3 +28,7 @@
 		margin-bottom: 0;
 	}
 }
+
+.sizingPlaceholder {
+	/* Public Class Names */
+}

--- a/TimePicker/TimePicker.module.less
+++ b/TimePicker/TimePicker.module.less
@@ -34,3 +34,7 @@
 		});
 	}
 }
+
+.sizingPlaceholder {
+	min-width: @sand-timepicker-sizing-placeholder-min-width;
+}

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -364,6 +364,7 @@ const TimePickerBase = kind({
 									accessibilityHint={minuteAccessibilityHint}
 									aria-label={minuteAriaLabel}
 									className={css.minutePicker}
+									css={css}
 									data-last-element={isLastElement}
 									data-webos-voice-disabled={voiceDisabled}
 									data-webos-voice-group-label={minuteAccessibilityHint}

--- a/internal/DateComponentPicker/DateComponentPicker.module.less
+++ b/internal/DateComponentPicker/DateComponentPicker.module.less
@@ -16,3 +16,7 @@
 		white-space: nowrap;
 	}
 }
+
+.sizingPlaceholder {
+	/* Public Class Names */
+}

--- a/internal/DateComponentPicker/DateComponentRangePicker.js
+++ b/internal/DateComponentPicker/DateComponentRangePicker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import RangePicker from '../../RangePicker';
 
-import css from './DateComponentPicker.module.less';
+import componentCss from './DateComponentPicker.module.less';
 
 /**
  * {@link sandstone/internal/DataComponentPicker.DateComponentRangePicker} allows the selection of
@@ -52,6 +52,19 @@ const DateComponentRangePickerBase = kind({
 		accessibilityHint: PropTypes.string,
 
 		/**
+		 * Customizes the component by mapping the supplied collection of CSS class names to the
+		 * corresponding internal elements and states of this component.
+		 *
+		 * The following classes are supported:
+		 *
+		 * * `sizingPlaceholder` - The sizing placeholder class
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		css: PropTypes.object,
+
+		/**
 		 * The label to display below the picker
 		 *
 		 * @type {String}
@@ -78,8 +91,9 @@ const DateComponentRangePickerBase = kind({
 	},
 
 	styles: {
-		css,
-		className: 'dateComponentPicker'
+		css: componentCss,
+		className: 'dateComponentPicker',
+		publicClassNames: ['sizingPlaceholder']
 	},
 
 	computed: {
@@ -88,10 +102,11 @@ const DateComponentRangePickerBase = kind({
 		}
 	},
 
-	render: ({accessibilityHint, label, max, min, noAnimation, value, wrap, voiceLabel, ...rest}) => (
+	render: ({accessibilityHint, css, label, max, min, noAnimation, value, wrap, voiceLabel, ...rest}) => (
 		<RangePicker
 			{...rest}
 			accessibilityHint={(accessibilityHint == null) ? label : accessibilityHint}
+			css={css}
 			data-webos-voice-labels-ext={voiceLabel}
 			joined
 			max={max}

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -71,7 +71,7 @@ const forwardBlur = forward('onBlur'),
 	forwardKeyUp = forward('onKeyUp'),
 	forwardWheel = forward('onWheel');
 
-const allowedClassNames = ['picker', 'valueWrapper', 'joined', 'horizontal', 'vertical'];
+const allowedClassNames = ['picker', 'valueWrapper', 'joined', 'horizontal', 'vertical', 'sizingPlaceholder'];
 
 /**
  * The base component for {@link sandstone/internal/Picker.Picker}.

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -227,6 +227,7 @@
 // Date and Time Picker
 @sand-datecomponentpicker-margin: 24px;
 @sand-timepicker-colon-margin: 0 6px;
+@sand-timepicker-sizing-placeholder-min-width: 132px;
 
 // Heading
 @sand-heading-line-height: @sand-common-line-height;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Minute picker's animation looks weird in some locales(e.g. ko-KR, ar-SA,...)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We display pickers in Timepicker with flex and in some locales, the start position would have decimal points since we determine the width of the pickers by the number of '0'.
It seems like an issue with blink but we couldn't make a pure HTML example that reproduces the issue.
Meanwhile, we've found that if we make the picker's width integer value, the animation seems ok.
So I've added min-width to sizingPlaceholder.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-5513

### Comments
