### PR TITLE
WRN-2730: QA-Sampler: Fix the title is the same as the story name

### DIFF
--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -155,6 +155,8 @@ const StorybookDecorator = (story, config = {}) => {
 		groupId: 'Development'
 	};
 
+	const componentName = config.kind.replace(/^([^\/]+)\//, '');
+
 	// NOTE: 'config' object is not extensible.
 	const hasInfoText = config.parameters && config.parameters.info && config.parameters.info.text;
 	const hasProps = config.parameters && config.parameters.props;
@@ -178,7 +180,7 @@ const StorybookDecorator = (story, config = {}) => {
 	return (
 		<Theme
 			className={classnames(classes)}
-			title={`${config.kind}`.replace(/\//g, ' ').trim()}
+			title={componentName === config.name ? `Sandstone ${componentName}` : `${componentName} ${config.name}`}
 			description={hasInfoText ? config.parameters.info.text : null}
 			locale={globals.locale}
 			textSize={globals.largeText ? 'large' : 'normal'}

--- a/tests/screenshot/apps/components/Slider.js
+++ b/tests/screenshot/apps/components/Slider.js
@@ -2,11 +2,12 @@ import Slider, {SliderTooltip as Tooltip} from '../../../../Slider';
 
 import css from './Slider.module.less';
 
-// TODO: RTL, different min/max with visible tooltip
-
 const SliderTests = [
 	<Slider />,
+	<Slider disabled />,
+	<Slider min={0} max={20} progressAnchor={0.4} />,
 	<Slider value={50} />,
+	<Slider value={50} noFill />,
 	<Slider value={50} showAnchor />,
 	<Slider value={100} />,
 	<Slider backgroundProgress={0.5} />,
@@ -46,8 +47,7 @@ const SliderTests = [
 
 	// *************************************************************
 	// tooltip - all positions
-	// NOTE: Tooltip won't show on slider without focus.  Nothing should show!
-	// TODO: Add focus support
+	// NOTE: Tooltip won't show on slider without focus. Nothing should show!
 	// *************************************************************
 	{
 		component: <Slider tooltip percent value={50} />,
@@ -58,6 +58,13 @@ const SliderTests = [
 	},
 	{
 		component: <Slider tooltip min={-60.0} max={60.0} step={0.5} value={4.5} />,
+		wrapper: {
+			padded: true
+		},
+		focus: true
+	},
+	{
+		component: <Slider tooltip min={0} max={100} step={5} value={20} focused />,
 		wrapper: {
 			padded: true
 		},
@@ -204,12 +211,50 @@ const SliderTests = [
 		},
 		focus: true
 	},
-	// *************************************************************
-	// locale = 'ar-SA'
-	// *************************************************************
+	// RTL
 	{
 		locale: 'ar-SA',
-		component: <Slider value={40} backgroundProgress={0.5} />
+		component: <Slider />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider disabled />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider min={0} max={20} progressAnchor={0.4} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider value={60} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider value={60} noFill />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider progressAnchor={0.7} value={60} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider progressAnchor={0.6} value={60} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider progressAnchor={0.4} value={60} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider backgroundProgress={0.5} value={40} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider backgroundProgress={0.25} value={75} progressAnchor={0.5} />
+	},
+	{
+		locale: 'ar-SA',
+		component: <Slider disabled backgroundProgress={0.25} value={50} />
 	}
 ];
 export default SliderTests;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Before migrating storybook 6.x, the title of each sample was the same as its story name.
There seems to be a bug when migrating the storybook.


### Resolution
Make the title of each sample the same as the story name.


### Additional Considerations


### Links
WRN-2730


### Comments
