### PR TITLE
WRN-12697: Cross-Platform Enact Android/iOS: BodyText - font size should change for rtl locale

### DIFF
--- a/BodyText/BodyText.module.less
+++ b/BodyText/BodyText.module.less
@@ -17,6 +17,10 @@
 		.enact-locale-tallglyph({
 			font-size: @sand-tallglyph-body-small-font-size;
 		});
+
+		.sand-locale-non-latin({
+			font-size: @sand-non-latin-body-small-font-size;
+		});
 	}
 
 	.enact-locale-rtl({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/BodyText` size when RTL locale is used
+- `sandstone/BodyText` font-size for size `small` and RTL locale
 
 ## [2.1.2] - 2021-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/BodyText` size when RTL locale is used
+
 ## [2.1.2] - 2021-12-22
 
 - Fixed samples build issue 

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -167,6 +167,7 @@
 @sand-tallglyph-alert-title-font-size:  @sand-alert-title-font-size;
 @sand-tallglyph-alert-notitle-content-font-size: @sand-alert-notitle-content-font-size;
 @sand-non-latin-body-font-size:         54px;
+@sand-non-latin-body-small-font-size:   48px;
 @sand-tallglyph-body-small-font-size:   48px;
 @sand-non-latin-button-large-font-size: 72px;
 @sand-non-latin-button-small-font-size: 54px;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`BodyText` does not change size when RTL locale is used

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a new `@sand-non-latin-body-small-font-size: 48px` variable. An old PR (#6) removed this variable when upgrading variables from FHD to 4k

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12697

### Comments
