### PR TITLE
WRN-1236: Updated panels sampler to render VirtualGridList within panel with fixed items

### DIFF
--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -18,16 +18,22 @@ import compose from 'ramda/src/compose';
 
 const Config = mergeComponentMetadata('Panels', Panels);
 
+const items = [];
+
+for (let i = 0; i < 100; i++) {
+	const text = `Item ${i}`,
+		color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
+		source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${i}`,
+		caption = 'Sample list';
+	items.push({text, source, caption});
+}
+
 // Used to render VirtualGridList into Panels
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
-	const text = `Item ${index}`,
-		color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
-		source = `http://placehold.it/300x300/${color}/ffffff&text=Image ${index}`,
-		caption = 'Sample list';
-
+	const {caption, source, text} = items[index];
 	return (
-		<ImageItem {...rest} src={source} label={caption}>
+		<ImageItem {...rest} label={caption} src={source}>
 			{text}
 		</ImageItem>
 	);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed panels sampler not to flickers when transitioning panel

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated panels sampler to render `VirtualGridList` with fixed items 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-1236

### Comments
