### PR TITLE
WRN-11532: Added props to override aria-label of ActionGuide's button

### DIFF
--- a/ActionGuide/ActionGuide.js
+++ b/ActionGuide/ActionGuide.js
@@ -38,6 +38,14 @@ const ActionGuideBase = kind({
 
 	propTypes: /** @lends sandstone/ActionGuide.ActionGuideBase.prototype */ {
 		/**
+		 * The "aria-label" for the button.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		buttonAriaLabel: PropTypes.string,
+
+		/**
 		 * The contents for the action guide.
 		 *
 		 * @type {String}
@@ -95,10 +103,10 @@ const ActionGuideBase = kind({
 		publicClassNames: ['actionGuide']
 	},
 
-	render: ({children, css, disabled, icon, onClick, ...rest}) => {
+	render: ({buttonAriaLabel, children, css, disabled, icon, onClick, ...rest}) => {
 		return (
 			<div {...rest}>
-				<Button className={css.icon} disabled={disabled} icon={icon} minWidth={false} onClick={onClick} size="small" />
+				<Button aria-label={buttonAriaLabel ? buttonAriaLabel : null} className={css.icon} disabled={disabled} icon={icon} minWidth={false} onClick={onClick} size="small" />
 				<Marquee className={css.label} marqueeOn="render" alignment="center">{children}</Marquee>
 			</div>
 		);

--- a/ActionGuide/tests/ActionGuide-specs.js
+++ b/ActionGuide/tests/ActionGuide-specs.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {ActionGuideBase} from '../ActionGuide';
 
 describe('ActionGuide', () => {
@@ -30,6 +30,20 @@ describe('ActionGuide', () => {
 			expect(actual).toBe(expected);
 		}
 	);
+
+	test('should set "buttonAriaLabel" to action guide', () => {
+		const label = 'custom aria-label';
+		const subject = mount(
+			<ActionGuideBase buttonAriaLabel={label}>content</ActionGuideBase>
+		);
+
+		const actionGuideButton = subject.find('.button');
+
+		const expected = label;
+		const actual = actionGuideButton.prop('aria-label');
+
+		expect(actual).toBe(expected);
+	});
 
 	describe('CSS override', () => {
 		test(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/ActionGuide` prop `buttonAriaLabel` and `sandstone/MediaControls` prop `actionGuideButtonAriaLabel` to override aria-label of `ActionGuide` button
+
 ## [1.4.4-experimental-7] - 2021-04-07
 
 ### Fixed

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -80,6 +80,14 @@ const MediaControlsBase = kind({
 		actionGuideAriaLabel: PropTypes.string,
 
 		/**
+		 * The `aria-label` for the action guide button.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		actionGuideButtonAriaLabel: PropTypes.string,
+
+		/**
 		 * Disables the ActionGuide.
 		 *
 		 * @type {Boolean}
@@ -313,6 +321,7 @@ const MediaControlsBase = kind({
 
 	render: ({
 		actionGuideAriaLabel,
+		actionGuideButtonAriaLabel,
 		actionGuideDisabled,
 		actionGuideLabel,
 		actionGuideShowing,
@@ -352,7 +361,7 @@ const MediaControlsBase = kind({
 					{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 				</Container>
 				{actionGuideShowing ?
-					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} css={css} className={actionGuideClassName} icon="arrowsmalldown" onClick={onActionGuideClick} disabled={actionGuideDisabled}>{actionGuideLabel}</ActionGuide> :
+					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} buttonAriaLabel={actionGuideButtonAriaLabel} css={css} className={actionGuideClassName} icon="arrowsmalldown" onClick={onActionGuideClick} disabled={actionGuideDisabled}>{actionGuideLabel}</ActionGuide> :
 					null
 				}
 				{moreComponentsRendered ?

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -33,7 +33,7 @@ const VideoPlayerView = () => (
 		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
 			<source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
-			<MediaControls actionGuideLabel="Press Down Button to Scroll" actionGuideButtonLabel="This is label 0.">
+			<MediaControls actionGuideLabel="Press Down Button to Scroll" actionGuideButtonAriaLabel="This is label 0.">
 				<bottomComponents>
 					<VirtualGridList
 						dataSize={20}

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -33,7 +33,7 @@ const VideoPlayerView = () => (
 		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
 			<source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
-			<MediaControls actionGuideLabel="Press Down Button to Scroll">
+			<MediaControls actionGuideLabel="Press Down Button to Scroll" actionGuideButtonLabel="This is label 0.">
 				<bottomComponents>
 					<VirtualGridList
 						dataSize={20}

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -33,7 +33,7 @@ const VideoPlayerView = () => (
 		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
 			<source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
-			<MediaControls actionGuideLabel="Press Down Button to Scroll" actionGuideButtonAriaLabel="This is label 0.">
+			<MediaControls actionGuideButtonAriaLabel="This is label 0." actionGuideLabel="Press Down Button to Scroll">
 				<bottomComponents>
 					<VirtualGridList
 						dataSize={20}

--- a/samples/sampler/stories/default/ActionGuide.js
+++ b/samples/sampler/stories/default/ActionGuide.js
@@ -27,7 +27,7 @@ storiesOf('Sandstone', module)
 			}
 
 			return (
-				<ActionGuide buttonAriaLabel={text('buttonAriaLabel', Config, icon)} icon={icon}>
+				<ActionGuide buttonAriaLabel={text('buttonAriaLabel', Config)} icon={icon}>
 					{text('children', Config, 'Press some key to do something')}
 				</ActionGuide>
 			);

--- a/samples/sampler/stories/default/ActionGuide.js
+++ b/samples/sampler/stories/default/ActionGuide.js
@@ -27,7 +27,7 @@ storiesOf('Sandstone', module)
 			}
 
 			return (
-				<ActionGuide icon={icon}>
+				<ActionGuide buttonAriaLabel={text('buttonAriaLabel', Config, icon)} icon={icon}>
 					{text('children', Config, 'Press some key to do something')}
 				</ActionGuide>
 			);

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -178,7 +178,7 @@ storiesOf('Sandstone', module)
 						<infoComponents>A video about some things happening to and around some characters. Very exciting stuff.</infoComponents>
 						<MediaControls
 							actionGuideAriaLabel={text('actionGuideAriaLabel', MediaControlsConfig, 'Press Down Key Using Remote Control')}
-							actionGuideButtonAriaLabel={text('actionGuideButtonAriaLabel', MediaControlsConfig, 'below')}
+							actionGuideButtonAriaLabel={text('actionGuideButtonAriaLabel', MediaControlsConfig)}
 							actionGuideLabel={text('actionGuideLabel', MediaControlsConfig, 'Press Down Button to Scroll')}
 							jumpBackwardIcon={select('jumpBackwardIcon', icons, MediaControlsConfig, 'jumpbackward')}
 							jumpButtonsDisabled={boolean('jumpButtonsDisabled', MediaControlsConfig)}

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -178,6 +178,7 @@ storiesOf('Sandstone', module)
 						<infoComponents>A video about some things happening to and around some characters. Very exciting stuff.</infoComponents>
 						<MediaControls
 							actionGuideAriaLabel={text('actionGuideAriaLabel', MediaControlsConfig, 'Press Down Key Using Remote Control')}
+							actionGuideButtonAriaLabel={text('actionGuideButtonAriaLabel', MediaControlsConfig, 'below')}
 							actionGuideLabel={text('actionGuideLabel', MediaControlsConfig, 'Press Down Button to Scroll')}
 							jumpBackwardIcon={select('jumpBackwardIcon', icons, MediaControlsConfig, 'jumpbackward')}
 							jumpButtonsDisabled={boolean('jumpButtonsDisabled', MediaControlsConfig)}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is no way to set aria-label of actionGuide button

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `sandstone/ActionGuide` prop `buttonAriaLabel` 
Add `sandstone/MediaControls` prop `actionGuideButtonAriaLabel` 


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-11532

### Comments
