### PR TITLE
WRN-12781: Fixed Scroller to scroll correctly on AndroidChrome in RTL locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales via 5way
+
 ## [2.1.2] - 2021-12-22
 
 - Fixed samples build issue 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales via 5way
+- `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales
 
 ## [2.1.2] - 2021-12-22
 

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -259,7 +259,7 @@ const useSpottable = (props, instances) => {
 	/**
 	 * Calculates the new `scrollLeft`.
 	 *
-	 * @param {Node} focusedItem node
+	 * @param {Node} item node
 	 * @param {Number} scrollPosition last target position, passed when scroll animation is ongoing
 	 *
 	 * @returns {Number} Calculated `scrollLeft`
@@ -275,7 +275,7 @@ const useSpottable = (props, instances) => {
 		const
 			{rtl} = props,
 			// For Chrome 85+ or Safari that use negative coordinate system for RTL
-			coordinateCoefficient = rtl && (platform.ios || platform.safari || platform.chrome >= 85) ? -1 : 1,
+			coordinateCoefficient = rtl && (platform.ios || platform.safari || platform.chrome >= 85 || platform.androidChrome >= 85) ? -1 : 1,
 			{clientWidth} = scrollContentHandle.current.scrollBounds,
 			rtlDirection = rtl ? -1 : 1,
 			{left: containerLeft} = scrollContentNode.getBoundingClientRect(),


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- fixed `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales
- fixed jsdoc for calculateScrollLeft function

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12781

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com