### PR TITLE
WRN-6719: Revert ContextualPopupDecorator arrow patch

### DIFF
--- a/ContextualPopupDecorator/ContextualPopup.module.less
+++ b/ContextualPopupDecorator/ContextualPopup.module.less
@@ -63,9 +63,6 @@
 		height: @sand-contextualpopup-arrow-height;
 		width: @sand-contextualpopup-arrow-width;
 
-		// PLAT-84596: Coax the arrow onto a GPU layer to work around a rendering issue in Chromium
-		will-change: transform;
-
 		&.above {
 			transform: rotate(180deg);
 		}

--- a/DatePicker/DatePicker.module.less
+++ b/DatePicker/DatePicker.module.less
@@ -1,15 +1,9 @@
 // DatePicker.module.less
 //
-@import "../styles/variables.less";
-
 .datePicker {
 	.day,
 	.month,
 	.year {
 		/* These should be available to the JS but have no associated rules at this time. */
 	}
-}
-
-.sizingPlaceholder {
-	min-width: @sand-datecomponentpicker-sizing-placeholder-min-width;
 }

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -5,7 +5,7 @@ import $L from '../internal/$L';
 import {DateComponentRangePicker} from '../internal/DateComponentPicker';
 import DateTime from '../internal/DateTime';
 
-import componentCss from './DatePicker.module.less';
+import css from './DatePicker.module.less';
 
 /**
  * A date selection component.
@@ -81,15 +81,6 @@ const DatePickerBase = kind({
 		 * @public
 		 */
 		year: PropTypes.number.isRequired,
-
-		/**
-		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal elements and states of this component.
-		 *
-		 * @type {Object}
-		 * @private
-		 */
-		css: PropTypes.object,
 
 		/**
 		 * Disables voice control.
@@ -252,12 +243,11 @@ const DatePickerBase = kind({
 	},
 
 	styles: {
-		css: componentCss,
+		css,
 		className: 'datePicker'
 	},
 
 	render: ({
-		css,
 		'data-webos-voice-disabled': voiceDisabled,
 		disabled,
 		day,
@@ -306,7 +296,6 @@ const DatePickerBase = kind({
 									accessibilityHint={dayAccessibilityHint}
 									aria-label={dayAriaLabel}
 									className={css.day}
-									css={css}
 									data-last-element={isLast}
 									data-webos-voice-disabled={voiceDisabled}
 									data-webos-voice-group-label={dayAccessibilityHint}
@@ -330,7 +319,6 @@ const DatePickerBase = kind({
 									accessibilityHint={monthAccessibilityHint}
 									aria-label={monthAriaLabel}
 									className={css.month}
-									css={css}
 									data-last-element={isLast}
 									data-webos-voice-disabled={voiceDisabled}
 									data-webos-voice-group-label={monthAccessibilityHint}
@@ -354,7 +342,6 @@ const DatePickerBase = kind({
 									accessibilityHint={yearAccessibilityHint}
 									aria-label={yearAriaLabel}
 									className={css.year}
-									css={css}
 									data-last-element={isLast}
 									data-webos-voice-disabled={voiceDisabled}
 									data-webos-voice-group-label={yearAccessibilityHint}

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -265,7 +265,7 @@ const RangePickerBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'rangePicker',
-		publicClassNames: ['inlineTitle', 'sizingPlaceholder', 'title']
+		publicClassNames: ['inlineTitle', 'title']
 	},
 
 	computed: {

--- a/RangePicker/RangePicker.module.less
+++ b/RangePicker/RangePicker.module.less
@@ -28,7 +28,3 @@
 		margin-bottom: 0;
 	}
 }
-
-.sizingPlaceholder {
-	/* Public Class Names */
-}

--- a/TimePicker/TimePicker.module.less
+++ b/TimePicker/TimePicker.module.less
@@ -43,7 +43,3 @@
 		}
 	});
 }
