### PR TITLE
WRN-14493: Hide submit button in Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Input` prop `noSubmitButton` to omit submit button of number key pad
+
 ## [1.4.4-experimental-9] - 2021-11-25
 
 - The distribution 1.4.4-experimental-8 was broken due to changes in the dependencies

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -137,6 +137,14 @@ const InputPopupBase = kind({
 		noBackButton: PropTypes.bool,
 
 		/**
+		 * Omits the submit button.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		noSubmitButton: PropTypes.bool,
+
+		/**
 		 * The type of numeric input to use.
 		 *
 		 * The default is to display separated digits when `length` is less than `7`. If `field` is
@@ -330,6 +338,7 @@ const InputPopupBase = kind({
 		children,
 		css,
 		noBackButton,
+		noSubmitButton,
 		numberInputField,
 		onBeforeChange,
 		onClose,
@@ -404,6 +413,7 @@ const InputPopupBase = kind({
 								showKeypad
 								type={(type === 'passwordnumber') ? 'password' : 'number'}
 								numberInputField={numberInputField}
+								noSubmitButton={noSubmitButton}
 							/> :
 							<InputField
 								{...inputProps}

--- a/Input/NumberField.js
+++ b/Input/NumberField.js
@@ -74,6 +74,7 @@ const NumberFieldBase = kind({
 		invalidMessage: PropTypes.string,
 		maxLength: PropTypes.number,
 		minLength: PropTypes.number,
+		noSubmitButton: PropTypes.bool,
 		numberInputField: PropTypes.string,
 		onBeforeChange: PropTypes.func,
 		onComplete: PropTypes.func,
@@ -152,10 +153,10 @@ const NumberFieldBase = kind({
 				);
 			}
 		},
-		submitButton: ({css, disabled, invalid, maxLength, minLength, onSubmit, value, numberInputField}) => {
+		submitButton: ({css, disabled, invalid, maxLength, minLength, noSubmitButton, onSubmit, value, numberInputField}) => {
 			const isDisabled = disabled || invalid || (normalizeValue(value, maxLength).toString().length < minLength);
 
-			if (minLength !== maxLength || !getSeparated(numberInputField, maxLength)) {
+			if (!noSubmitButton && (minLength !== maxLength || !getSeparated(numberInputField, maxLength))) {
 				return <Button className={css.submitButton} disabled={isDisabled} onClick={onSubmit}>{$L('Submit')}</Button>;
 			} else {
 				return null;
@@ -175,6 +176,7 @@ const NumberFieldBase = kind({
 		delete rest.invalid;
 		delete rest.invalidMessage;
 		delete rest.minLength;
+		delete rest.noSubmitButton;
 		delete rest.onBeforeChange;
 		delete rest.onComplete;
 		delete rest.onSubmit;

--- a/Input/tests/Input-specs.js
+++ b/Input/tests/Input-specs.js
@@ -434,4 +434,17 @@ describe('Input specs', () => {
 		const actual = spy.mock.calls.length;
 		expect(actual).toBe(expected);
 	});
+
+	test('should not include a submit button when noSubmitButton is used', () => {
+		const subject = mount(
+			<FloatingLayerController>
+				<Input type="number" length={4} open numberInputField="joined" noSubmitButton />
+			</FloatingLayerController>
+		);
+
+		const expected = 0;
+		const actual = subject.find('.submitButton').first().length;
+
+		expect(actual).toBe(expected);
+	});
 });

--- a/samples/sampler/stories/default/Input.js
+++ b/samples/sampler/stories/default/Input.js
@@ -43,6 +43,7 @@ storiesOf('Sandstone', module)
 				'aria-label': text('aria-label', ConfigPopup, ''),
 				popupAriaLabel: text('popupAriaLabel', ConfigPopup, ''),
 				noBackButton: boolean('noBackButton', ConfigPopup),
+				noSubmitButton: boolean('noSubmitButton', ConfigPopup),
 				backButtonAriaLabel: select('backButtonAriaLabel', prop.backButtonAriaLabel, ConfigPopup)
 			};
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We need to backport #971 into the old touch branch to provide apps a way to hide a submit button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Cherry-picked #971

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
#971
WRN-14493
PLAT-145596

### Comments
