### PR TITLE
Remove unused QA sample Item integrated with other components

### DIFF
--- a/samples/sampler/stories/qa/Item.js
+++ b/samples/sampler/stories/qa/Item.js
@@ -2,7 +2,6 @@ import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 import Button from '@enact/sandstone/Button';
 import Heading from '@enact/sandstone/Heading';
 import Icon from '@enact/sandstone/Icon';
-import Image from '@enact/sandstone/Image';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import {Row} from '@enact/ui/Layout';
@@ -78,32 +77,6 @@ boolean('disabled', WithExtraSpaces, Item);
 text('Children', WithExtraSpaces, Item, inputData.extraSpaceText);
 
 WithExtraSpaces.storyName = 'with extra spaces';
-
-export const IntegratedWithOtherComponents = (args) => (
-	<Item disabled={args['disabled']}>
-		<Button>Click here</Button>
-		{args['Children']}
-		<Button>Click here</Button>
-		<Image src="http://lorempixel.com/512/512/city/1/" sizing="fill" alt="lorempixel" />
-		<p>
-			Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.
-			Aenean massa.
-		</p>
-		<p>
-			Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.
-			Aenean massa.
-		</p>
-		<p>
-			Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.
-			Aenean massa.
-		</p>
-	</Item>
-);
-
-boolean('disabled', IntegratedWithOtherComponents, Item);
-text('Children', IntegratedWithOtherComponents, Item, 'Hello Item');
-
-IntegratedWithOtherComponents.storyName = 'integrated with other components';
 
 export const SampleForSpotabilityTest = (args) => (
 	<div>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Sandstone Item component only supports single-line content but sample with multi-line case exists.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove unused QA sample Item integrated with other components

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-10967

### Comments