-
-.sizingPlaceholder {
-	min-width: @sand-datecomponentpicker-sizing-placeholder-min-width;
-}

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -6,7 +6,7 @@ import $L from '../internal/$L';
 import {DateComponentPicker, DateComponentRangePicker} from '../internal/DateComponentPicker';
 import DateTime from '../internal/DateTime';
 
-import componentCss from './TimePicker.module.less';
+import css from './TimePicker.module.less';
 
 // values to use in hour picker for 24 and 12 hour locales
 const hours24 = [
@@ -29,7 +29,6 @@ const hours12 = [
  */
 class HourPicker extends Component {
 	static propTypes = {
-		css: PropTypes.object,
 		hasMeridiem: PropTypes.bool,
 		value: PropTypes.number
 	};
@@ -57,11 +56,11 @@ class HourPicker extends Component {
 	}
 
 	render () {
-		const {css, hasMeridiem, ...rest} = this.props;
+		const {hasMeridiem, ...rest} = this.props;
 		const hours = hasMeridiem ? hours12 : hours24;
 
 		return (
-			<DateComponentPicker {...rest} css={css} noAnimation={this.state.noAnimation}>
+			<DateComponentPicker {...rest} noAnimation={this.state.noAnimation}>
 				{hours}
 			</DateComponentPicker>
 		);
@@ -119,15 +118,6 @@ const TimePickerBase = kind({
 		 * @public
 		 */
 		order: PropTypes.arrayOf(PropTypes.oneOf(['h', 'k', 'm', 'a'])).isRequired,
-
-		/**
-		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal elements and states of this component.
-		 *
-		 * @type {Object}
-		 * @private
-		 */
-		css: PropTypes.object,
 
 		/**
 		 * Disables voice control.
@@ -287,7 +277,7 @@ const TimePickerBase = kind({
 	},
 
 	styles: {
-		css: componentCss,
+		css,
 		className: 'timePicker'
 	},
 
@@ -297,7 +287,6 @@ const TimePickerBase = kind({
 	},
 
 	render: ({
-		css,
 		'data-webos-voice-disabled': voiceDisabled,
 		disabled,
 		hasMeridiem,
@@ -352,7 +341,6 @@ const TimePickerBase = kind({
 										accessibilityHint={hourAccessibilityHint}
 										aria-label={hourAriaLabel}
 										className={css.hourPicker}
-										css={css}
 										data-last-element={isLastElement}
 										data-webos-voice-disabled={voiceDisabled}
 										data-webos-voice-group-label={hourAccessibilityHint}
@@ -376,7 +364,6 @@ const TimePickerBase = kind({
 									accessibilityHint={minuteAccessibilityHint}
 									aria-label={minuteAriaLabel}
 									className={css.minutePicker}
-									css={css}
 									data-last-element={isLastElement}
 									data-webos-voice-disabled={voiceDisabled}
 									data-webos-voice-group-label={minuteAccessibilityHint}

--- a/internal/DateComponentPicker/DateComponentPicker.js
+++ b/internal/DateComponentPicker/DateComponentPicker.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import Picker, {PickerItem} from '../Picker';
 
-import componentCss from './DateComponentPicker.module.less';
+import css from './DateComponentPicker.module.less';
 
 /**
  * {@link sandstone/internal/DataComponentPicker.DateComponentPickerBase} allows the selection of one
@@ -58,19 +58,6 @@ const DateComponentPickerBase = kind({
 		'aria-valuetext': PropTypes.string,
 
 		/**
-		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal elements and states of this component.
-		 *
-		 * The following classes are supported:
-		 *
-		 * * `sizingPlaceholder` - The sizing placeholder class
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		css: PropTypes.object,
-
-		/**
 		 * The label to display below the picker
 		 *
 		 * @type {String}
@@ -105,9 +92,8 @@ const DateComponentPickerBase = kind({
 	},
 
 	styles: {
-		css: componentCss,
-		className: 'dateComponentPicker',
-		publicClassNames: ['sizingPlaceholder']
+		css,
+		className: 'dateComponentPicker'
 	},
 
 	computed: {
@@ -120,12 +106,11 @@ const DateComponentPickerBase = kind({
 		}
 	},
 
-	render: ({'aria-valuetext': ariaValuetext, accessibilityHint, children, css, label, max, noAnimation, reverse, value, voiceLabel, wrap, ...rest}) => (
+	render: ({'aria-valuetext': ariaValuetext, accessibilityHint, children, label, max, noAnimation, reverse, value, voiceLabel, wrap, ...rest}) => (
 		<Picker
 			{...rest}
 			accessibilityHint={(accessibilityHint == null) ? label : accessibilityHint}
 			aria-valuetext={(accessibilityHint == null) ? ariaValuetext : null}
-			css={css}
 			data-webos-voice-labels-ext={voiceLabel}
 			index={value}
 			joined

--- a/internal/DateComponentPicker/DateComponentPicker.module.less
+++ b/internal/DateComponentPicker/DateComponentPicker.module.less
@@ -16,7 +16,3 @@
 		white-space: nowrap;
 	}
 }
-
-.sizingPlaceholder {
-	/* Public Class Names */
-}

--- a/internal/DateComponentPicker/DateComponentRangePicker.js
+++ b/internal/DateComponentPicker/DateComponentRangePicker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import RangePicker from '../../RangePicker';
 
-import componentCss from './DateComponentPicker.module.less';
+import css from './DateComponentPicker.module.less';
 
 /**
  * {@link sandstone/internal/DataComponentPicker.DateComponentRangePicker} allows the selection of
@@ -52,19 +52,6 @@ const DateComponentRangePickerBase = kind({
 		accessibilityHint: PropTypes.string,
 
 		/**
-		 * Customizes the component by mapping the supplied collection of CSS class names to the
-		 * corresponding internal elements and states of this component.
-		 *
-		 * The following classes are supported:
-		 *
-		 * * `sizingPlaceholder` - The sizing placeholder class
-		 *
-		 * @type {Object}
-		 * @public
-		 */
-		css: PropTypes.object,
-
-		/**
 		 * The label to display below the picker
 		 *
 		 * @type {String}
@@ -91,9 +78,8 @@ const DateComponentRangePickerBase = kind({
 	},
 
 	styles: {
-		css: componentCss,
-		className: 'dateComponentPicker',
-		publicClassNames: ['sizingPlaceholder']
+		css,
+		className: 'dateComponentPicker'
 	},
 
 	computed: {
@@ -102,11 +88,10 @@ const DateComponentRangePickerBase = kind({
 		}
 	},
 
-	render: ({accessibilityHint, css, label, max, min, noAnimation, value, wrap, voiceLabel, ...rest}) => (
+	render: ({accessibilityHint, label, max, min, noAnimation, value, wrap, voiceLabel, ...rest}) => (
 		<RangePicker
 			{...rest}
 			accessibilityHint={(accessibilityHint == null) ? label : accessibilityHint}
-			css={css}
 			data-webos-voice-labels-ext={voiceLabel}
 			joined
 			max={max}

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -64,7 +64,7 @@ const forwardBlur = forward('onBlur'),
 	forwardKeyUp = forward('onKeyUp'),
 	forwardWheel = forward('onWheel');
 
-const allowedClassNames = ['picker', 'valueWrapper', 'joined', 'horizontal', 'vertical', 'sizingPlaceholder'];
+const allowedClassNames = ['picker', 'valueWrapper', 'joined', 'horizontal', 'vertical'];
 
 /**
  * The base component for {@link sandstone/internal/Picker.Picker}.

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -226,7 +226,6 @@
 
 // Date and Time Picker
 @sand-datecomponentpicker-margin: 24px;
-@sand-datecomponentpicker-sizing-placeholder-min-width: 132px;
 @sand-timepicker-colon-margin: 0 6px;
 
 // Heading


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Remove workaround code related to chrome rendering issue as patch has been applied.
chromium issue link: https://bugs.chromium.org/p/chromium/issues/detail?id=996931

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Revert https://github.com/enactjs/enact/pull/2501

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-6719

### Comments
