### PR TITLE
WRN-12696: Cross-Platform Enact Android/iOS: Alert - content clipped.

### DIFF
--- a/Alert/Alert.js
+++ b/Alert/Alert.js
@@ -8,6 +8,7 @@
  */
 
 import kind from '@enact/core/kind';
+import platform from '@enact/core/platform';
 import {mapAndFilterChildren} from '@enact/core/util';
 import IdProvider from '@enact/ui/internal/IdProvider';
 import Layout, {Cell} from '@enact/ui/Layout';
@@ -176,6 +177,9 @@ const AlertBase = kind({
 		const layoutOrientation = (fullscreen ? 'vertical' : 'horizontal');
 		const showTitle = (fullscreen && title);
 		const ariaLabelledBy = (showTitle ? `${id}_title ` : '') + `${id}_content ${id}_buttons`;
+		const isMobile = platform.platformName === 'androidChrome' || platform.platformName === 'ios' || platform.platformName === 'safari';
+		const limitWidth = isMobile && !fullscreen ? {width: `${window.innerWidth / 4}px`} : '';
+
 		return (
 			<div aria-owns={id} className={css.alertWrapper}>
 				<Popup
@@ -189,7 +193,7 @@ const AlertBase = kind({
 					<Layout align="center center" orientation={layoutOrientation}>
 						{image ? <Cell shrink className={css.alertImage}>{image}</Cell> : null}
 						{showTitle ? <Cell shrink><Heading size="title" alignment="center" className={css.title} id={`${id}_title`}>{title}</Heading></Cell> : null}
-						<Cell shrink align={fullscreen ? 'center' : ''} component={contentComponent} className={css.content} id={`${id}_content`}>
+						<Cell shrink align={fullscreen ? 'center' : ''} component={contentComponent} className={css.content} id={`${id}_content`} style={limitWidth}>
 							{children}
 						</Cell>
 						{buttons ?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Alert` to have smaller content area on mobile
+
 ## [2.1.2] - 2021-12-22
 
 - Fixed samples build issue 
@@ -13,7 +19,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Alert` to have smaller content area on mobile
 - `sandstone/Button` to have centered icon on RTL locale
 - `sandstone/VideoPlayer` to handle media related callbacks properly
 - `sandstone/FormCheckboxItem` to show correct color for the focused disabled checkbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-
 - `sandstone/Alert` to have smaller content area on mobile
 - `sandstone/Button` to have centered icon on RTL locale
 - `sandstone/VideoPlayer` to handle media related callbacks properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+
+- `sandstone/Alert` to have smaller content area on mobile
 - `sandstone/Button` to have centered icon on RTL locale
 - `sandstone/VideoPlayer` to handle media related callbacks properly
 - `sandstone/FormCheckboxItem` to show correct color for the focused disabled checkbox

--- a/samples/sampler/stories/default/Alert.js
+++ b/samples/sampler/stories/default/Alert.js
@@ -1,3 +1,4 @@
+import platform from '@enact/core/platform';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
@@ -9,25 +10,27 @@ AlertImage.displayName = 'AlertImage';
 const Config = mergeComponentMetadata('Alert', AlertBase, Alert);
 const ImageConfig = mergeComponentMetadata('AlertImage', AlertImage);
 
+const isMobile = platform.platformName === 'androidChrome' || platform.platformName === 'ios' || platform.platformName === 'safari';
+
 const prop = {
 	buttons: {
 		'no buttons': null,
 		'1 button': (
 			<buttons>
-				<Button>Button Label</Button>
+				<Button size={isMobile ? 'small' : 'large'}>Button Label</Button>
 			</buttons>
 		),
 		'2 buttons': (
 			<buttons>
-				<Button>Button Label</Button>
-				<Button>Button Label</Button>
+				<Button size={isMobile ? 'small' : 'large'}>Button Label</Button>
+				<Button size={isMobile ? 'small' : 'large'}>Button Label</Button>
 			</buttons>
 		),
 		'3 buttons': (
 			<buttons>
-				<Button>Button Label</Button>
-				<Button>Button Label</Button>
-				<Button>Button Label</Button>
+				<Button size={isMobile ? 'small' : 'large'}>Button Label</Button>
+				<Button size={isMobile ? 'small' : 'large'}>Button Label</Button>
+				<Button size={isMobile ? 'small' : 'large'}>Button Label</Button>
 			</buttons>
 		)
 	}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The alert content is clipped for type overlay.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the width of alert's content area on mobile devices to better handle overlay on smaller screens. Also changed the size of the buttons in sampler if on mobile devices to better illustrate how it should look.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12696

### Comments
