### PR TITLE
WRN-12963: Add back button to Video Player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [2.1.2] - 2021-12-22
 
-- Fixed samples build issue 
+- Fixed samples build issue
 
 ## [2.1.1] - 2021-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
-
 ### Added
 
 - `sandstone/VideoPlayer` prop `backButtonAriaLabel`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/VideoPlayer` prop `onBack` to provide a way to exit video player via touch
+
 ### Fixed
 
 - `sandstone/BodyText` font-size for size `small` and RTL locale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/VideoPlayer` prop `backButtonAriaLabel`
 - `sandstone/VideoPlayer` prop `onBack` to provide a way to exit video player via touch
 
 ### Fixed

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -26,7 +26,8 @@ import css from './MediaControls.module.less';
 const OuterContainer = SpotlightContainerDecorator({
 	defaultElement: [
 		`.${spotlightDefaultClass}`
-	]
+	],
+	leaveFor: {left: '', right: ''}
 }, 'div');
 const Container = SpotlightContainerDecorator({
 	enterTo: 'default-element'

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -11,7 +11,7 @@ import ApiDecorator from '@enact/core/internal/ApiDecorator';
 import {on, off} from '@enact/core/dispatcher';
 import {memoize} from '@enact/core/util';
 
-import {adaptEvent, call, forKey, forward, forwardWithPrevent, handle, preventDefault, stopImmediate, returnsTrue} from '@enact/core/handle';
+import {adaptEvent, call, forKey, forward, forwardCustom, forwardWithPrevent, handle, preventDefault, stopImmediate, returnsTrue} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import {platform} from '@enact/core/platform';
 import EnactPropTypes from '@enact/core/internal/prop-types';
@@ -1778,6 +1778,8 @@ const VideoPlayerBase = class extends Component {
 		this.sliderScrubbing = false;
 	};
 
+	handleBack = this.handle(forwardCustom('onBack'));
+
 	handleKnobMove = (ev) => {
 		this.sliderScrubbing = true;
 
@@ -2051,7 +2053,7 @@ const VideoPlayerBase = class extends Component {
 									className={css.back}
 									icon="arrowhookleft"
 									iconFlip="auto"
-									onClick={onBack}
+									onClick={this.handleBack}
 									size="small"
 								/> :
 								null

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -207,6 +207,15 @@ const VideoPlayerBase = class extends Component {
 		autoCloseTimeout: PropTypes.number,
 
 		/**
+		 * Sets the hint string read when focusing the back button.
+		 *
+		 * @type {String}
+		 * @default 'go to previous'
+		 * @public
+		 */
+		backButtonAriaLabel: PropTypes.string,
+
+		/**
 		 * Removes interactive capability from this component. This includes, but is not limited to,
 		 * key-press events, most clickable buttons, and prevents the showing of the controls.
 		 *
@@ -1920,6 +1929,7 @@ const VideoPlayerBase = class extends Component {
 
 	render () {
 		const {
+			backButtonAriaLabel,
 			className,
 			disabled,
 			infoComponents,
@@ -2037,8 +2047,10 @@ const VideoPlayerBase = class extends Component {
 						{
 							this.state.mediaControlsVisible ?
 								<Button
+									aria-label={backButtonAriaLabel == null ? $L('go to previous') : backButtonAriaLabel}
 									className={css.back}
 									icon="arrowhookleft"
+									iconFlip="auto"
 									onClick={onBack}
 									size="small"
 								/> :

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -1964,6 +1964,7 @@ const VideoPlayerBase = class extends Component {
 		delete mediaProps.miniFeedbackHideDelay;
 		delete mediaProps.noAutoShowMediaControls;
 		delete mediaProps.noMediaSliderFeedback;
+		delete mediaProps.onBack;
 		delete mediaProps.onControlsAvailable;
 		delete mediaProps.onFastForward;
 		delete mediaProps.onJumpBackward;

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -35,6 +35,7 @@ import {isValidElement, cloneElement, Component} from 'react';
 import ReactDOM from 'react-dom';
 
 import $L from '../internal/$L';
+import Button from '../Button';
 import Skinnable from '../Skinnable';
 import Spinner from '../Spinner';
 import {
@@ -84,7 +85,7 @@ const RootContainer = SpotlightContainerDecorator(
 
 const ControlsContainer = SpotlightContainerDecorator(
 	{
-		enterTo: '',
+		enterTo: 'default-element',
 		straightOnly: true
 	},
 	'div'
@@ -399,6 +400,14 @@ const VideoPlayerBase = class extends Component {
 		 * @public
 		 */
 		noSpinner: PropTypes.bool,
+
+		/**
+		 * Called when the back button is clicked.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onBack: PropTypes.func,
 
 		/**
 		 * Called when the player's controls change availability, whether they are shown
@@ -1744,11 +1753,6 @@ const VideoPlayerBase = class extends Component {
 		};
 	};
 
-	disablePointerMode = () => {
-		Spotlight.setPointerMode(false);
-		return true;
-	};
-
 	//
 	// Player Interaction events
 	//
@@ -1836,8 +1840,6 @@ const VideoPlayerBase = class extends Component {
 			}
 		} else if (is('up', keyCode)) {
 			Spotlight.setPointerMode(false);
-			preventDefault(ev);
-			stopImmediate(ev);
 		}
 	};
 
@@ -1931,6 +1933,7 @@ const VideoPlayerBase = class extends Component {
 			noMiniFeedback,
 			noSlider,
 			noSpinner,
+			onBack,
 			selection,
 			spotlightDisabled,
 			spotlightId,
@@ -2031,6 +2034,16 @@ const VideoPlayerBase = class extends Component {
 						>
 							{secondsToTime(this.state.sliderTooltipTime, durFmt)}
 						</FeedbackContent>
+						{
+							this.state.mediaControlsVisible ?
+								<Button
+									className={css.back}
+									icon="arrowhookleft"
+									onClick={onBack}
+									size="small"
+								/> :
+								null
+						}
 						<ControlsContainer
 							className={css.bottom + (this.state.mediaControlsVisible ? '' : ' ' + css.hidden) + (this.state.infoVisible ? ' ' + css.lift : '')}
 							spotlightDisabled={spotlightDisabled || !this.state.mediaControlsVisible}
@@ -2074,7 +2087,6 @@ const VideoPlayerBase = class extends Component {
 										onFocus={this.handleSliderFocus}
 										onKeyDown={this.handleSliderKeyDown}
 										onKnobMove={this.handleKnobMove}
-										onSpotlightUp={this.handleSpotlightUpFromSlider}
 										selection={proportionSelection}
 										spotlightDisabled={spotlightDisabled || !this.state.mediaControlsVisible}
 										value={this.state.proportionPlayed}

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -1945,7 +1945,6 @@ const VideoPlayerBase = class extends Component {
 			noMiniFeedback,
 			noSlider,
 			noSpinner,
-			onBack,
 			selection,
 			spotlightDisabled,
 			spotlightId,

--- a/VideoPlayer/VideoPlayer.module.less
+++ b/VideoPlayer/VideoPlayer.module.less
@@ -52,6 +52,12 @@
 			pointer-events: none;
 		}
 
+		.back {
+			position: absolute;
+			top: @sand-video-back-button-top;
+			.position-start-end(@sand-video-back-button-left, initial);
+		}
+
 		.bottom {
 			position: absolute;
 			z-index: 100;  // Value assigned as part of the VideoPlayer API so layers may be inserted in-between

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -142,6 +142,7 @@ export const _VideoPlayer = (args) => {
 			</label>
 			<VideoPlayer
 				autoCloseTimeout={args['autoCloseTimeout']}
+				backButtonAriaLabel={args['backButtonAriaLabel']}
 				disabled={args['disabled']}
 				feedbackHideDelay={args['feedbackHideDelay']}
 				initialJumpDelay={args['initialJumpDelay']}
@@ -210,6 +211,7 @@ export const _VideoPlayer = (args) => {
 select('source', _VideoPlayer, prop.videoTitles, Config, 'Sintel');
 range('video scale', _VideoPlayer, Config, {min: 0.05, max: 1, step: 0.01}, 1);
 number('autoCloseTimeout', _VideoPlayer, Config, 7000);
+text('backButtonAriaLabel', _VideoPlayer, Config, 'go to previous');
 boolean('disabled', _VideoPlayer, Config);
 number('feedbackHideDelay', _VideoPlayer, Config, 3000);
 number('initialJumpDelay', _VideoPlayer, Config, 400);

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -53,6 +53,7 @@ const prop = {
 	},
 	events: [
 		'onAbort',
+		'onBack',
 		'onCanPlay',
 		'onCanPlayThrough',
 		'onControlsAvailable',

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -943,6 +943,8 @@
 
 // Video
 // ---------------------------------------
+@sand-video-back-button-left                      : 150px;
+@sand-video-back-button-top                       : 114px;
 @sand-video-slider-tooltip-arrow-border-left-right: 18px;
 @sand-video-slider-tooltip-arrow-border-top:       24px;
 @sand-video-slider-tooltip-position-bottom:        42px;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -943,8 +943,8 @@
 
 // Video
 // ---------------------------------------
-@sand-video-back-button-left                      : 150px;
-@sand-video-back-button-top                       : 114px;
+@sand-video-back-button-left:                      150px;
+@sand-video-back-button-top:                       114px;
 @sand-video-slider-tooltip-arrow-border-left-right: 18px;
 @sand-video-slider-tooltip-arrow-border-top:       24px;
 @sand-video-slider-tooltip-position-bottom:        42px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Video player needs backbutton and a prop for aria-label override.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Cherrypick https://github.com/enactjs/sandstone/pull/803 
- Add backButtonAriaLabel.
- To support RTL, add iconFlip="auto"


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12963, WRN-127111

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
