### PR TITLE
WRN-6634: Fixed background color of overlayed Alert when high contrast mode

### DIFF
--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -15,8 +15,8 @@ const defaultConfig = {
 		light: 'light',
 		custom: 'custom'
 	},
-	defaultVariants: ['highContrast'],
-	allowedVariants: ['highContrast', 'largeText', 'grayscale']
+	allowedVariants: ['highContrast', 'largeText', 'grayscale'],
+	defaultVariants: null
 };
 
 /**

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -282,7 +282,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		render () {
 			const {skin: skinProp, ...rest} = this.props;
 			const skinName = skinProp || typeof window === 'object' && window.CUSTOM_SKIN || 'neutral';
-			const className = classNames(css.root, this.props.className, 'sandstone-theme', skinName, 'enact-unselectable', {
+			const className = classNames(css.root, this.props.className, 'sandstone-theme', 'enact-unselectable', {
 				[bgClassName]: !float,
 				'enact-fit': !disableFullscreen
 			});

--- a/styles/skin.less
+++ b/styles/skin.less
@@ -7,14 +7,14 @@
 	@import "./color-mixins.less";
 
 	// Neutral Skin
-	:global(.neutral) & {
+	&:global(.neutral) {
 		// Load the sandstone neutral rules into this scope
 		@import (multiple) "./colors.less";
 
 		@componentRules();
 
 		// High Contrast Variant
-		:global(.enact-a11y-high-contrast):global(.highContrast)& {
+		:global(.enact-a11y-high-contrast) &:global(.highContrast) {
 			@import "./colors-highcontrast.less";
 
 			@componentRules();
@@ -22,7 +22,7 @@
 	}
 
 	// Light Skin
-	:global(.light) & {
+	&:global(.light) {
 		@import (multiple) "./colors.less";
 		@import "./colors-light.less";
 
@@ -30,7 +30,7 @@
 	}
 
 	// Custom Skin
-	:global(.custom) & {
+	&:global(.custom) {
 		@import (multiple) "./colors.less";
 		@import "./colors-custom.less";
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A background color of overlayed Alert when high contrast mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Removed unintended class 'highContrast' from app root
- Removed unnecessary class on app root since it will be added by Skinnable
- Restored applySkins() mixin code to apply high contrast mode

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-6634

### Comments
