### PR TITLE
WRN-12845: Fixed joined horizontal Picker to go to the next item by touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- Joined horizontal `sandstone/Picker` to go to the next item by touch
+- `sandstone/Picker` joined horizontal to go to the next item by touch
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Fixed
+
+- Joined horizontal `sandstone/Picker` to go to the next item by touch
+
 ### Added
 
 - `sandstone/VideoPlayer` prop `backButtonAriaLabel`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
-### Fixed
-
-- `sandstone/Picker` joined horizontal to go to the next item by touch
-
 ### Added
 
 - `sandstone/VideoPlayer` prop `backButtonAriaLabel`
@@ -22,6 +18,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/BodyText` font-size for size `small` and RTL locale
 - `sandstone/Input.InputField` size 'small' line-height to center text vertically
 - `sandstone/Input` to show title and keypad properly when `type` is `number` and screen width is narrow
+- `sandstone/Picker` horizontal joined behavior going to the next item by touch
 - `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales
 
 ## [2.1.2] - 2021-12-22

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -60,7 +60,6 @@ const selectDecIcon = selectIcon('decrementIcon', 'triangledown', 'triangleleft'
 const forwardBlur = forward('onBlur'),
 	forwardFocus = forward('onFocus'),
 	forwardKeyDown = forward('onKeyDown'),
-	forwardMouseDown = forward('onMouseDown'),
 	forwardKeyUp = forward('onKeyUp'),
 	forwardWheel = forward('onWheel');
 
@@ -552,14 +551,6 @@ const PickerBase = class extends ReactComponent {
 
 	emulateMouseUp = new Job(this.clearPressedState, 175);
 
-	handleMouseDown = (ev) => {
-		const {joined, orientation} = this.props;
-		forwardMouseDown(ev, this.props);
-
-		if (joined && orientation === 'horizontal') {
-			this.setIncPickerButtonPressed();
-		}
-	};
 
 	handleUp = () => {
 		if (this.props.joined && (this.pickerButtonPressed !== 0 || this.state.pressed !== 0)) {
@@ -569,6 +560,10 @@ const PickerBase = class extends ReactComponent {
 
 	handleDown = () => {
 		const {joined, orientation} = this.props;
+
+		if (joined && orientation === 'horizontal') {
+			this.setIncPickerButtonPressed();
+		}
 
 		if (joined && this.pickerButtonPressed === 1) {
 			this.handleIncrement();
@@ -952,7 +947,6 @@ const PickerBase = class extends ReactComponent {
 				onKeyDown={this.handleKeyDown}
 				onKeyUp={this.handleKeyUp}
 				onUp={this.handleUp}
-				onMouseDown={this.handleMouseDown}
 				onMouseLeave={this.clearPressedState}
 				orientation={orientation}
 				ref={this.initContainerRef}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed joined horizontal Picker to go to the next item by touch

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Go to the next item by clicking on the joined horizontal Picker was introduced sandstone by https://github.com/enyojs/sandstone/pull/179.
When this feature added, I assume the touch behavior was not considered.
When we interact with the mouse, `onDown` event is fired after `onMouseDown`. But, with touch, `onDown` event is fired before `onMouseDown` so the logic flows the wrong way.
To resolve this, I moved the `setIncPickerButtonPressed` related logic into `handleDown` so that even if the order of the events is swapped, the behavior could be right.

This change originated from https://github.com/enactjs/sandstone/pull/788.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12845

### Comments
Enact-DCO-1.0-Signed-off-by: Clapou George Vladut vladut.clapou@lgepartner.com