### PR TITLE
WRN-6758: Changed inputField numeric keyboard for Samsung devices.

### DIFF
--- a/Input/InputField.js
+++ b/Input/InputField.js
@@ -279,6 +279,16 @@ const InputFieldBase = kind({
 		},
 		className: ({invalid, size, styler}) => styler.append({invalid}, size),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
+		inputMode: ({type}) => {
+			// eslint-disable-next-line
+			const samsung = navigator.userAgent.includes('SM-');
+			return type === 'number' && samsung ? 'numeric' : '';
+		},
+		inputType: ({type}) => {
+			// eslint-disable-next-line
+			const samsung = navigator.userAgent.includes('SM-');
+			return type === 'number' && samsung ? 'text' : type;
+		},
 		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.')}) => {
 			if (invalid && invalidMessage) {
 				return (
@@ -292,7 +302,7 @@ const InputFieldBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {
+	render: ({css, dir, disabled, iconAfter, iconBefore, inputMode, inputType, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {
 		const inputProps = extractInputProps(rest);
 		const voiceProps = extractVoiceProps(rest);
 		const isPasswordtel = type === 'passwordtel';
@@ -319,10 +329,11 @@ const InputFieldBase = kind({
 					className={classnames(css.input, {[css.passwordtel]: isPasswordtel})}
 					dir={dir}
 					disabled={disabled}
+					inputMode={inputMode}
 					onChange={onChange}
 					placeholder={placeholder}
 					tabIndex={-1}
-					type={isPasswordtel ? 'tel' : type}
+					type={isPasswordtel ? 'tel' : inputType}
 					value={value}
 				/>
 				<InputFieldDecoratorIcon position="after" size={size}>{iconAfter}</InputFieldDecoratorIcon>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Samsung numeric keyboard has no '-' option.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added inputMode into Input.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-6758

### Comments
