### PR TITLE
Use node14 instead of lts for Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "lts/*"
+    - "14"
 sudo: false
 cache: npm
 install:


### PR DESCRIPTION
Yesterday, node 16 became LTS version.
Use node14 to prevent Travis test fail
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
