### PR TITLE
WRN-13076: Support overscroll effect for flicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/Scroller` and `sandstone/VirtualList` to show overscroll effect when flicking
+
 ## [2.1.2] - 2021-12-22
 
 - Fixed samples build issue 
@@ -9,6 +15,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ## [2.1.1] - 2021-12-22
 
 ### Added
+
 - `sandstone/VideoPlayer` props `onWillFastForward`, `onWillJumpBackward`, `onWillJumpForward`, `onWillPause`, `onWillPlay`, and `onWillRewind`
 
 ### Fixed

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -335,7 +335,7 @@ Scroller.propTypes = /** @lends sandstone/Scroller.Scroller.prototype */ {
 	 * @type {Object}
 	 * @default {
 	 *	arrowKey: false,
-	 *	drag: false,
+	 *	drag: true,
 	 *	pageKey: false,
 	 *	track: false,
 	 *	wheel: true
@@ -420,7 +420,7 @@ Scroller.defaultProps = {
 	onScrollStop: nop,
 	overscrollEffectOn: {
 		arrowKey: false,
-		drag: false,
+		drag: true,
 		pageKey: false,
 		track: false,
 		wheel: true

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -346,7 +346,7 @@ VirtualList.propTypes = /** @lends sandstone/VirtualList.VirtualList.prototype *
 	 * @type {Object}
 	 * @default {
 	 *	arrowKey: false,
-	 *	drag: false,
+	 *	drag: true,
 	 *	pageKey: false,
 	 *	track: false,
 	 *	wheel: true
@@ -471,7 +471,7 @@ VirtualList.defaultProps = {
 	onScrollStop: nop,
 	overscrollEffectOn: {
 		arrowKey: false,
-		drag: false,
+		drag: true,
 		pageKey: false,
 		track: false,
 		wheel: true
@@ -786,7 +786,7 @@ VirtualGridList.propTypes = /** @lends sandstone/VirtualList.VirtualGridList.pro
 	 * @type {Object}
 	 * @default {
 	 *	arrowKey: false,
-	 *	drag: false,
+	 *	drag: true,
 	 *	pageKey: false,
 	 *	track: false,
 	 *	wheel: true
@@ -920,7 +920,7 @@ VirtualGridList.defaultProps = {
 	onScrollStop: nop,
 	overscrollEffectOn: {
 		arrowKey: false,
-		drag: false,
+		drag: true,
 		pageKey: false,
 		track: false,
 		wheel: true


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Feature to show overscroll effect for flicking input on touchable devices

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated default effect option for lists and scrollers.
For better tracking, I cherry-picked an old PR from an experimental branch for touch support testing.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
On touchable devices, flicking by a press-and-hold pointer also makes overscroll effects when a scrollable component reaches the edge. This is intended behavior as a pointer scrolls contents when a user press-and-hold a button.

### Links
[//]: # (Related issues, references)
WRN-13076
PLAT-125221
#792
#874

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
