### PR TITLE
WRN-6762: Cross-Platform Enact Android: qa-scroller/qa-VirtualGridList - when changing 'width', 'dataSize', VKB flashes and goes away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/useScroll` handleResizeWindow method to not blur the focused item if its type is input
+
 ## [2.0.4] - 2021-11-01
 
 ### Added

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -235,7 +235,7 @@ const useThemeScroll = (props, instances) => {
 	function handleResizeWindow () {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem) {
+		if (focusedItem && focusedItem.nodeName !== 'INPUT') {
 			focusedItem.blur();
 		}
 	}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed qa-scroller, qa-virtualGridList, samples on Android devices so the VKB is always displayed and you can modify the input data.

When the VKB is displaying, a page resizing is triggered, Input loses focus and the VKB disappears. Scroller and ScrollerNative have a handleResizeWindow methods defined which tells the Scroller to blur the focused item. I've made a small change to that method, if the focused item is an input, the input should always be focused.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
