### PR TITLE
WRN-5836: Alert: Remove display `block` from the root node

### DIFF
--- a/Alert/Alert.js
+++ b/Alert/Alert.js
@@ -186,7 +186,7 @@ const AlertBase = kind({
 		const showTitle = (fullscreen && title);
 		const ariaLabelledBy = (showTitle ? `${id}_title ` : '') + `${id}_content ${id}_buttons`;
 		return (
-			<div aria-owns={id}>
+			<div aria-owns={id} className={css.alertWrapper}>
 				<Popup
 					{...rest}
 					id={id}

--- a/Alert/Alert.module.less
+++ b/Alert/Alert.module.less
@@ -4,6 +4,10 @@
 @import "../styles/variables.less";
 @import "../styles/skin.less";
 
+.alertWrapper {
+	display: inline;
+}
+
 .alert {
 
 	&.noImage { /* Needed to prevent global class being added in the DOM */ }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Alert` to remove default display `block` from the wrapper `div`
 - `sandstone/Dropdown` to restore focus within the list when moving mouse after clicking dropdown button
 - `sandstone/Scroller` to move focus via up/down keys from scroll thumb when the content is short but the scrollbar is visible
 - `sandstone/TimePicker` abnormal minute animation in some locales

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
-## [unreleased]
-
-### Fixed
-
-- `sandstone/Alert` to remove default display `block` from the wrapper `div`
-
 ## [2.0.0-rc.8] - 2021-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
-## [2.0.0-rc.8] - 2021-08-31
+## [unreleased]
 
 ### Fixed
 
 - `sandstone/Alert` to remove default display `block` from the wrapper `div`
+
+## [2.0.0-rc.8] - 2021-08-31
+
+### Fixed
+
 - `sandstone/Dropdown` to restore focus within the list when moving mouse after clicking dropdown button
 - `sandstone/Scroller` to move focus via up/down keys from scroll thumb when the content is short but the scrollbar is visible
 - `sandstone/TimePicker` abnormal minute animation in some locales


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Alert root `div` node has a default display `block` which can affect the app layout breaking.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apply display `inline` instead.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-5836

### Comments

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>

