### PR TITLE
WRN-12680: Scroller - edge dragging should be bouncing

### DIFF
--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -20,6 +20,7 @@ const prop = {
 	scrollModeOption: ['native', 'translate']
 };
 
+const ConfigOverscroll = mergeComponentMetadata('ConfigOverscroll', UiScrollerBasic, Scroller);
 const ScrollerConfig = mergeComponentMetadata('Scroller', UiScrollerBasic, Scroller);
 
 export default {
@@ -55,6 +56,13 @@ export const _Scroller = (args) => {
 			noScrollByWheel={args['noScrollByWheel']}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollMode={args['scrollMode']}
 			spotlightDisabled={args['spotlightDisabled']}
 			verticalScrollbar={verticalScrollbar}
@@ -93,6 +101,11 @@ select('verticalScrollbar', _Scroller, prop.scrollbarOption, ScrollerConfig);
 boolean('fadeOut', _Scroller, ScrollerConfig);
 boolean('hoverToScroll', _Scroller, ScrollerConfig);
 boolean('noScrollByWheel', _Scroller, ScrollerConfig);
+boolean('overscrollEffectOnArrowKey', _Scroller, ConfigOverscroll, false);
+boolean('overscrollEffectOnDrag', _Scroller, ConfigOverscroll, true);
+boolean('overscrollEffectOnPageKey', _Scroller, ConfigOverscroll, false);
+boolean('overscrollEffectOnTrack', _Scroller, ConfigOverscroll, false);
+boolean('overscrollEffectOnWheel', _Scroller, ConfigOverscroll, true);
 select('scrollMode', _Scroller, prop.scrollModeOption, ScrollerConfig);
 boolean('spotlightDisabled', _Scroller, ScrollerConfig, false);
 

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -20,7 +20,7 @@ const prop = {
 	scrollModeOption: ['native', 'translate']
 };
 
-const ConfigOverscroll = mergeComponentMetadata('ConfigOverscroll', UiScrollerBasic, Scroller);
+const ConfigOverscroll = mergeComponentMetadata('Config Overscroll', UiScrollerBasic, Scroller);
 const ScrollerConfig = mergeComponentMetadata('Scroller', UiScrollerBasic, Scroller);
 
 export default {

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -58,6 +58,12 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
+const ConfigOverscroll = mergeComponentMetadata(
+	'ConfigOverscroll',
+	UiVirtualListBasic,
+	VirtualGridList
+);
+
 const VirtualGridListConfig = mergeComponentMetadata(
 	'VirtualGridList',
 	UiVirtualListBasic,
@@ -89,6 +95,13 @@ export const _VirtualGridList = (args) => (
 		noScrollByWheel={args['noScrollByWheel']}
 		onScrollStart={action('onScrollStart')}
 		onScrollStop={action('onScrollStop')}
+		overscrollEffectOn={{
+			arrowKey: args['overscrollEffectOnArrowKey'],
+			drag: args['overscrollEffectOnDrag'],
+			pageKey: args['overscrollEffectOnPageKey'],
+			track: args['overscrollEffectOnTrack'],
+			wheel: args['overscrollEffectOnWheel']
+		}}
 		scrollMode={args['scrollMode']}
 		spacing={ri.scale(args['spacing'])}
 		spotlightDisabled={args['spotlightDisabled']}
@@ -105,6 +118,11 @@ boolean('hoverToScroll', _VirtualGridList, VirtualGridListConfig);
 number('itemSize.minWidth', _VirtualGridList, VirtualGridListConfig, 688);
 number('itemSize.minHeight', _VirtualGridList, VirtualGridListConfig, 570);
 boolean('noScrollByWheel', _VirtualGridList, VirtualGridListConfig);
+boolean('overscrollEffectOnArrowKey', _VirtualGridList, ConfigOverscroll, false);
+boolean('overscrollEffectOnDrag', _VirtualGridList, ConfigOverscroll, true);
+boolean('overscrollEffectOnPageKey', _VirtualGridList, ConfigOverscroll, false);
+boolean('overscrollEffectOnTrack', _VirtualGridList, ConfigOverscroll, false);
+boolean('overscrollEffectOnWheel', _VirtualGridList, ConfigOverscroll, true);
 select('scrollMode', _VirtualGridList, prop.scrollModeOption, VirtualGridListConfig);
 number('spacing', _VirtualGridList, VirtualGridListConfig, 0);
 boolean('spotlightDisabled', _VirtualGridList, VirtualGridListConfig, false);

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -59,7 +59,7 @@ const updateDataSize = (dataSize) => {
 updateDataSize(defaultDataSize);
 
 const ConfigOverscroll = mergeComponentMetadata(
-	'ConfigOverscroll',
+	'Config Overscroll',
 	UiVirtualListBasic,
 	VirtualGridList
 );

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -43,7 +43,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const ConfigOverscroll = mergeComponentMetadata('ConfigOverscroll', UiVirtualListBasic, VirtualList);
+const ConfigOverscroll = mergeComponentMetadata('Config Overscroll', UiVirtualListBasic, VirtualList);
 const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBasic, VirtualList);
 
 export default {

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -43,6 +43,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
+const ConfigOverscroll = mergeComponentMetadata('ConfigOverscroll', UiVirtualListBasic, VirtualList);
 const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBasic, VirtualList);
 
 export default {
@@ -62,6 +63,13 @@ export const _VirtualList = (args) => (
 		noScrollByWheel={args['noScrollByWheel']}
 		onScrollStart={action('onScrollStart')}
 		onScrollStop={action('onScrollStop')}
+		overscrollEffectOn={{
+			arrowKey: args['overscrollEffectOnArrowKey'],
+			drag: args['overscrollEffectOnDrag'],
+			pageKey: args['overscrollEffectOnPageKey'],
+			track: args['overscrollEffectOnTrack'],
+			wheel: args['overscrollEffectOnWheel']
+		}}
 		scrollMode={args['scrollMode']}
 		spacing={ri.scale(args['spacing'])}
 		spotlightDisabled={args['spotlightDisabled']}
@@ -76,6 +84,11 @@ boolean('hoverToScroll', _VirtualList, VirtualListConfig);
 number('itemSize', _VirtualList, VirtualListConfig, 156);
 number('itemSize', _VirtualList, VirtualListConfig, 156);
 boolean('noScrollByWheel', _VirtualList, VirtualListConfig);
+boolean('overscrollEffectOnArrowKey', _VirtualList, ConfigOverscroll, false);
+boolean('overscrollEffectOnDrag', _VirtualList, ConfigOverscroll, true);
+boolean('overscrollEffectOnPageKey', _VirtualList, ConfigOverscroll, false);
+boolean('overscrollEffectOnTrack', _VirtualList, ConfigOverscroll, false);
+boolean('overscrollEffectOnWheel', _VirtualList, ConfigOverscroll, true);
 select('scrollMode', _VirtualList, prop.scrollModeOption, VirtualListConfig);
 number('spacing', _VirtualList, VirtualListConfig);
 boolean('spotlightDisabled', _VirtualList, VirtualListConfig, false);

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -16,11 +16,20 @@ import {Component} from 'react';
 import css from './Scroller.module.less';
 
 const Config = mergeComponentMetadata('Scroller', UiScrollerBasic, Scroller);
+const ConfigOverscroll = mergeComponentMetadata('Overscroll', UiScrollerBasic, Scroller);
 
 const itemData = [];
 for (let i = 0; i < 100; i++) {
 	itemData.push(`Item ${i}`);
 }
+
+const setOverscroll = (story) => {
+	boolean('overscrollEffectOnArrowKey', story, ConfigOverscroll, false);
+	boolean('overscrollEffectOnDrag', story, ConfigOverscroll, true);
+	boolean('overscrollEffectOnPageKey', story, ConfigOverscroll, false);
+	boolean('overscrollEffectOnTrack', story, ConfigOverscroll, false);
+	boolean('overscrollEffectOnWheel', story, ConfigOverscroll, true);
+};
 
 const prop = {
 	direction: ['both', 'horizontal', 'vertical'],
@@ -81,6 +90,13 @@ class ScrollerWithLongItem extends Component {
 				onKeyDown={action('onKeyDown')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
+				overscrollEffectOn={{
+					arrowKey: args['overscrollEffectOnArrowKey'],
+					drag: args['overscrollEffectOnDrag'],
+					pageKey: args['overscrollEffectOnPageKey'],
+					track: args['overscrollEffectOnTrack'],
+					wheel: args['overscrollEffectOnWheel']
+				}}
 				scrollMode={args['scrollMode']}
 			>
 				<Item>
@@ -113,6 +129,13 @@ class ScrollerWithResizable extends Component {
 				onKeyDown={action('onKeyDown')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
+				overscrollEffectOn={{
+					arrowKey: args['overscrollEffectOnArrowKey'],
+					drag: args['overscrollEffectOnDrag'],
+					pageKey: args['overscrollEffectOnPageKey'],
+					track: args['overscrollEffectOnTrack'],
+					wheel: args['overscrollEffectOnWheel']
+				}}
 				scrollMode={args['scrollMode']}
 				verticalScrollbar="visible"
 			>
@@ -142,6 +165,13 @@ class ScrollerWithLargeContainer extends Component {
 				onKeyDown={action('onKeyDown')}
 				onScrollStart={action('onScrollStart')}
 				onScrollStop={action('onScrollStop')}
+				overscrollEffectOn={{
+					arrowKey: args['overscrollEffectOnArrowKey'],
+					drag: args['overscrollEffectOnDrag'],
+					pageKey: args['overscrollEffectOnPageKey'],
+					track: args['overscrollEffectOnTrack'],
+					wheel: args['overscrollEffectOnWheel']
+				}}
 				scrollMode={args['scrollMode']}
 				spotlightId="scroller"
 				style={{height: ri.scaleToRem(600)}}
@@ -177,6 +207,13 @@ export const ListOfThings = (args) => (
 		onKeyDown={action('onKeyDown')}
 		onScrollStart={action('onScrollStart')}
 		onScrollStop={action('onScrollStop')}
+		overscrollEffectOn={{
+			arrowKey: args['overscrollEffectOnArrowKey'],
+			drag: args['overscrollEffectOnDrag'],
+			pageKey: args['overscrollEffectOnPageKey'],
+			track: args['overscrollEffectOnTrack'],
+			wheel: args['overscrollEffectOnWheel']
+		}}
 		scrollMode={args['scrollMode']}
 		spotlightDisabled={args['spotlightDisabled']}
 		verticalScrollbar={args['verticalScrollbar']}
@@ -192,6 +229,7 @@ boolean('noScrollByWheel', ListOfThings, Config);
 select('scrollMode', ListOfThings, prop.scrollModeOption, Config);
 boolean('spotlightDisabled', ListOfThings, Config, false);
 select('verticalScrollbar', ListOfThings, prop.scrollbarOption, Config);
+setOverscroll(ListOfThings);
 
 ListOfThings.storyName = 'List of things';
 
@@ -206,6 +244,13 @@ export const HorizontalScroll = (args) => (
 		onKeyDown={action('onKeyDown')}
 		onScrollStart={action('onScrollStart')}
 		onScrollStop={action('onScrollStop')}
+		overscrollEffectOn={{
+			arrowKey: args['overscrollEffectOnArrowKey'],
+			drag: args['overscrollEffectOnDrag'],
+			pageKey: args['overscrollEffectOnPageKey'],
+			track: args['overscrollEffectOnTrack'],
+			wheel: args['overscrollEffectOnWheel']
+		}}
 		scrollMode={args['scrollMode']}
 		spotlightDisabled={args['spotlightDisabled']}
 		verticalScrollbar={args['verticalScrollbar']}
@@ -231,6 +276,7 @@ boolean('noScrollByWheel', HorizontalScroll, Config);
 select('scrollMode', HorizontalScroll, prop.scrollModeOption, Config);
 boolean('spotlightDisabled', HorizontalScroll, Config, false);
 select('verticalScrollbar', HorizontalScroll, prop.scrollbarOption, Config);
+setOverscroll(HorizontalScroll);
 
 HorizontalScroll.storyName = 'Horizontal scroll';
 
@@ -245,6 +291,13 @@ export const WithSpottableComponents = (args) => (
 		onKeyDown={action('onKeyDown')}
 		onScrollStart={action('onScrollStart')}
 		onScrollStop={action('onScrollStop')}
+		overscrollEffectOn={{
+			arrowKey: args['overscrollEffectOnArrowKey'],
+			drag: args['overscrollEffectOnDrag'],
+			pageKey: args['overscrollEffectOnPageKey'],
+			track: args['overscrollEffectOnTrack'],
+			wheel: args['overscrollEffectOnWheel']
+		}}
 		scrollMode={args['scrollMode']}
 		spotlightDisabled={args['spotlightDisabled']}
 		verticalScrollbar={args['verticalScrollbar']}
@@ -284,6 +337,7 @@ boolean('noScrollByWheel', WithSpottableComponents, Config);
 select('scrollMode', WithSpottableComponents, prop.scrollModeOption, Config);
 boolean('spotlightDisabled', WithSpottableComponents, Config, false);
 select('verticalScrollbar', WithSpottableComponents, prop.scrollbarOption, Config);
+setOverscroll(WithSpottableComponents);
 
 WithSpottableComponents.storyName = 'With Spottable Components';
 
@@ -298,6 +352,13 @@ export const WithShortContents = (args) => (
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollMode={args['scrollMode']}
 			spotlightDisabled={args['spotlightDisabled']}
 			style={{height: ri.scaleToRem(600)}}
@@ -317,6 +378,7 @@ boolean('noScrollByWheel', WithShortContents, Config);
 select('scrollMode', WithShortContents, prop.scrollModeOption, Config);
 boolean('spotlightDisabled', WithShortContents, Config, false);
 select('verticalScrollbar', WithShortContents, prop.scrollbarOption, Config);
+setOverscroll(WithShortContents);
 
 WithShortContents.storyName = 'With short contents';
 
@@ -327,6 +389,7 @@ ScrollerWithResizable.propTypes = {
 export const WithResizable = (args) => <ScrollerWithResizable args={args} />;
 
 select('scrollMode', WithResizable, prop.scrollModeOption, Config);
+setOverscroll(WithResizable);
 
 WithResizable.storyName = 'With Resizable';
 
@@ -365,6 +428,7 @@ export const WithLargeContainer = (args) => <ScrollerWithLargeContainer args={ar
 
 select('focusableScrollbar', WithLargeContainer, prop.focusableScrollbarOption, Config);
 select('scrollMode', WithLargeContainer, prop.scrollModeOption, Config);
+setOverscroll(WithLargeContainer);
 
 WithLargeContainer.storyName = 'With Large Container';
 
@@ -377,6 +441,13 @@ export const WithFocusOutsideContainer = (args) => (
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollMode={args['scrollMode']}
 			style={{height: ri.scaleToRem(840), width: ri.scaleToRem(600), display: 'inline-block'}}
 		>
@@ -396,6 +467,7 @@ export const WithFocusOutsideContainer = (args) => (
 
 select('focusableScrollbar', WithFocusOutsideContainer, prop.focusableScrollbarOption, Config);
 select('scrollMode', WithFocusOutsideContainer, prop.scrollModeOption, Config);
+setOverscroll(WithFocusOutsideContainer);
 
 WithFocusOutsideContainer.storyName = 'With Focus outside Container';
 
@@ -407,6 +479,13 @@ export const TestScrollingToBoundaryWithSmallOverflow = (args) => {
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollMode={args['scrollMode']}
 			style={{height: ri.scaleToRem(480)}}
 		>
@@ -421,6 +500,7 @@ export const TestScrollingToBoundaryWithSmallOverflow = (args) => {
 
 range('Spacer size', TestScrollingToBoundaryWithSmallOverflow, Config, {max: 600, min: 0}, 200);
 select('scrollMode', TestScrollingToBoundaryWithSmallOverflow, prop.scrollModeOption, Config);
+setOverscroll(TestScrollingToBoundaryWithSmallOverflow);
 
 TestScrollingToBoundaryWithSmallOverflow.storyName = 'Test scrolling to boundary with small overflow';
 
@@ -433,6 +513,13 @@ export const TestScrollingToBoundaryWithLongOverflow = (args) => {
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollMode={args['scrollMode']}
 			style={{height: ri.scaleToRem(402)}}
 		>
@@ -454,6 +541,7 @@ export const TestScrollingToBoundaryWithLongOverflow = (args) => {
 range('Spacer size', TestScrollingToBoundaryWithLongOverflow, Config, {max: 600, min: 0}, 402);
 select('focusableScrollbar', TestScrollingToBoundaryWithLongOverflow, prop.focusableScrollbarOption, Config);
 select('scrollMode', TestScrollingToBoundaryWithLongOverflow, prop.scrollModeOption, Config);
+setOverscroll(TestScrollingToBoundaryWithLongOverflow);
 
 TestScrollingToBoundaryWithLongOverflow.storyName = 'Test scrolling to boundary with long overflow';
 
@@ -466,6 +554,13 @@ export const WithSpotlightTargetCalculation = (args) => (
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollMode={args['scrollMode']}
 			style={{height: ri.scaleToRem(804)}}
 		>
@@ -476,6 +571,7 @@ export const WithSpotlightTargetCalculation = (args) => (
 
 select('focusableScrollbar', WithSpotlightTargetCalculation, prop.focusableScrollbarOption, Config);
 select('scrollMode', WithSpotlightTargetCalculation, prop.scrollModeOption, Config);
+setOverscroll(WithSpotlightTargetCalculation);
 
 WithSpotlightTargetCalculation.storyName = 'With Spotlight Target Calculation';
 
@@ -487,6 +583,7 @@ export const WithLongItem = (args) => <ScrollerWithLongItem args={args} />;
 
 select('focusableScrollbar', WithLongItem, prop.focusableScrollbarOption, Config);
 select('scrollMode', WithLongItem, prop.scrollModeOption, Config);
+setOverscroll(WithLongItem);
 
 WithLongItem.storyName = 'With Long Item';
 
@@ -497,6 +594,13 @@ export const WithOneLongHeightItem = (args) => (
 		onKeyDown={action('onKeyDown')}
 		onScrollStart={action('onScrollStart')}
 		onScrollStop={action('onScrollStop')}
+		overscrollEffectOn={{
+			arrowKey: args['overscrollEffectOnArrowKey'],
+			drag: args['overscrollEffectOnDrag'],
+			pageKey: args['overscrollEffectOnPageKey'],
+			track: args['overscrollEffectOnTrack'],
+			wheel: args['overscrollEffectOnWheel']
+		}}
 		scrollMode={args['scrollMode']}
 	>
 		<div style={{height: ri.scaleToRem(2442)}}>
@@ -507,6 +611,7 @@ export const WithOneLongHeightItem = (args) => (
 
 select('focusableScrollbar', WithOneLongHeightItem, prop.focusableScrollbarOption, Config);
 select('scrollMode', WithOneLongHeightItem, prop.scrollModeOption, Config);
+setOverscroll(WithOneLongHeightItem);
 
 WithOneLongHeightItem.storyName = 'With One Long Height Item';
 
@@ -519,13 +624,6 @@ export const WithNestedScroller = (args) => {
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
-			overscrollEffectOn={{
-				arrowKey: false,
-				drag: true,
-				pageKey: false,
-				track: false,
-				wheel: true
-			}}
 			scrollMode={args['scrollMode']}
 			verticalScrollbar="visible"
 		>
@@ -539,11 +637,11 @@ export const WithNestedScroller = (args) => {
 				onScrollStart={action('onScrollStart (Nested 1st Scroller)')}
 				onScrollStop={action('onScrollStop (Nested 1st Scroller)')}
 				overscrollEffectOn={{
-					arrowKey: false,
-					drag: true,
-					pageKey: false,
-					track: false,
-					wheel: true
+					arrowKey: args['overscrollEffectOnArrowKey'],
+					drag: args['overscrollEffectOnDrag'],
+					pageKey: args['overscrollEffectOnPageKey'],
+					track: args['overscrollEffectOnTrack'],
+					wheel: args['overscrollEffectOnWheel']
 				}}
 				scrollMode={args['scrollMode']}
 				style={{
@@ -585,11 +683,11 @@ export const WithNestedScroller = (args) => {
 				onScrollStart={action('onScrollStart (Nested 2nd Scroller)')}
 				onScrollStop={action('onScrollStop (Nested 2nd Scroller)')}
 				overscrollEffectOn={{
-					arrowKey: false,
-					drag: true,
-					pageKey: false,
-					track: false,
-					wheel: true
+					arrowKey: args['overscrollEffectOnArrowKey'],
+					drag: args['overscrollEffectOnDrag'],
+					pageKey: args['overscrollEffectOnPageKey'],
+					track: args['overscrollEffectOnTrack'],
+					wheel: args['overscrollEffectOnWheel']
 				}}
 				scrollMode={args['scrollMode']}
 				style={{
@@ -628,6 +726,7 @@ export const WithNestedScroller = (args) => {
 select('focusableScrollbar', WithNestedScroller, prop.focusableScrollbarOption, Config);
 boolean('noScrollByWheel', WithNestedScroller, Config, false);
 select('scrollMode', WithNestedScroller, prop.scrollModeOption, Config);
+setOverscroll(WithNestedScroller);
 
 WithNestedScroller.storyName = 'With Nested Scroller';
 
@@ -639,6 +738,13 @@ export const WithCustomizedStyle = (args) => (
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 			scrollbarTrackCss={css}
 			scrollMode={args['scrollMode']}
 			style={{height: ri.scaleToRem(804)}}
@@ -653,6 +759,7 @@ export const WithCustomizedStyle = (args) => (
 
 select('focusableScrollbar', WithCustomizedStyle, prop.focusableScrollbarOption, Config);
 select('scrollMode', WithCustomizedStyle, prop.scrollModeOption, Config);
+setOverscroll(WithCustomizedStyle);
 
 WithCustomizedStyle.storyName = 'With Customized Style';
 
@@ -677,6 +784,13 @@ export const WithLongContents = (args) => {
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: args['overscrollEffectOnArrowKey'],
+				drag: args['overscrollEffectOnDrag'],
+				pageKey: args['overscrollEffectOnPageKey'],
+				track: args['overscrollEffectOnTrack'],
+				wheel: args['overscrollEffectOnWheel']
+			}}
 		>
 			<BodyText style={{whiteSpace: 'pre-line'}}>
 				{longContents}
@@ -687,5 +801,6 @@ export const WithLongContents = (args) => {
 
 select('focusableScrollbar', WithLongContents, prop.focusableScrollbarOption, Config, 'byEnter');
 select('scrollMode', WithLongContents, prop.scrollModeOption, Config);
+setOverscroll(WithLongContents);
 
 WithLongContents.storyName = 'With Long Contents';

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -16,7 +16,7 @@ import {Component} from 'react';
 import css from './Scroller.module.less';
 
 const Config = mergeComponentMetadata('Scroller', UiScrollerBasic, Scroller);
-const ConfigOverscroll = mergeComponentMetadata('Overscroll', UiScrollerBasic, Scroller);
+const ConfigOverscroll = mergeComponentMetadata('Config Overscroll', UiScrollerBasic, Scroller);
 
 const itemData = [];
 for (let i = 0; i < 100; i++) {

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -511,7 +511,6 @@ select('scrollMode', WithOneLongHeightItem, prop.scrollModeOption, Config);
 WithOneLongHeightItem.storyName = 'With One Long Height Item';
 
 export const WithNestedScroller = (args) => {
-	let noScrollByWheel = boolean('noScrollByWheel', Config);
 	return (
 		<Scroller
 			direction="vertical"
@@ -520,6 +519,13 @@ export const WithNestedScroller = (args) => {
 			onKeyDown={action('onKeyDown')}
 			onScrollStart={action('onScrollStart')}
 			onScrollStop={action('onScrollStop')}
+			overscrollEffectOn={{
+				arrowKey: false,
+				drag: true,
+				pageKey: false,
+				track: false,
+				wheel: true
+			}}
 			scrollMode={args['scrollMode']}
 			verticalScrollbar="visible"
 		>
@@ -528,10 +534,17 @@ export const WithNestedScroller = (args) => {
 				focusableScrollbar={args['focusableScrollbar']}
 				horizontalScrollbar="visible"
 				key={args['scrollMode'] + '2'}
-				noScrollByWheel={noScrollByWheel}
+				noScrollByWheel={args['noScrollByWheel']}
 				onKeyDown={action('onKeyDown (Nested 1st Scroller)')}
 				onScrollStart={action('onScrollStart (Nested 1st Scroller)')}
 				onScrollStop={action('onScrollStop (Nested 1st Scroller)')}
+				overscrollEffectOn={{
+					arrowKey: false,
+					drag: true,
+					pageKey: false,
+					track: false,
+					wheel: true
+				}}
 				scrollMode={args['scrollMode']}
 				style={{
 					height: 'auto',
@@ -567,10 +580,17 @@ export const WithNestedScroller = (args) => {
 				focusableScrollbar={args['focusableScrollbar']}
 				horizontalScrollbar="visible"
 				key={args['scrollMode'] + '3'}
-				noScrollByWheel={noScrollByWheel}
+				noScrollByWheel={args['noScrollByWheel']}
 				onKeyDown={action('onKeyDown (Nested 2nd Scroller)')}
 				onScrollStart={action('onScrollStart (Nested 2nd Scroller)')}
 				onScrollStop={action('onScrollStop (Nested 2nd Scroller)')}
+				overscrollEffectOn={{
+					arrowKey: false,
+					drag: true,
+					pageKey: false,
+					track: false,
+					wheel: true
+				}}
 				scrollMode={args['scrollMode']}
 				style={{
 					height: 'auto',
@@ -606,6 +626,7 @@ export const WithNestedScroller = (args) => {
 };
 
 select('focusableScrollbar', WithNestedScroller, prop.focusableScrollbarOption, Config);
+boolean('noScrollByWheel', WithNestedScroller, Config, false);
 select('scrollMode', WithNestedScroller, prop.scrollModeOption, Config);
 
 WithNestedScroller.storyName = 'With Nested Scroller';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The scroller did not bounce for drag action(only for wheel). There was also a missing Control (noScrollByWheel).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the overscrollEffectOn from the default state to have 'drag: true'. Also added the noScrollByWheel Control.
Also added a different Control tab for overscroll effect for sampler/Scroller, sampler/VirtualList, sampler/VirtualGridList and
qa-sampler/Scroller.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12680

### Comments
