### PR TITLE
WRN-15665: VirtualList: Fix `HoverToScroll` to update properly after changing `dataSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` to show title and keypad properly when `type` is `number` and screen width is narrow
 - `sandstone/Picker` horizontal joined behavior going to the next item by touch
 - `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales
+- `sandstone/VirtualList` to scroll properly by hover after changing `dataSize` when `hoverToScroll` is `true`
 
 ## [2.1.2] - 2021-12-22
 

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -51,7 +51,7 @@ const directionToFocus = {
 const HoverToScrollBase = (props) => {
 	const {
 		direction,
-		scrollContainerHandle: {current: scrollContainer},
+		scrollContainer,
 		scrollObserver: {addObserverOnScroll, removeObserverOnScroll}
 	} = props;
 
@@ -213,7 +213,7 @@ HoverToScrollBase.displayName = 'HoverToScrollBase';
 
 HoverToScrollBase.propTypes = /** @lends sandstone/useScroll.HoverToScroll.HoverToScrollBase.prototype */ {
 	direction: PropTypes.string,
-	scrollContainerHandle: PropTypes.object
+	scrollContainer: PropTypes.object
 };
 
 /**
@@ -224,11 +224,11 @@ HoverToScrollBase.propTypes = /** @lends sandstone/useScroll.HoverToScroll.Hover
  * @ui
  * @private
  */
-const HoverToScroll = ({scrollContainerHandle, ...rest}) => {
-	return scrollContainerHandle ? (
+const HoverToScroll = ({scrollContainer, ...rest}) => {
+	return scrollContainer ? (
 		<>
-			<HoverToScrollBase scrollContainerHandle={scrollContainerHandle} {...rest} direction="horizontal" />
-			<HoverToScrollBase scrollContainerHandle={scrollContainerHandle} {...rest} direction="vertical" />
+			<HoverToScrollBase scrollContainer={scrollContainer} {...rest} direction="horizontal" />
+			<HoverToScrollBase scrollContainer={scrollContainer} {...rest} direction="vertical" />
 		</>
 	) : null;
 };
@@ -236,7 +236,7 @@ const HoverToScroll = ({scrollContainerHandle, ...rest}) => {
 HoverToScroll.displayName = 'HoverToScroll';
 
 HoverToScroll.propTypes = /** @lends sandstone/useScroll.HoverToScroll.prototype */ {
-	scrollContainerHandle: PropTypes.object
+	scrollContainer: PropTypes.object
 };
 
 export default HoverToScroll;

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -51,7 +51,7 @@ const directionToFocus = {
 const HoverToScrollBase = (props) => {
 	const {
 		direction,
-		scrollContainer,
+		scrollContainerHandleRef,
 		scrollObserver: {addObserverOnScroll, removeObserverOnScroll}
 	} = props;
 
@@ -70,7 +70,7 @@ const HoverToScrollBase = (props) => {
 	const handleGlobalKeyDown = useCallback(({keyCode}) => {
 		let position = mutableRef.current.hoveredPosition;
 
-		if (scrollContainer.rtl && direction === 'horizontal') {
+		if (scrollContainerHandleRef.rtl && direction === 'horizontal') {
 			position = position === 'after' ? 'before' : 'after';
 		}
 
@@ -79,9 +79,9 @@ const HoverToScrollBase = (props) => {
 				directionToFocus[direction][position],
 				getLastPointerPosition()
 			);
-			scrollContainer.stop();
+			scrollContainerHandleRef.stop();
 		}
-	}, [direction, scrollContainer]);
+	}, [direction, scrollContainerHandleRef]);
 
 	const startRaf = useCallback((job) => {
 		if (typeof window === 'object') {
@@ -105,7 +105,7 @@ const HoverToScrollBase = (props) => {
 	const getPointerEnterHandler = useCallback((position) => {
 		if (typeof window === 'object') {
 			const {axis, clientSize, maxPosition, scrollPosition} = getBoundsPropertyNames(direction);
-			const bounds = scrollContainer.getScrollBounds();
+			const bounds = scrollContainerHandleRef.getScrollBounds();
 
 			return function ({pointerType}) {
 				if (pointerType === 'mouse') {
@@ -118,12 +118,12 @@ const HoverToScrollBase = (props) => {
 
 					const scrollByHover = () => {
 						if (getLastInputType() === 'mouse') {
-							scrollContainer.scrollTo({
+							scrollContainerHandleRef.scrollTo({
 								position: {
 									[axis]: clamp(
 										0,
 										bounds[maxPosition],
-										scrollContainer[scrollPosition] + distance
+										scrollContainerHandleRef[scrollPosition] + distance
 									)
 								},
 								animate: false
@@ -139,11 +139,11 @@ const HoverToScrollBase = (props) => {
 		} else {
 			return nop;
 		}
-	}, [direction, scrollContainer, startRaf, stopRaf]);
+	}, [direction, scrollContainerHandleRef, startRaf, stopRaf]);
 
 	const update = useCallback(() => {
 		const {canScrollFunc, maxPosition, scrollPosition} = getBoundsPropertyNames(direction);
-		const {[canScrollFunc]: canScroll, getScrollBounds, [scrollPosition]: currentPosition} = scrollContainer;
+		const {[canScrollFunc]: canScroll, getScrollBounds, [scrollPosition]: currentPosition} = scrollContainerHandleRef;
 		const bounds = getScrollBounds();
 		const position = mutableRef.current.hoveredPosition;
 		let curAfter = false, curBefore = false;
@@ -159,7 +159,7 @@ const HoverToScrollBase = (props) => {
 
 		setAfter(curAfter);
 		setBefore(curBefore);
-	}, [direction, after, before, scrollContainer, stopRaf]);
+	}, [direction, after, before, scrollContainerHandleRef, stopRaf]);
 
 	// Hooks
 
@@ -171,8 +171,8 @@ const HoverToScrollBase = (props) => {
 	}, [update, addObserverOnScroll, removeObserverOnScroll]);
 
 	useLayoutEffect(() => {
-		if (scrollContainer) {
-			const {[getBoundsPropertyNames(direction).canScrollFunc]: canScroll, getScrollBounds} = scrollContainer;
+		if (scrollContainerHandleRef) {
+			const {[getBoundsPropertyNames(direction).canScrollFunc]: canScroll, getScrollBounds} = scrollContainerHandleRef;
 			if (canScroll && getScrollBounds) {
 				update();
 			} else {
@@ -180,7 +180,7 @@ const HoverToScrollBase = (props) => {
 				setBefore(null);
 			}
 		}
-	}, [update, direction, scrollContainer]);
+	}, [update, direction, scrollContainerHandleRef]);
 
 	useLayoutEffect(() => {
 		return () => {
@@ -213,7 +213,7 @@ HoverToScrollBase.displayName = 'HoverToScrollBase';
 
 HoverToScrollBase.propTypes = /** @lends sandstone/useScroll.HoverToScroll.HoverToScrollBase.prototype */ {
 	direction: PropTypes.string,
-	scrollContainer: PropTypes.object
+	scrollContainerHandleRef: PropTypes.object
 };
 
 /**
@@ -224,11 +224,11 @@ HoverToScrollBase.propTypes = /** @lends sandstone/useScroll.HoverToScroll.Hover
  * @ui
  * @private
  */
-const HoverToScroll = ({scrollContainer, ...rest}) => {
-	return scrollContainer ? (
+const HoverToScroll = ({scrollContainerHandleRef, ...rest}) => {
+	return scrollContainerHandleRef ? (
 		<>
-			<HoverToScrollBase scrollContainer={scrollContainer} {...rest} direction="horizontal" />
-			<HoverToScrollBase scrollContainer={scrollContainer} {...rest} direction="vertical" />
+			<HoverToScrollBase scrollContainerHandleRef={scrollContainerHandleRef} {...rest} direction="horizontal" />
+			<HoverToScrollBase scrollContainerHandleRef={scrollContainerHandleRef} {...rest} direction="vertical" />
 		</>
 	) : null;
 };
@@ -236,7 +236,7 @@ const HoverToScroll = ({scrollContainer, ...rest}) => {
 HoverToScroll.displayName = 'HoverToScroll';
 
 HoverToScroll.propTypes = /** @lends sandstone/useScroll.HoverToScroll.prototype */ {
-	scrollContainer: PropTypes.object
+	scrollContainerHandleRef: PropTypes.object
 };
 
 export default HoverToScroll;

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -485,7 +485,7 @@ const useScroll = (props) => {
 	});
 
 	assignProperties('hoverToScrollProps', {
-		scrollContainer: scrollContainerHandle.current,
+		scrollContainerHandleRef: scrollContainerHandle.current,
 		scrollObserver
 	});
 

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -485,7 +485,7 @@ const useScroll = (props) => {
 	});
 
 	assignProperties('hoverToScrollProps', {
-		scrollContainerHandle,
+		scrollContainer: scrollContainerHandle.current,
 		scrollObserver
 	});
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VirtualList/VirtualGridList: hoverToScroll not working after rendering

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Cause : 
`HoverToScrollBase` hook function and life cycle functions should be invoked properly when `scrollContainer` is updated.
However, the lifecycle functions are called later by setState from update().
It is becuase `HoverToScrollBase` receive `scrollContainerHandle` instead of `scrollContainer`.

Resolution : 
I changed `HoverToScrollBase` to get `scrollContainerHandle.current` instead of `scrollContainerHandle`.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-15665

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)