### PR TITLE
WRN-8227: change light skink progressbar color for visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Changed
 
-- `sandstone/ProgressBar` bar color for light skin
+- `sandstone/ProgressBar` bar color for `sandstone/Alert`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Icon` supported icon list, adding a new icon `spanner`
 
+### Changed
+
+- `sandstone/ProgressBar` bar color for light skin
+
 ### Fixed
 
 - `sandstone/VirtualList` to not move focus to an unexpected item when 5-way directional key hold

--- a/ProgressBar/ProgressBar.module.less
+++ b/ProgressBar/ProgressBar.module.less
@@ -121,7 +121,7 @@
 
 		&.showAnchor {
 			&::after {
-				background-color: @sand-progressbar-bar-bg-color;
+				background-color: @sand-progressbar-bg-color;
 			}
 		}
 	});

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -271,7 +271,7 @@
 		&.showAnchor {
 			.progressBar {
 				&::after {
-					background-color: @sand-progressbar-bar-bg-color;
+					background-color: @sand-progressbar-bg-color;
 				}
 			}
 		}

--- a/styles/colors-light.less
+++ b/styles/colors-light.less
@@ -53,6 +53,7 @@
 
 // ProgressBar
 // ---------------------------------------
-@sand-progressbar-bar-bg-color: #a1a1a1;
+@sand-progressbar-bg-color: #a1a1a1;
+@sand-progressbar-bar-bg-color: fade(@sand-progressbar-bg-color, 40%);
 @sand-progressbar-load-bg-color: fade(#373a41, 30%);
 @sand-progressbar-fill-bg-color: #373a41;

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -232,7 +232,8 @@
 
 // ProgressBar
 // ---------------------------------------
-@sand-progressbar-bar-bg-color: #373A41;
+@sand-progressbar-bg-color: #373A41;
+@sand-progressbar-bar-bg-color: @sand-progressbar-bg-color;
 @sand-progressbar-load-bg-color: fade(@sand-light-gray, 30%);
 @sand-progressbar-fill-bg-color: @sand-spotlight-bg-color;
 @sand-progressbar-highlighted-fill-bg-color: @sand-white;
@@ -281,7 +282,7 @@
 
 // Slider
 // ---------------------------------------
-@sand-slider-bar-bg-color: @sand-progressbar-bar-bg-color;
+@sand-slider-bar-bg-color: @sand-progressbar-bg-color;
 @sand-slider-fill-bg-color: #8d9298;
 @sand-slider-load-bg-color: @sand-progressbar-load-bg-color;
 @sand-slider-knob-bg-color: @sand-slider-fill-bg-color;

--- a/tests/screenshot/specs/light/Light-specs.js
+++ b/tests/screenshot/specs/light/Light-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 1
+});

--- a/tests/screenshot/specs/light/Light2-specs.js
+++ b/tests/screenshot/specs/light/Light2-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 2
+});

--- a/tests/screenshot/specs/light/Light3-specs.js
+++ b/tests/screenshot/specs/light/Light3-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 3
+});

--- a/tests/screenshot/specs/light/Light4-specs.js
+++ b/tests/screenshot/specs/light/Light4-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 4
+});

--- a/tests/screenshot/specs/light/Light5-specs.js
+++ b/tests/screenshot/specs/light/Light5-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 5
+});

--- a/tests/screenshot/specs/light/Light6-specs.js
+++ b/tests/screenshot/specs/light/Light6-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 6
+});

--- a/tests/screenshot/specs/light/Light7-specs.js
+++ b/tests/screenshot/specs/light/Light7-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 7
+});

--- a/tests/screenshot/specs/light/Light8-specs.js
+++ b/tests/screenshot/specs/light/Light8-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 8
+});

--- a/tests/screenshot/specs/light/Light9-specs.js
+++ b/tests/screenshot/specs/light/Light9-specs.js
@@ -1,0 +1,11 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+
+const Page = require('./SandstonePage');
+
+runTest({
+	testName: 'Sandstone Light',
+	Page: Page,
+	skin: 'light',
+	highContrast: false,
+	concurrency: 9
+});

--- a/tests/screenshot/specs/light/SandstonePage.js
+++ b/tests/screenshot/specs/light/SandstonePage.js
@@ -1,0 +1,19 @@
+'use strict';
+const {Page} = require('@enact/ui-test-utils/utils');
+
+class SandstonePage extends Page {
+	constructor () {
+		super();
+		this.title = 'Sandstone Test';
+	}
+
+	open (urlExtra) {
+		super.open('Sandstone-View', urlExtra);
+	}
+
+	get component () {
+		return $('[data-ui-test-id="test"]');
+	}
+}
+
+module.exports = new SandstonePage();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In light skin, 
There was not much difference between the progress bar and fill or load colors.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add alpha 40% for bar color to improve visibility.
Add Light skin spec to screenshot test

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-8227

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)