### PR TITLE
WRN-12676: Cross-Platform Enact Android: Picker - tall string is truncated

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -12,6 +12,7 @@
 
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
+import platform from '@enact/core/platform';
 import {cap} from '@enact/core/util';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import Spottable from '@enact/spotlight/Spottable';
@@ -216,8 +217,11 @@ const ButtonBase = kind({
 		delete rest.iconPosition;
 		delete rest.focusEffect;
 
+		const isMobile = platform.platformName === 'androidChrome' || platform.platformName === 'ios' || platform.platformName === 'safari';
+
 		return UiButtonBase.inline({
 			'data-webos-voice-intent': 'Select',
+			fontFamily: isMobile ? 'Noto Sans' : '',
 			...rest,
 			css
 		});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Picker` changed the size of @sand-picker-line-height
 - `sandstone/VideoPlayer` to handle media related callbacks properly
 - `sandstone/FormCheckboxItem` to show correct color for the focused disabled checkbox
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Picker` line-height so tall characters are not truncated on mobile devices
+- `sandstone/PickerItem` changed font so tall characters are not truncated on mobile devices
+- `sandstone/Button` changed font so tall characters are not truncated on mobile devices
 - `sandstone/Button` to have centered icon on RTL locale
 - `sandstone/VideoPlayer` to handle media related callbacks properly
 - `sandstone/FormCheckboxItem` to show correct color for the focused disabled checkbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Picker` changed the size of @sand-picker-line-height
+- `sandstone/Picker` line-height so tall characters are not truncated on mobile devices
 - `sandstone/Button` to have centered icon on RTL locale
 - `sandstone/VideoPlayer` to handle media related callbacks properly
 - `sandstone/FormCheckboxItem` to show correct color for the focused disabled checkbox

--- a/internal/Picker/PickerItem.js
+++ b/internal/Picker/PickerItem.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import platform from '@enact/core/platform';
 
 import Marquee from '../../Marquee';
 
@@ -16,9 +17,12 @@ const PickerItemBase = kind({
 		className: ({children, styler}) => styler.append({numeric: !isNaN(Number(children))})
 	},
 
-	render: (props) => (
-		<Marquee {...props} alignment="center" />
-	)
+	render: (props) => {
+		const isMobile = platform.platformName === 'androidChrome' || platform.platformName === 'ios' || platform.platformName === 'safari';
+		const fontFamily = isMobile ? {fontFamily: 'Noto Sans'} : {};
+
+		return <Marquee {...props} alignment="center" style={fontFamily}/>
+	}
 });
 
 export default PickerItemBase;

--- a/internal/Picker/PickerItem.js
+++ b/internal/Picker/PickerItem.js
@@ -21,7 +21,7 @@ const PickerItemBase = kind({
 		const isMobile = platform.platformName === 'androidChrome' || platform.platformName === 'ios' || platform.platformName === 'safari';
 		const fontFamily = isMobile ? {fontFamily: 'Noto Sans'} : {};
 
-		return <Marquee {...props} alignment="center" style={fontFamily}/>
+		return <Marquee {...props} alignment="center" style={fontFamily} />;
 	}
 });
 

--- a/styles/internal/fonts.less
+++ b/styles/internal/fonts.less
@@ -1,5 +1,9 @@
 @import "~@enact/ui/styles/mixins.less";
 
+// Imported font Noto Sans used to fix problem with tall glyphs on mobile devices
+//
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap');
+
 // Local theme font variables (not to be used externally)
 //
 @font-family-base-name: "Sandstone";
@@ -71,7 +75,6 @@
 	// nameWeightStyleRepeat:			local("name") 100 italic, local("name2") 200 normal;
 	// nameMultipleWeightStyleRepeat:	local("name") 100 900 italic, local("name2") 200 800 normal;
 };
-
 
 // Deprecated Mixin. Retained for legacy references.
 // Generate a pair of rules in the correct order for the fallback glyphs and the preferred glyphs

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -288,7 +288,7 @@
 @sand-tallglyph-item-small-label-line-height: @sand-tallglyph-item-small-line-height;
 
 // Picker
-@sand-picker-line-height: 1.88em;
+@sand-picker-line-height: 1.5em;
 @sand-tallglyph-picker-line-height: @sand-tallglyph-body-line-height;
 @sand-picker-joined-font-weight: @sand-spottable-font-weight;
 

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -288,7 +288,7 @@
 @sand-tallglyph-item-small-label-line-height: @sand-tallglyph-item-small-line-height;
 
 // Picker
-@sand-picker-line-height: 1.5em;
+@sand-picker-line-height: 1.88em;
 @sand-tallglyph-picker-line-height: @sand-tallglyph-body-line-height;
 @sand-picker-joined-font-weight: @sand-spottable-font-weight;
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Changed the font for picker Item and Button to Noto Sans to display the tall glyphs correctly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The font was applied only to pickerItem and Button because it had no impact on the rest of the components. The change of fonts does not fix the problem for joined picker.

### Links
[//]: # (Related issues, references)
WRN-12676

### Comments
