### PR TITLE
WRN-797: Create a sample to test spotlight/Spottable: Prevent re-render on focus change

### DIFF
--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -4,6 +4,7 @@ import Spotlight from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Spottable from '@enact/spotlight/Spottable';
+import Skinnable from '@enact/sandstone/Skinnable';
 import Button from '@enact/sandstone/Button';
 import CheckboxItem from '@enact/sandstone/CheckboxItem';
 import DatePicker from '@enact/sandstone/DatePicker';
@@ -299,7 +300,7 @@ const SimpleDiv = () => {
 	return <div>Spottable Component</div>
 };
 
-const SpottableItem = Spottable('div');
+const SpottableItem = Spottable(Skinnable('div'));
 export const CheckRerender = () => (
 	<div>
 		<p>

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -3,6 +3,7 @@ import {boolean, select} from '@enact/storybook-utils/addons/knobs';
 import Spotlight from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import Spottable from '@enact/spotlight/Spottable';
 import Button from '@enact/sandstone/Button';
 import CheckboxItem from '@enact/sandstone/CheckboxItem';
 import DatePicker from '@enact/sandstone/DatePicker';
@@ -23,6 +24,8 @@ import PropTypes from 'prop-types';
 import {Component, cloneElement} from 'react';
 
 import docs from '../../images/icon-enact-docs.png';
+import css from './Spotlight.module.less';
+
 
 const Container = SpotlightContainerDecorator({enterTo: 'last-focused'}, 'div');
 
@@ -304,6 +307,32 @@ export const MultipleButtons = () => (
 		</Cell>
 	</Row>
 );
+
+const SimpleDiv = () => {
+        action('Render')();
+        return <h1 className={css.bgColor}>Hello</h1>
+};
+
+const SpottableComponent = Spottable('div');
+export const CheckRerender = () => (
+	<div>
+		<p>
+			A spottable component must not be re-rendered when a focus change occurs.
+			So 'Render' action message must be displayed only once when it is first loaded.
+		</p>
+		<Row align="center space-evenly">
+			<SpottableComponent onSpotlightDown={action('onSpotlightDown')}
+				onSpotlightLeft={action('onSpotlightLeft')}
+				onSpotlightRight={action('onSpotlightRight')}
+				onSpotlightUp={action('onSpotlightUp')}
+			>
+				<SimpleDiv />
+			</SpottableComponent>
+		</Row>
+	</div>
+);
+
+CheckRerender.storyName = 'Check Re-render';
 
 export const MultipleContainers = () => (
 	<Scroller>

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -297,7 +297,7 @@ export default {
 
 const SimpleDiv = () => {
 	action('Render')(true);
-	return <div>Spottable Component</div>
+	return <div>Spottable Component</div>;
 };
 
 const SpottableItem = Spottable(Skinnable('div'));
@@ -305,7 +305,7 @@ export const CheckRerender = () => (
 	<div>
 		<p>
 			A spottable component must not be re-rendered when a focus change occurs.
-			So the message 'Render' in the Actions tab should be displayed only once when it is first loaded.
+			So the message of the Actions tab(&apos;Render: true&apos;) should be displayed only once when it is first loaded.
 		</p>
 		<Row align="center space-evenly">
 			<SpottableItem className={css.spottableitem}>

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -301,11 +301,12 @@ const SimpleDiv = () => {
 };
 
 const SpottableItem = Spottable(Skinnable('div'));
+
 export const CheckRerender = () => (
 	<div>
 		<p>
 			A spottable component must not be re-rendered when a focus change occurs.
-			So the message of the Actions tab(&apos;Render: true&apos;) should be displayed only once when it is first loaded.
+			So the message of the Actions tab(&apos;Render: true&apos;) should be displayed only once.
 		</p>
 		<Row align="center space-evenly">
 			<SpottableItem className={css.spottableitem}>

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -294,6 +294,28 @@ export default {
 	component: 'Spotlight'
 };
 
+const SimpleDiv = () => {
+	action('Render')();
+	return <div>Spottable Component</div>
+};
+
+const SpottableComponent = Spottable('div');
+export const CheckRerender = () => (
+	<div>
+		<p>
+			A spottable component must not be re-rendered when a focus change occurs.
+			So 'Render' action message must be displayed only once when it is first loaded.
+		</p>
+		<Row align="center space-evenly">
+			<SpottableComponent className={css.spottablediv}>
+				<SimpleDiv />
+			</SpottableComponent>
+		</Row>
+	</div>
+);
+
+CheckRerender.storyName = 'Check Re-render';
+
 export const MultipleButtons = () => (
 	<Row align="center space-evenly">
 		<Cell shrink>
@@ -307,32 +329,6 @@ export const MultipleButtons = () => (
 		</Cell>
 	</Row>
 );
-
-const SimpleDiv = () => {
-        action('Render')();
-        return <h1 className={css.bgColor}>Hello</h1>
-};
-
-const SpottableComponent = Spottable('div');
-export const CheckRerender = () => (
-	<div>
-		<p>
-			A spottable component must not be re-rendered when a focus change occurs.
-			So 'Render' action message must be displayed only once when it is first loaded.
-		</p>
-		<Row align="center space-evenly">
-			<SpottableComponent onSpotlightDown={action('onSpotlightDown')}
-				onSpotlightLeft={action('onSpotlightLeft')}
-				onSpotlightRight={action('onSpotlightRight')}
-				onSpotlightUp={action('onSpotlightUp')}
-			>
-				<SimpleDiv />
-			</SpottableComponent>
-		</Row>
-	</div>
-);
-
-CheckRerender.storyName = 'Check Re-render';
 
 export const MultipleContainers = () => (
 	<Scroller>

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -295,21 +295,21 @@ export default {
 };
 
 const SimpleDiv = () => {
-	action('Render')();
+	action('Render')(true);
 	return <div>Spottable Component</div>
 };
 
-const SpottableComponent = Spottable('div');
+const SpottableItem = Spottable('div');
 export const CheckRerender = () => (
 	<div>
 		<p>
 			A spottable component must not be re-rendered when a focus change occurs.
-			So 'Render' action message must be displayed only once when it is first loaded.
+			So the message 'Render' in the Actions tab should be displayed only once when it is first loaded.
 		</p>
 		<Row align="center space-evenly">
-			<SpottableComponent className={css.spottablediv}>
+			<SpottableItem className={css.spottableitem}>
 				<SimpleDiv />
-			</SpottableComponent>
+			</SpottableItem>
 		</Row>
 	</div>
 );

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -4,7 +4,6 @@ import Spotlight from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Spottable from '@enact/spotlight/Spottable';
-import Skinnable from '@enact/sandstone/Skinnable';
 import Button from '@enact/sandstone/Button';
 import CheckboxItem from '@enact/sandstone/CheckboxItem';
 import DatePicker from '@enact/sandstone/DatePicker';
@@ -15,6 +14,7 @@ import Item from '@enact/sandstone/Item';
 import Picker from '@enact/sandstone/Picker';
 import Popup from '@enact/sandstone/Popup';
 import RadioItem from '@enact/sandstone/RadioItem';
+import Skinnable from '@enact/sandstone/Skinnable';
 import SwitchItem from '@enact/sandstone/SwitchItem';
 import TimePicker from '@enact/sandstone/TimePicker';
 import Scroller from '@enact/sandstone/Scroller';
@@ -24,9 +24,9 @@ import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {Component, cloneElement} from 'react';
 
-import docs from '../../images/icon-enact-docs.png';
 import css from './Spotlight.module.less';
 
+import docs from '../../images/icon-enact-docs.png';
 
 const Container = SpotlightContainerDecorator({enterTo: 'last-focused'}, 'div');
 

--- a/samples/sampler/stories/qa/Spotlight.module.less
+++ b/samples/sampler/stories/qa/Spotlight.module.less
@@ -1,10 +1,12 @@
-@import "~@enact/sandstone/styles/mixins.less";
+@import "~@enact/sandstone/styles/skin.less";
 
 .spottableitem {
-	background-color: transparent;
-	color: #e6e6e6;
-	.focus({
-		background-color:  #e6e6e6;
-		color: #4c5059;
+	.applySkins({
+		background-color: transparent;
+		color: @sand-text-color;
+		.focus({
+			background-color: @sand-spotlight-bg-color;
+			color: @sand-spotlight-text-color;
+		});
 	});
 }

--- a/samples/sampler/stories/qa/Spotlight.module.less
+++ b/samples/sampler/stories/qa/Spotlight.module.less
@@ -1,0 +1,9 @@
+.bgColor {
+	background-color: rgb(255, 0, 0);
+}
+.bgColor.spottable:focus {
+	background-color: rgb(0, 0, 255);
+}
+.bgColor:hover {
+	background-color: rgb(0, 255, 0);
+}

--- a/samples/sampler/stories/qa/Spotlight.module.less
+++ b/samples/sampler/stories/qa/Spotlight.module.less
@@ -1,9 +1,6 @@
 @import "~@enact/sandstone/styles/mixins.less";
 
-.spottablediv {
-	display: inline-block;
-	padding: 24px;
-	text-align: center;
+.spottableitem {
 	background-color: transparent;
 	color: #e6e6e6;
 	.focus({

--- a/samples/sampler/stories/qa/Spotlight.module.less
+++ b/samples/sampler/stories/qa/Spotlight.module.less
@@ -1,9 +1,13 @@
-.bgColor {
-	background-color: rgb(255, 0, 0);
-}
-.bgColor.spottable:focus {
-	background-color: rgb(0, 0, 255);
-}
-.bgColor:hover {
-	background-color: rgb(0, 255, 0);
+@import "~@enact/sandstone/styles/mixins.less";
+
+.spottablediv {
+	display: inline-block;
+	padding: 24px;
+	text-align: center;
+	background-color: transparent;
+	color: #e6e6e6;
+	.focus({
+		background-color:  #e6e6e6;
+		color: #4c5059;
+	});
 }


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Need to test to check whether the Spottable component is re-rendered when the focus is changed .

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a qa-sample for checking re-render of Spottable component on focus change.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-797

### Comments