### PR TITLE
WRN-12676: Use web font(thai) instead of system font to avoid truncating tall strings

### DIFF
--- a/styles/internal/fonts.less
+++ b/styles/internal/fonts.less
@@ -35,6 +35,9 @@
 @font-system-src-sandstone-icons:  local("Sandstone Icons"), local("SandstoneIcons"), url("../../fonts/Sandstone_Icons.ttf") format("truetype");
 @font-system-src-lg-icons:         @font-system-src-sandstone-400, local("LG Smart UI Dingbat"), local("LGSmartUIDingbat");
 
+// ----- WEB FONT NAMES ------
+@font-web-src-th-locale-normal: url(https://fonts.gstatic.com/s/notosansthai/v13/iJWQBXeUZi_OHPqn4wq6hQ2_hbJ1xyN9wd43SofNWcdfKI2h.woff2) format('woff2');
+
 // Localized fonts
 // Order correlates with load and priority order. Later fonts are stacked on top of earlier fonts.
 // In the case of glyphs existing in two fonts, the later glyphs will be used.
@@ -115,6 +118,8 @@
 .buildFontFamily("@{font-family-base-name} Number"; @font-system-src-sandstone-number-700; @font-system-src-sandstone-condensed-700; 700);
 
 /* ----- Manual Sandstone Locale Fonts (Stacking onto "Sandstone") ------ */
+.buildFontFace(@font-family-base-name; @font-web-src-th-locale-normal; 300 400 600 700);
+
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-400);
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-300; 300);
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-600; 600);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On android devices, some tall strings(th-TH locale) is truncated since they use system font.
Make web font to be rendered instead of system font for this specific case.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
@font-face rule related to thai font will be stacked onto Manual Sandstone Locale Fonts rules.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Need to be tested with enact:feature/WRN-12676 branch (https://github.com/enactjs/enact/pull/2990)

### Links
[//]: # (Related issues, references)
WRN-12676

### Comments
