### PR TITLE
WRN-9173: TimePicker: Fixed disabled color of separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
-## [unreleased] 
+## [unreleased]
 
 ### Fixed
 
 - `sandstone` to support India region font correctly
+- `sandstone/TimePicker` to apply disabled color to the separator
 
 ## [2.0.2] - 2021-10-07
 

--- a/TimePicker/TimePicker.module.less
+++ b/TimePicker/TimePicker.module.less
@@ -1,6 +1,7 @@
 // TimePicker.module.less
 //
 @import "../styles/mixins.less";
+@import "../styles/skin.less";
 @import "../styles/variables.less";
 
 .timePicker {
@@ -33,6 +34,14 @@
 			}
 		});
 	}
+
+	.applySkins({
+		.timeSeparator {
+			.sand-disabled({
+				.sand-disabled-colors();
+			});
+		}
+	});
 }
 
 .sizingPlaceholder {

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -1,5 +1,4 @@
 import kind from '@enact/core/kind';
-import classNames from 'classnames';
 import {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import classNames from 'classnames';
 import {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 
@@ -367,7 +368,7 @@ const TimePickerBase = kind({
 										width={4}
 										wrap
 									/>
-									<span className={css.timeSeparator}>:</span>
+									<span className={css.timeSeparator} disabled={disabled}>:</span>
 								</Fragment>
 							);
 						case 'm':


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When it is changed to disabled state, only the text color of the Picker is changed except for the separator.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
By passing the `disabled` prop to the separator node, `sand-disabled` mixins are applied.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-9173

### Comments
