### PR TITLE
WRN-6815: Fixed VirtualList to not focus the item again if focus moved out of the list via 5way when `snapToCenter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/VirtualList` to not focus to the item again if focus moved out of the list via 5way when `snapToCenter`
+- `sandstone/VirtualList` to not focus the item again if focus moved out of the list via 5way when `snapToCenter`
 
 ## [2.0.0-rc.8] - 2021-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/VirtualList` to not focus to the item again if focus moved out of the list via 5way when `snapToCenter`
+
 ## [2.0.0-rc.8] - 2021-08-31
 
 ### Fixed

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -235,7 +235,7 @@ const useSpottable = (props, instances) => {
 			pause.resume();
 			if (utilDOM.containsDangerously(itemNode, candidate)) {
 				returnVal = focusOnNode(candidate);
-			} else {
+			} else if (!mutableRef.current.isScrollingBySnapToCenter || props.scrollContainerContainsDangerously(current)) {
 				returnVal = focusOnNode(itemNode);
 			}
 			mutableRef.current.isScrolledBy5way = false;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualList is focusing the item again if focus moved out of the list via 5way quickly when `snapToCenter`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a guard that checks if scrolling is ongoing and the current focus is in the list. If not, the list will not focus again.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-6815

### Comments
