### PR TITLE
WRN-12780: Fix Scroller and VirtualList to focus the topmost element after scroll via voice control in pointer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` and `sandstone/VirtualList` to not restore focus after scroll with voice control scroll in pointer mode
+- `sandstone/Scroller` and `sandstone/VirtualList` to not restore focus after scroll with voice control in pointer mode
 
 ## [2.0.4] - 2021-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` and `sandstone/VirtualList` to not restore focus after scroll with voice control in pointer mode
+- `sandstone/Scroller` and `sandstone/VirtualList` to not restore focus after scroll by voice control in pointer mode
 
 ## [2.0.4] - 2021-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` and `sandstone/VirtualList` to not restore focus after scroll with voice control scroll in pointer mode
+
 ## [2.0.4] - 2021-11-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` and `sandstone/VirtualList` to not restore focus after scroll by voice control in pointer mode
+- `sandstone/Scroller` and `sandstone/VirtualList` to focus the topmost element after scroll by voice control in pointer mode
 
 ## [2.0.4] - 2021-11-01
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -454,7 +454,7 @@ const useEventVoice = (props, instances) => {
 			}
 		} else if (!spotItem && scrollContainerNode) {
 			// In pointer mode, reset last-focus to the item currently visible
-			Spotlight.focus(scrollContainerNode, {enterTo: 'default-element'});
+			Spotlight.focus(scrollContainerNode, {enterTo: 'top-most'});
 		}
 	};
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -454,7 +454,7 @@ const useEventVoice = (props, instances) => {
 			}
 		} else if (!spotItem && scrollContainerNode) {
 			// In pointer mode, reset last-focus to the item currently visible
-			Spotlight.focus(scrollContainerNode, {enterTo: 'top-most'});
+			Spotlight.focus(scrollContainerNode, {enterTo: 'topmost'});
 		}
 	};
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -452,6 +452,9 @@ const useEventVoice = (props, instances) => {
 					}
 				}
 			}
+		} else if (!spotItem && scrollContainerNode) {
+			// In pointer mode, reset last-focus to the item currently visible
+			Spotlight.focus(scrollContainerNode, {enterTo: 'default-element'});
 		}
 	};
 


### PR DESCRIPTION


### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroll position is rollback after voice control scroll

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In pointer mode, reset last-focus to the item currently visible

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12780

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)