### PR TITLE
WRN-12703: Fixed container height for Spinner qa-samples

### DIFF
--- a/samples/sampler/stories/qa/Spinner.js
+++ b/samples/sampler/stories/qa/Spinner.js
@@ -64,8 +64,7 @@ export const WithLongContent = (args) => (
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
 				ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-				laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+				laboris nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<Button onClick={action('Inside Button events')}>Button</Button>
 			<Spinner
@@ -100,9 +99,7 @@ export const BlockingClickEvents = (args) => (
 			<p>
 				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
 				ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-				laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-				cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+				laboris nisi ut aliquip ex ea commodo consequat.
 			</p>
 			<Button onClick={action('Inside Button events')}>Button</Button>
 			<Spinner

--- a/samples/sampler/stories/qa/Spinner.js
+++ b/samples/sampler/stories/qa/Spinner.js
@@ -57,7 +57,7 @@ export const WithLongContent = (args) => (
 	<div>
 		<div
 			style={{
-				height: ri.scaleToRem(840),
+				height: 'fit-content',
 				border: ri.scaleToRem(6) + ' dotted red'
 			}}
 		>
@@ -65,8 +65,7 @@ export const WithLongContent = (args) => (
 				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
 				ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
 				laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-				cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 			</p>
 			<Button onClick={action('Inside Button events')}>Button</Button>
 			<Spinner
@@ -94,7 +93,7 @@ export const BlockingClickEvents = (args) => (
 	<div>
 		<div
 			style={{
-				height: ri.scaleToRem(300),
+				height: 'fit-content',
 				border: ri.scaleToRem(6) + ' dotted red'
 			}}
 		>
@@ -102,7 +101,8 @@ export const BlockingClickEvents = (args) => (
 				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
 				ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
 				laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+				voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+				cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 			</p>
 			<Button onClick={action('Inside Button events')}>Button</Button>
 			<Spinner

--- a/samples/sampler/stories/qa/Spinner.js
+++ b/samples/sampler/stories/qa/Spinner.js
@@ -94,7 +94,7 @@ export const BlockingClickEvents = (args) => (
 	<div>
 		<div
 			style={{
-				height: ri.scaleToRem(840),
+				height: ri.scaleToRem(300),
 				border: ri.scaleToRem(6) + ' dotted red'
 			}}
 		>
@@ -102,8 +102,7 @@ export const BlockingClickEvents = (args) => (
 				Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
 				ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
 				laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-				voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-				cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+				voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 			</p>
 			<Button onClick={action('Inside Button events')}>Button</Button>
 			<Spinner


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The container for the qa-samplers for "Spinner with long content" and "Spinner blocking click events" had a height bigger than the screen size or the 2 buttons were overlapping

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the height of the container to "fit-content" in order to make all the content fit on screens with portrait mode ( phones and tablets)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12703

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com