### PR TITLE
WRN-14979: Fix ui-test to use async test

### DIFF
--- a/tests/screenshot/specs/light/SandstonePage.js
+++ b/tests/screenshot/specs/light/SandstonePage.js
@@ -7,8 +7,8 @@ class SandstonePage extends Page {
 		this.title = 'Sandstone Test';
 	}
 
-	open (urlExtra) {
-		super.open('Sandstone-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('Sandstone-View', urlExtra);
 	}
 
 	get component () {

--- a/tests/screenshot/specs/neutral/SandstonePage.js
+++ b/tests/screenshot/specs/neutral/SandstonePage.js
@@ -7,8 +7,8 @@ class SandstonePage extends Page {
 		this.title = 'Sandstone Test';
 	}
 
-	open (urlExtra) {
-		super.open('Sandstone-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('Sandstone-View', urlExtra);
 	}
 
 	get component () {

--- a/tests/ui/specs/Alert/Alert-specs.js
+++ b/tests/ui/specs/Alert/Alert-specs.js
@@ -10,64 +10,65 @@ describe('Alert', () => {
 
 	// Using 5-way
 	describe('using 5-way', () => {
-		it('should spot the fullscreen alert button', () => {
-			expect(alertCommon.buttonFullscreen.isFocused()).to.be.true();
+		it('should spot the fullscreen alert button', async () => {
+			expect(await alertCommon.buttonFullscreen.isFocused()).to.be.true();
 		});
 
-		it('should spot the cancel button', () => {
-			Page.spotlightSelect();
-			Page.spotlightRight();
+		it('should spot the cancel button', async () => {
+			await Page.spotlightSelect();
+			await Page.spotlightRight();
 
-			expect(components.alertFullscreen.buttonCancel.isFocused()).to.be.true();
+			expect(await components.alertFullscreen.buttonCancel.isFocused()).to.be.true();
 		});
 
-		it('should close the fullscreen alert using the ok button', () => {
-			Page.spotlightSelect();
-			Page.spotlightSelect();
+		it('should close the fullscreen alert using the ok button', async () => {
+			await Page.spotlightSelect();
+			await Page.spotlightSelect();
 
-			expect(alertCommon.buttonFullscreen.isFocused()).to.be.true();
+			expect(await alertCommon.buttonFullscreen.isFocused()).to.be.true();
 		});
 
-		it('should close the fullscreen alert using the back key', () => {
-			Page.spotlightSelect();
-			Page.backKey();
+		it('should close the fullscreen alert using the back key', async () => {
+			await Page.spotlightSelect();
+			await Page.backKey();
 
-			expect(alertCommon.buttonFullscreen.isFocused()).to.be.true();
+			expect(await alertCommon.buttonFullscreen.isFocused()).to.be.true();
 		});
 
-		it('should spot the cancel button', () => {
-			Page.spotlightRight();
-			Page.spotlightSelect();
-			Page.spotlightDown();
+		it('should spot the cancel button', async () => {
+			await Page.spotlightRight();
+			await Page.spotlightSelect();
+			await Page.spotlightDown();
 
-			expect(components.alertOverlay.buttonCancel.isFocused()).to.be.true();
+			expect(await components.alertOverlay.buttonCancel.isFocused()).to.be.true();
 		});
 
-		it('should close the overlay alert using the close button', () => {
-			Page.spotlightRight();
-			Page.spotlightSelect();
-			Page.spotlightDown();
-			Page.spotlightSelect();
+		it('should close the overlay alert using the close button', async () => {
+			await Page.spotlightRight();
+			await Page.spotlightSelect();
+			await Page.spotlightDown();
+			await Page.spotlightSelect();
+			browser.pause(100);
 
-			expect(alertCommon.buttonOverlay.isFocused()).to.be.true();
+			expect(await alertCommon.buttonOverlay.isFocused()).to.be.true();
 		});
 
-		it('should close the overlay alert using the back key', () => {
-			Page.spotlightRight();
-			Page.spotlightSelect();
-			Page.backKey();
+		it('should close the overlay alert using the back key', async () => {
+			await Page.spotlightRight();
+			await Page.spotlightSelect();
+			await Page.backKey();
 
-			expect(alertCommon.buttonOverlay.isFocused()).to.be.true();
+			expect(await alertCommon.buttonOverlay.isFocused()).to.be.true();
 		});
 	});
 
 	// Using pointer
 	describe('using pointer', () => {
-		it('should focus the fullscreen alert button', () => {
-			expect(alertCommon.buttonFullscreen.isFocused()).to.be.true();
+		it('should focus the fullscreen alert button', async () => {
+			expect(await alertCommon.buttonFullscreen.isFocused()).to.be.true();
 		});
 
-		it('should open the fullscreen alert', () => {
+		it('should open the fullscreen alert', async () => {
 			alertCommon.buttonFullscreen.click();
 
 			browser.pause(100);
@@ -75,7 +76,7 @@ describe('Alert', () => {
 			validateTitle(components.alertFullscreen, 'Fullscreen Alert\nOk\nCancel');
 		});
 
-		it('should open and close the fullscreen alert', () => {
+		it('should open and close the fullscreen alert', async () => {
 			alertCommon.buttonFullscreen.click();
 
 			browser.pause(100);
@@ -86,7 +87,7 @@ describe('Alert', () => {
 			expectClosed(alertCommon);
 		});
 
-		it('should open the overlay alert', () => {
+		it('should open the overlay alert', async () => {
 			alertCommon.buttonOverlay.click();
 
 			browser.pause(100);
@@ -94,7 +95,7 @@ describe('Alert', () => {
 			validateTitle(components.alertOverlay, 'Overlay Alert\nOk\nCancel');
 		});
 
-		it('should open and close the overlay alert', () => {
+		it('should open and close the overlay alert', async () => {
 			alertCommon.buttonOverlay.click();
 
 			browser.pause(100);
@@ -106,7 +107,7 @@ describe('Alert', () => {
 			expectClosed(alertCommon);
 		});
 
-		it('should open and close the overlay alert by clicking the background', () => {
+		it('should open and close the overlay alert by clicking the background', async () => {
 			alertCommon.buttonOverlay.click();
 
 			browser.pause(100);

--- a/tests/ui/specs/Alert/Alert-specs.js
+++ b/tests/ui/specs/Alert/Alert-specs.js
@@ -4,8 +4,8 @@ const {expectClosed, expectOpen, validateTitle} = require('./Alert-utils.js');
 describe('Alert', () => {
 
 	const {alertCommon, components} = Page;
-	beforeEach(() => {
-		Page.open();
+	beforeEach(async () => {
+		await Page.open();
 	});
 
 	// Using 5-way

--- a/tests/ui/specs/Alert/Alert-utils.js
+++ b/tests/ui/specs/Alert/Alert-utils.js
@@ -1,13 +1,13 @@
-function validateTitle (alert, title) {
-	expect(alert.title).to.equal(title);
+async function validateTitle (alert, title) {
+	expect(await alert.title).to.equal(title);
 }
 
-const expectClosed = (alert) => {
-	expect(alert.isAlertExist).to.be.false();
+const expectClosed = async (alert) => {
+	expect(await alert.isAlertExist).to.be.false();
 };
 
-const expectOpen = (alert) => {
-	expect(alert.isAlertExist).to.be.true();
+const expectOpen = async (alert) => {
+	expect(await alert.isAlertExist).to.be.true();
 };
 
 module.exports = {

--- a/tests/ui/specs/Alert/AlertPage.js
+++ b/tests/ui/specs/Alert/AlertPage.js
@@ -49,8 +49,8 @@ class AlertPage extends Page {
 		this.components.alertOverlay = new AlertInterface('alertOverlay');
 	}
 
-	open (urlExtra) {
-		super.open('Alert-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('Alert-View', urlExtra);
 	}
 }
 

--- a/tests/ui/specs/Button/Button-specs.js
+++ b/tests/ui/specs/Button/Button-specs.js
@@ -14,29 +14,28 @@ describe('Button', function () {
 	} = Page.components;
 
 	describe('5-way', function () {
-		it('should focus disabled button on 5-way right', function () {
-			buttonDefault.focus();
-			Page.spotlightRight();
-			expect(buttonDisabled.self.isFocused()).to.be.true();
+		it('should focus disabled button on 5-way right', async function () {
+			await buttonDefault.focus();
+			await Page.spotlightRight();
+			expect(await buttonDisabled.self.isFocused()).to.be.true();
 		});
 
-		it('should focus buttonSizeSmall button on 5-way left', function () {
-			iconButton.focus();
-			Page.spotlightLeft();
-			expect(buttonSizeSmall.self.isFocused()).to.be.true();
+		it('should focus buttonSizeSmall button on 5-way left', async function () {
+			await iconButton.focus();
+			await Page.spotlightLeft();
+			expect(await buttonSizeSmall.self.isFocused()).to.be.true();
 		});
 	});
 
 	describe('pointer', function () {
-		it('should focus the disabled when hovered', function () {
-			buttonDisabled.hover();
-			expect(buttonDisabled.self.isFocused()).to.be.true();
+		it('should focus the disabled when hovered', async function () {
+			await buttonDisabled.hover();
+			expect(await buttonDisabled.self.isFocused()).to.be.true();
 		});
 
-		it('should focus first when hovered', function () {
-			buttonDefault.hover();
-			expect(buttonDefault.self.isFocused()).to.be.true();
+		it('should focus first when hovered', async function () {
+			await buttonDefault.hover();
+			expect(await buttonDefault.self.isFocused()).to.be.true();
 		});
 	});
-
 });

--- a/tests/ui/specs/Button/Button-specs.js
+++ b/tests/ui/specs/Button/Button-specs.js
@@ -2,8 +2,8 @@ const Page = require('./ButtonPage');
 
 describe('Button', function () {
 
-	beforeEach(function () {
-		Page.open();
+	beforeEach(async function () {
+		await Page.open();
 	});
 
 	const {

--- a/tests/ui/specs/Button/ButtonPage.js
+++ b/tests/ui/specs/Button/ButtonPage.js
@@ -10,12 +10,12 @@ class ButtonInterface {
 		this.selector = `#${this.id}`;
 	}
 
-	focus () {
-		return browser.execute((el) => el.focus(), $(this.selector));
+	async focus () {
+		return await browser.execute((el) => el.focus(), await $(this.selector));
 	}
 
-	hover () {
-		return $(this.selector).moveTo({xOffset: 0, yOffset: 0});
+	async hover () {
+		return await $(this.selector).moveTo({xOffset: 0, yOffset: 0});
 	}
 
 	get self () {

--- a/tests/ui/specs/Button/ButtonPage.js
+++ b/tests/ui/specs/Button/ButtonPage.js
@@ -78,8 +78,8 @@ class ButtonPage extends Page {
 		};
 	}
 
-	open (urlExtra) {
-		super.open('Button-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('Button-View', urlExtra);
 	}
 }
 

--- a/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
@@ -12,66 +12,66 @@ describe('CheckboxItem', function () {
 		describe('default', function () {
 			const checkboxItem = Page.components.checkboxDefault;
 
-			it('should have focus on first item at start', function () {
-				expect(checkboxItem.self.isFocused()).to.be.true();
+			it('should have focus on first item at start', async function () {
+				expect(await checkboxItem.self.isFocused()).to.be.true();
 			});
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item');
 			});
 
-			it('should not be checked', function () {
+			it('should not be checked', async function () {
 				expectUnchecked(checkboxItem);
 			});
 
-			it('should have the icon to the left of marquee text', function () {
+			it('should have the icon to the left of marquee text', async function () {
 				expectOrdering(checkboxItem.checkboxIcon, checkboxItem.value);
 			});
 
 			describe('5-way', function () {
-				it('should check the item when selected - [GT-28221]', function () {
-					Page.spotlightSelect();
+				it('should check the item when selected - [GT-28221]', async function () {
+					await Page.spotlightSelect();
 					expectChecked(checkboxItem);
 				});
 
-				it('should re-uncheck the item when selected twice', function () {
-					Page.spotlightSelect();
-					Page.spotlightSelect();
+				it('should re-uncheck the item when selected twice', async function () {
+					await Page.spotlightSelect();
+					await Page.spotlightSelect();
 					expectUnchecked(checkboxItem);
 				});
 
-				it('should display check the icon when selected', function () {
-					Page.spotlightSelect();
-					expect(checkboxItem.checkboxIconSymbol).to.equal('✓');
+				it('should display check the icon when selected', async function () {
+					await Page.spotlightSelect();
+					expect(await checkboxItem.checkboxIconSymbol).to.equal('✓');
 				});
 
-				it('should move focus down on SpotlightDown', function () {
-					Page.spotlightDown();
-					expect(Page.components.checkboxDefaultSelected.self.isFocused()).to.be.true();
+				it('should move focus down on SpotlightDown', async function () {
+					await Page.spotlightDown();
+					expect(await Page.components.checkboxDefaultSelected.self.isFocused()).to.be.true();
 				});
 
-				it('should move focus up on SpotlightUp', function () {
-					Page.components.checkboxDefaultSelected.focus();
-					Page.spotlightUp();
-					expect(checkboxItem.self.isFocused()).to.be.true();
+				it('should move focus up on SpotlightUp', async function () {
+					await Page.components.checkboxDefaultSelected.focus();
+					await Page.spotlightUp();
+					expect(await checkboxItem.self.isFocused()).to.be.true();
 				});
 			});
 
 			describe('pointer', function () {
-				it('should check the item when clicked', function () {
-					checkboxItem.self.click();
+				it('should check the item when clicked', async function () {
+					await checkboxItem.self.click();
 					expectChecked(checkboxItem);
 				});
 
-				it('should re-uncheck the item when clicked twice', function () {
-					checkboxItem.self.click();
-					checkboxItem.self.click();
+				it('should re-uncheck the item when clicked twice', async function () {
+					await checkboxItem.self.click();
+					await checkboxItem.self.click();
 					expectUnchecked(checkboxItem);
 				});
 
-				it('should display check the icon when clicked', function () {
-					checkboxItem.self.click();
-					expect(checkboxItem.checkboxIconSymbol).to.equal('✓');
+				it('should display check the icon when clicked', async function () {
+					await checkboxItem.self.click();
+					expect(await checkboxItem.checkboxIconSymbol).to.equal('✓');
 				});
 			});
 		});
@@ -79,42 +79,42 @@ describe('CheckboxItem', function () {
 		describe('selected', function () {
 			const checkboxItem = Page.components.checkboxDefaultSelected;
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item selected');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item selected');
 			});
 
-			it('should be checked', function () {
+			it('should be checked', async function () {
 				expectChecked(checkboxItem);
 			});
 
-			it('should display correct icon - [GT-28222]', function () {
-				expect(checkboxItem.checkboxIconSymbol).to.equal('✓');
+			it('should display correct icon - [GT-28222]', async function () {
+				expect(await checkboxItem.checkboxIconSymbol).to.equal('✓');
 			});
 
 			describe('5-way', function () {
-				it('should uncheck the item when selected', function () {
-					checkboxItem.focus();
-					Page.spotlightSelect();
+				it('should uncheck the item when selected', async function () {
+					await checkboxItem.focus();
+					await Page.spotlightSelect();
 					expectUnchecked(checkboxItem);
 				});
 
-				it('should re-check the item when selected twice', function () {
-					checkboxItem.focus();
-					Page.spotlightSelect();
-					Page.spotlightSelect();
+				it('should re-check the item when selected twice', async function () {
+					await checkboxItem.focus();
+					await Page.spotlightSelect();
+					await Page.spotlightSelect();
 					expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
-				it('should uncheck the item when clicked', function () {
-					checkboxItem.self.click();
+				it('should uncheck the item when clicked', async function () {
+					await checkboxItem.self.click();
 					expectUnchecked(checkboxItem);
 				});
 
-				it('should re-check the item when clicked twice', function () {
-					checkboxItem.self.click();
-					checkboxItem.self.click();
+				it('should re-check the item when clicked twice', async function () {
+					await checkboxItem.self.click();
+					await checkboxItem.self.click();
 					expectChecked(checkboxItem);
 				});
 			});
@@ -123,80 +123,80 @@ describe('CheckboxItem', function () {
 		describe('indeterminate', function () {
 			const checkboxItem = Page.components.checkboxIndeterminate;
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item indeterminate');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item indeterminate');
 			});
 
-			it('should be indeterminate state', function () {
-				expect(checkboxItem.isIndeterminate).to.be.true();
+			it('should be indeterminate state', async function () {
+				expect(await checkboxItem.isIndeterminate).to.be.true();
 			});
 
-			it('should dislay an indeterminate icon', function () {
-				expect(checkboxItem.indeterminateIconSymbol).to.equal('-');
+			it('should display an indeterminate icon', async function () {
+				expect(await checkboxItem.indeterminateIconSymbol).to.equal('-');
 			});
 		});
 
 		describe('slotBefore', function () {
 			const checkboxItem = Page.components.checkboxSlot;
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item slotBefore');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item slotBefore');
 			});
 
-			it('should have a node(icon) to the right of checkbox icon ', function () {
-				expectOrdering(checkboxItem.checkboxIcon, checkboxItem.slotBeforeNode);
+			it('should have a node(icon) to the right of checkbox icon ', async function () {
+				expectOrdering(await checkboxItem.checkboxIcon, checkboxItem.slotBeforeNode);
 			});
 
-			it('should have a node(icon) to the left of text', function () {
-				expectOrdering(checkboxItem.slotBeforeNode, checkboxItem.value);
+			it('should have a node(icon) to the left of text', async function () {
+				expectOrdering(await checkboxItem.slotBeforeNode, checkboxItem.value);
 			});
 		});
 
 		describe('inline', function () {
 			const checkboxItem = Page.components.checkboxInline;
 
-			it('should have two inlined checkboxes positioned inlined', function () {
-				const checkboxItem2 = Page.components.checkboxInlineIndeterminate.self;
+			it('should have two inlined checkboxes positioned inlined', async function () {
+				const checkboxItem2 = await Page.components.checkboxInlineIndeterminate.self;
 
-				expectInline(checkboxItem.self, checkboxItem2);
+				expectInline(await checkboxItem.self, checkboxItem2);
 			});
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item inline');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item inline');
 			});
 
-			it('should be checked', function () {
+			it('should be checked', async function () {
 				expectChecked(checkboxItem);
 			});
 
-			it('should display item inline', function () {
-				expect(checkboxItem.isInline).to.be.true();
+			it('should display item inline', async function () {
+				expect(await checkboxItem.isInline).to.be.true();
 			});
 
 			describe('5-way', function () {
-				it('should uncheck the item when selected', function () {
-					checkboxItem.focus();
-					Page.spotlightSelect();
+				it('should uncheck the item when selected', async function () {
+					await checkboxItem.focus();
+					await Page.spotlightSelect();
 					expectUnchecked(checkboxItem);
 				});
 
-				it('should re-check the item when selected twice', function () {
-					checkboxItem.focus();
-					Page.spotlightSelect();
+				it('should re-check the item when selected twice', async function () {
+					await checkboxItem.focus();
+					await Page.spotlightSelect();
 					Page.spotlightSelect();
 					expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
-				it('should uncheck the item when clicked', function () {
-					checkboxItem.self.click();
+				it('should uncheck the item when clicked', async function () {
+					await checkboxItem.self.click();
 					expectUnchecked(checkboxItem);
 				});
 
-				it('should re-check the item when clicked twice', function () {
-					checkboxItem.self.click();
-					checkboxItem.self.click();
+				it('should re-check the item when clicked twice', async function () {
+					await checkboxItem.self.click();
+					await checkboxItem.self.click();
 					expectChecked(checkboxItem);
 				});
 			});
@@ -205,12 +205,12 @@ describe('CheckboxItem', function () {
 		describe('inline indeterminate', function () {
 			const checkboxItem = Page.components.checkboxInlineIndeterminate;
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item inline indeterminate');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item inline indeterminate');
 			});
 
-			it('should display item inline', function () {
-				expect(checkboxItem.isInline).to.be.true();
+			it('should display item inline', async function () {
+				expect(await checkboxItem.isInline).to.be.true();
 			});
 		});
 
@@ -221,29 +221,29 @@ describe('CheckboxItem', function () {
 			const checkboxItem = Page.components.checkboxDisabled;
 			const prevCheckboxItem = Page.components.checkboxInlineIndeterminate;
 
-			it('should have correct text', function () {
-				expect(checkboxItem.valueText).to.equal('Checkbox Item disabled');
+			it('should have correct text', async function () {
+				expect(await checkboxItem.valueText).to.equal('Checkbox Item disabled');
 			});
 
-			it('should be checked', function () {
+			it('should be checked', async function () {
 				expectChecked(checkboxItem);
 			});
 
 			describe('5-way', function () {
-				it('should be able to focus the item', function () {
-					prevCheckboxItem.focus();
-					Page.spotlightDown();
-					expect(checkboxItem.self.isFocused()).to.be.true();
+				it('should be able to focus the item', async function () {
+					await prevCheckboxItem.focus();
+					await Page.spotlightDown();
+					expect(await checkboxItem.self.isFocused()).to.be.true();
 				});
-				it('should not uncheck the item when selected', function () {
-					Page.spotlightDown();
+				it('should not uncheck the item when selected', async function () {
+					await Page.spotlightDown();
 					expectChecked(checkboxItem);
 				});
 			});
 
 			describe('pointer', function () {
-				it('should not uncheck the item when clicked', function () {
-					checkboxItem.self.click();
+				it('should not uncheck the item when clicked', async function () {
+					await checkboxItem.self.click();
 					expectChecked(checkboxItem);
 				});
 			});
@@ -258,28 +258,28 @@ describe('CheckboxItem', function () {
 			Page.open('?locale=ar-SA');
 		});
 
-		it('should have focus on first item at start', function () {
-			expect(Page.components.checkboxDefault.self.isFocused()).to.be.true();
+		it('should have focus on first item at start', async function () {
+			expect(await Page.components.checkboxDefault.self.isFocused()).to.be.true();
 		});
 
-		it('should have checkbox icon to the right of text when default', function () {
-			const checkboxItem = Page.components.checkboxDefault;
+		it('should have checkbox icon to the right of text when default', async function () {
+			const checkboxItem = await Page.components.checkboxDefault;
 			expectOrdering(checkboxItem.value, checkboxItem.checkboxIcon);
 		});
 
-		it('should have a node(icon) to the right of text when default', function () {
-			const checkboxItem = Page.components.checkboxSlot;
+		it('should have a node(icon) to the right of text when default', async function () {
+			const checkboxItem = await Page.components.checkboxSlot;
 			expectOrdering(checkboxItem.value, checkboxItem.slotBeforeNode);
 		});
 
-		it('should have checkbox icon to the right of a node(icon)', function () {
-			const checkboxItem = Page.components.checkboxSlot;
+		it('should have checkbox icon to the right of a node(icon)', async function () {
+			const checkboxItem = await Page.components.checkboxSlot;
 			expectOrdering(checkboxItem.slotBeforeNode, checkboxItem.checkboxIcon);
 		});
 
-		it('should have two inlined checkboxes positioned inlined', function () {
-			const checkboxItem1 = Page.components.checkboxInline.self;
-			const checkboxItem2 = Page.components.checkboxInlineIndeterminate.self;
+		it('should have two inlined checkboxes positioned inlined', async function () {
+			const checkboxItem1 = await Page.components.checkboxInline.self;
+			const checkboxItem2 = await Page.components.checkboxInlineIndeterminate.self;
 
 			expectInline(checkboxItem1, checkboxItem2);
 		});

--- a/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItem-specs.js
@@ -5,8 +5,8 @@ const Page = require('./CheckboxItemPage'),
 describe('CheckboxItem', function () {
 
 	describe('LTR locale', function () {
-		beforeEach(function () {
-			Page.open();
+		beforeEach(async function () {
+			await Page.open();
 		});
 
 		describe('default', function () {
@@ -254,8 +254,8 @@ describe('CheckboxItem', function () {
 	});
 
 	describe('RTL locale', function () {
-		beforeEach(function () {
-			Page.open('?locale=ar-SA');
+		beforeEach(async function () {
+			await Page.open('?locale=ar-SA');
 		});
 
 		it('should have focus on first item at start', async function () {

--- a/tests/ui/specs/CheckboxItem/CheckboxItem-utils.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItem-utils.js
@@ -6,15 +6,14 @@ module.exports = {
 };
 
 // Expect blocks
-function expectChecked (checkboxItem) {
-	expect(checkboxItem.isChecked).to.be.true();
+async function expectChecked (checkboxItem) {
+	expect(await checkboxItem.isChecked).to.be.true();
 }
 
-function expectUnchecked (checkboxItem) {
-	expect(checkboxItem.isChecked).to.be.false();
+async function expectUnchecked (checkboxItem) {
+	expect(await checkboxItem.isChecked).to.be.false();
 }
 
-function expectInline (checkboxItem1, checkboxItem2) {
-	expect(checkboxItem1.getLocation().x === checkboxItem2.getLocation().x).to.be.false();
+async function expectInline (checkboxItem1, checkboxItem2) {
+	expect(await checkboxItem1.getLocation().x === checkboxItem2.getLocation().x).to.be.false();
 }
-

--- a/tests/ui/specs/CheckboxItem/CheckboxItemPage.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItemPage.js
@@ -9,8 +9,8 @@ class CheckboxItemInterface {
 		this.slotBeforeNodeSelector = `#${this.id} >  .Item_Item_slotBefore > div:last-child`;
 	}
 
-	focus () {
-		return browser.execute((el) => el.focus(), $(`#${this.id}`));
+	async focus () {
+		return await browser.execute((el) => el.focus(), await $(`#${this.id}`));
 	}
 
 	get self () {

--- a/tests/ui/specs/CheckboxItem/CheckboxItemPage.js
+++ b/tests/ui/specs/CheckboxItem/CheckboxItemPage.js
@@ -69,8 +69,8 @@ class CheckboxItemPage extends Page {
 		};
 	}
 
-	open (urlExtra) {
-		super.open('CheckboxItem-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('CheckboxItem-View', urlExtra);
 	}
 }
 

--- a/tests/ui/specs/ContextualMenuDecorator/ContextualMenuDecorator-specs.js
+++ b/tests/ui/specs/ContextualMenuDecorator/ContextualMenuDecorator-specs.js
@@ -2,8 +2,8 @@ const Page = require('./ContextualMenuDecoratorPage');
 
 describe('ContextualMenuDecorator', function () {
 
-	beforeEach(function () {
-		Page.open();
+	beforeEach(async function () {
+		await Page.open();
 	});
 
 	const {

--- a/tests/ui/specs/ContextualMenuDecorator/ContextualMenuDecorator-specs.js
+++ b/tests/ui/specs/ContextualMenuDecorator/ContextualMenuDecorator-specs.js
@@ -15,88 +15,88 @@ describe('ContextualMenuDecorator', function () {
 
 	describe('not using open', function () {
 
-		it('should have the menu on start', function () {
-			expect(menu1.isMenuExist).to.be.false();
-			expect(menu2.item(0).isFocused()).to.be.true();
+		it('should have the menu on start', async function () {
+			expect(await menu1.isMenuExist).to.be.false();
+			expect(await menu2.item(0).isFocused()).to.be.true();
 		});
 
 		describe('using 5-way', function () {
-			it('should close on back key', function () {
-				Page.backKey();
-				expect(menu2.isMenuExist).to.be.false();
+			it('should close on back key', async function () {
+				await Page.backKey();
+				expect(await menu2.isMenuExist).to.be.false();
 			});
 
-			it('should move focus to first menu item on select - [QWT-2740]', function () {
+			it('should move focus to first menu item on select - [QWT-2740]', async function () {
 				// Spotlight is on the first item (verify step 3)
-				Page.backKey();
-				Page.spotlightLeft();
-				Page.spotlightSelect();
-				expect(menu1.isMenuExist).to.be.true();
-				expect(menu1.item(0).isFocused()).to.be.true();
+				await Page.backKey();
+				await Page.spotlightLeft();
+				await Page.spotlightSelect();
+				expect(await menu1.isMenuExist).to.be.true();
+				expect(await menu1.item(0).isFocused()).to.be.true();
 			});
 
-			it('should not dismiss the menu on 5-way left from menu item - [QWT-2735]', function () {
+			it('should not dismiss the menu on 5-way left from menu item - [QWT-2735]', async function () {
 				// The *Contextual Button* menu does not close. Spotlight is on same item (verify step 4)
-				Page.spotlightLeft();
-				expect(menu2.isMenuExist).to.be.true();
-				expect(menu2.item(0).isFocused()).to.be.true();
+				await Page.spotlightLeft();
+				expect(await menu2.isMenuExist).to.be.true();
+				expect(await menu2.item(0).isFocused()).to.be.true();
 			});
 
-			it('should not dismiss the menu on 5-way right from menu item - [QWT-2735]', function () {
+			it('should not dismiss the menu on 5-way right from menu item - [QWT-2735]', async function () {
 				// The *Contextual Button* menu does not close. Spotlight is on same item (verify step 5)
-				Page.spotlightRight();
-				expect(menu2.isMenuExist).to.be.true();
-				expect(menu2.item(0).isFocused()).to.be.true();
+				await Page.spotlightRight();
+				expect(await menu2.isMenuExist).to.be.true();
+				expect(await menu2.item(0).isFocused()).to.be.true();
 			});
 
-			it('should not dismiss the menu on 5-way up from first menu item - [QWT-2735]', function () {
+			it('should not dismiss the menu on 5-way up from first menu item - [QWT-2735]', async function () {
 				// The *Contextual Button* menu does not close. Spotlight is on on same item (verify step 6)
-				Page.spotlightUp();
-				expect(menu2.isMenuExist).to.be.true();
-				expect(menu2.item(0).isFocused()).to.be.true();
+				await Page.spotlightUp();
+				expect(await menu2.isMenuExist).to.be.true();
+				expect(await menu2.item(0).isFocused()).to.be.true();
 			});
 
-			it('should move focus to the next menu item on 5-way down - [QWT-2734]', function () {
+			it('should move focus to the next menu item on 5-way down - [QWT-2734]', async function () {
 				// Spotlight is on the second item. (verify step 4)
-				Page.spotlightDown();
-				expect(menu2.item(1).isFocused()).to.be.true();
+				await Page.spotlightDown();
+				expect(await menu2.item(1).isFocused()).to.be.true();
 			});
 
-			it('should not dismiss the menu and move focus back to activator on close - [QWT-2734]', function () {
+			it('should not dismiss the menu and move focus back to activator on close - [QWT-2734]', async function () {
 				// The *Contextual Button* menu does not close. Spotlight is on bottom button. (verify step 5)
-				Page.spotlightDown();
-				Page.spotlightDown();
-				Page.spotlightDown();
-				expect(menu2.isMenuExist).to.be.true();
-				expect(menu2.item(2).isFocused()).to.be.true();
+				await Page.spotlightDown();
+				await Page.spotlightDown();
+				await Page.spotlightDown();
+				expect(await menu2.isMenuExist).to.be.true();
+				expect(await menu2.item(2).isFocused()).to.be.true();
 			});
 		});
 
 		describe('using pointer', function () {
 
-			it('should not keep Spotlight on button when menu opens with pointer - [QWT-2736]', function () {
-				button2.self.moveTo();
-				$('.ContextualPopupDecorator_HolePunchScrim_holePunchScrim').click({x: -100, y: 100});	// Click on scrim to close popup (note -100 offset is important to get away from button)
+			it('should not keep Spotlight on button when menu opens with pointer - [QWT-2736]', async function () {
+				await button2.self.moveTo();
+				await $('.ContextualPopupDecorator_HolePunchScrim_holePunchScrim').click({x: -100, y: 100});	// Click on scrim to close popup (note -100 offset is important to get away from button)
 				// this will close menu2
-				expect(menu2.isMenuExist, 'menu2 closed').to.be.false();
+				expect(await menu2.isMenuExist, 'menu2 closed').to.be.false();
 
-				button1.self.click();	// this will open menu1
-				expect(button1.self.isFocused()).to.be.false();  // (verify step 4)
-				expect(menu1.isMenuExist, 'menu1 open').to.be.true();  // (verify step 4)
-				expect(menu1.item(0).isFocused()).to.be.false();  // Spotlight is not on the first item. (verify step 3)
+				await button1.self.click();	// this will open menu1
+				expect(await button1.self.isFocused()).to.be.false();  // (verify step 4)
+				expect(await menu1.isMenuExist, 'menu1 open').to.be.true();  // (verify step 4)
+				expect(await menu1.item(0).isFocused()).to.be.false();  // Spotlight is not on the first item. (verify step 3)
 
-				$('.ContextualPopupDecorator_HolePunchScrim_holePunchScrim').click({x: -100, y: 100});	// Click on scrim to close popup
+				await $('.ContextualPopupDecorator_HolePunchScrim_holePunchScrim').click({x: -100, y: 100});	// Click on scrim to close popup
 				// this will close menu1
-				expect(menu1.isMenuExist, 'menu1 closed').to.be.false(); 	// (verify step 5)
+				expect(await menu1.isMenuExist, 'menu1 closed').to.be.false(); 	// (verify step 5)
 			});
 		});
 	});
 
 	// Menu with Button 2 is explicitly set as opened. It is using an open prop. It is there to test that if a user specifies that prop, they can programmatically control when it closes.
 	describe('using open', function () {
-		it('should have the menu on start, with focus on first item', function () {
-			expect(menu2.isMenuExist).to.be.true();
-			expect(menu2.item(0).isFocused()).to.be.true();
+		it('should have the menu on start, with focus on first item', async function () {
+			expect(await menu2.isMenuExist).to.be.true();
+			expect(await menu2.item(0).isFocused()).to.be.true();
 		});
 	});
 

--- a/tests/ui/specs/ContextualMenuDecorator/ContextualMenuDecoratorPage.js
+++ b/tests/ui/specs/ContextualMenuDecorator/ContextualMenuDecoratorPage.js
@@ -58,8 +58,8 @@ class ContextualMenuDecoratorPage extends Page {
 		};
 	}
 
-	open (urlExtra) {
-		super.open('ContextualMenuDecorator-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('ContextualMenuDecorator-View', urlExtra);
 	}
 }
 

--- a/tests/ui/specs/ContextualPopupDecorator/ContextualPopupDecorator-specs.js
+++ b/tests/ui/specs/ContextualPopupDecorator/ContextualPopupDecorator-specs.js
@@ -16,8 +16,8 @@ describe('ContextualPopupDecorator', function () {
 			button1.focus();
 		});
 
-		it('should focus the first button on start', function () {
-			expect(button1.self.isFocused()).to.be.true();
+		it('should focus the first button on start', async function () {
+			expect(await button1.self.isFocused()).to.be.true();
 		});
 
 		describe('using 5-way', function () {
@@ -26,11 +26,11 @@ describe('ContextualPopupDecorator', function () {
 				Page.spotlightSelect();
 			});
 
-			it('should have Spotlight on close button when ContextualPopup opens - [QWT-2731]', function () {
+			it('should have Spotlight on close button when ContextualPopup opens - [QWT-2731]', async function () {
 				// 5-waySelectableActivator: Button Retains Spotlight when Popup Hides
 				let popupButton = $('#popupButton');
 
-				expect(popupButton.isFocused()).to.be.true();
+				expect(await popupButton.isFocused()).to.be.true();
 			});
 		});
 	});

--- a/tests/ui/specs/ContextualPopupDecorator/ContextualPopupDecorator-specs.js
+++ b/tests/ui/specs/ContextualPopupDecorator/ContextualPopupDecorator-specs.js
@@ -2,8 +2,8 @@ const Page = require('./ContextualPopupDecoratorPage');
 
 describe('ContextualPopupDecorator', function () {
 
-	beforeEach(function () {
-		Page.open();
+	beforeEach(async function () {
+		await Page.open();
 	});
 
 	const {

--- a/tests/ui/specs/ContextualPopupDecorator/ContextualPopupDecoratorPage.js
+++ b/tests/ui/specs/ContextualPopupDecorator/ContextualPopupDecoratorPage.js
@@ -34,8 +34,8 @@ class ContextualPopupDecoratorPage extends Page {
 		};
 	}
 
-	open (urlExtra) {
-		super.open('ContextualPopupDecorator-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('ContextualPopupDecorator-View', urlExtra);
 	}
 }
 

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -88,7 +88,7 @@ describe('DatePicker', function () {
 					await Page.spotlightDown();
 					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
-					expect( value).to.equal(expected);
+					expect(value).to.equal(expected);
 				});
 				// End of [QWT-2553] - Month, Day, Year pickers Animate with 5-way - LTR
 			});
@@ -103,7 +103,7 @@ describe('DatePicker', function () {
 				// Start of [QWT-2555] - Month, Day, Year pickers Animate with Pointer Click - LTR
 				it('should increase the month when incrementing the picker', async function () {
 					const {month} = await extractValues(datePicker);
-					await await datePicker.month.click();
+					await datePicker.month.click();
 					expect(await datePicker.month.isFocused()).to.be.true();
 					await datePicker.incrementer(datePicker.month).click();
 					const {month: value} = await extractValues(datePicker);

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -9,152 +9,156 @@ describe('DatePicker', function () {
 		});
 
 		describe('default', function () {
-			const datePicker = Page.components.datePickerDefault;
+			let datePicker;
 
-			it('should have correct title', function () {
+			beforeEach(async function () {
+				datePicker = await Page.components.datePickerDefault;
+			});
+
+			it('should have correct title', async function () {
 				validateTitle(datePicker, 'Date Picker Default');
 			});
 
-			it('should have month-day-year order', function () {
-				expect(datePicker.month.isFocused(), 'Month').to.be.true();
-				Page.spotlightRight();
-				expect(datePicker.day.isFocused(), 'Day').to.be.true();
-				Page.spotlightRight();
-				expect(datePicker.year.isFocused(), 'Year').to.be.true();
+			it('should have month-day-year order', async function () {
+				expect(await datePicker.month.isFocused(), 'Month').to.be.true();
+				await Page.spotlightRight();
+				expect(await datePicker.day.isFocused(), 'Day').to.be.true();
+				await Page.spotlightRight();
+				expect(await datePicker.year.isFocused(), 'Year').to.be.true();
 			});
 
 			describe('5-way', function () {
 				// Start of [QWT-2553] - Month, Day, Year pickers Animate with 5-way - LTR
-				it('should increase the month when incrementing the picker', function () {
-					const {month} = extractValues(datePicker);
-					expect(datePicker.month.isFocused()).to.be.true();
-					Page.spotlightUp();
-					const {month: value} = extractValues(datePicker);
+				it('should increase the month when incrementing the picker', async function () {
+					const {month} = await extractValues(datePicker);
+					expect(await datePicker.month.isFocused()).to.be.true();
+					await Page.spotlightUp();
+					const {month: value} = await extractValues(datePicker);
 					const expected = month < 12 ? month + 1 : 1;
 					expect(value).to.equal(expected);
 				});
 
-				it('should decrease the month when decrementing the picker', function () {
-					const {month} = extractValues(datePicker);
-					expect(datePicker.month.isFocused()).to.be.true();
-					Page.spotlightDown();
-					const {month: value} = extractValues(datePicker);
+				it('should decrease the month when decrementing the picker', async function () {
+					const {month} = await extractValues(datePicker);
+					expect(await datePicker.month.isFocused()).to.be.true();
+					await Page.spotlightDown();
+					const {month: value} = await extractValues(datePicker);
 					const expected = month > 1 ? month - 1 : 12;
 					expect(value).to.equal(expected);
 				});
 
-				it('should increase the day when incrementing the picker', function () {
-					const {day, month, year} = extractValues(datePicker);
+				it('should increase the day when incrementing the picker', async function () {
+					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
-					Page.spotlightRight();
-					expect(datePicker.day.isFocused()).to.be.true();
-					Page.spotlightUp();
-					const {day: value} = extractValues(datePicker);
+					await Page.spotlightRight();
+					expect(await datePicker.day.isFocused()).to.be.true();
+					await Page.spotlightUp();
+					const {day: value} = await extractValues(datePicker);
 					const expected = day !== numDays ? day + 1 : 1;
 					expect(value).to.equal(expected);
 				});
 
-				it('should decrease the day when decrementing the picker', function () {
-					const {day, month, year} = extractValues(datePicker);
+				it('should decrease the day when decrementing the picker', async function () {
+					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
-					Page.spotlightRight();
-					expect(datePicker.day.isFocused()).to.be.true();
-					Page.spotlightDown();
-					const {day: value} = extractValues(datePicker);
+					await Page.spotlightRight();
+					expect(await datePicker.day.isFocused()).to.be.true();
+					await Page.spotlightDown();
+					const {day: value} = await extractValues(datePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
 					expect(value).to.equal(expected);
 				});
 
-				it('should increase the year when incrementing the picker', function () {
-					const {year} = extractValues(datePicker);
-					Page.spotlightRight();
-					Page.spotlightRight();
-					expect(datePicker.year.isFocused()).to.be.true();
-					Page.spotlightUp();
-					const {year: value} = extractValues(datePicker);
+				it('should increase the year when incrementing the picker', async function () {
+					const {year} = await extractValues(datePicker);
+					await Page.spotlightRight();
+					await Page.spotlightRight();
+					expect(await datePicker.year.isFocused()).to.be.true();
+					await Page.spotlightUp();
+					const {year: value} = await extractValues(datePicker);
 					const expected = year + 1;
 					expect(value).to.equal(expected);
 				});
 
-				it('should decrease the year when decrementing the picker', function () {
-					const {year} = extractValues(datePicker);
-					Page.spotlightRight();
-					Page.spotlightRight();
-					expect(datePicker.year.isFocused()).to.be.true();
-					Page.spotlightDown();
-					const {year: value} = extractValues(datePicker);
+				it('should decrease the year when decrementing the picker', async function () {
+					const {year} = await extractValues(datePicker);
+					await Page.spotlightRight();
+					await Page.spotlightRight();
+					expect(await datePicker.year.isFocused()).to.be.true();
+					await Page.spotlightDown();
+					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
-					expect(value).to.equal(expected);
+					expect( value).to.equal(expected);
 				});
 				// End of [QWT-2553] - Month, Day, Year pickers Animate with 5-way - LTR
 			});
 
 			describe('pointer', function () {
 
-				it('should select item', function () {
-					datePicker.month.click();
-					expect(datePicker.month.isFocused()).to.be.true();
+				it('should select item', async function () {
+					await datePicker.month.click();
+					expect(await datePicker.month.isFocused()).to.be.true();
 				});
 
 				// Start of [QWT-2555] - Month, Day, Year pickers Animate with Pointer Click - LTR
-				it('should increase the month when incrementing the picker', function () {
-					const {month} = extractValues(datePicker);
-					datePicker.month.click();
-					expect(datePicker.month.isFocused()).to.be.true();
-					datePicker.incrementer(datePicker.month).click();
-					const {month: value} = extractValues(datePicker);
+				it('should increase the month when incrementing the picker', async function () {
+					const {month} = await extractValues(datePicker);
+					await await datePicker.month.click();
+					expect(await datePicker.month.isFocused()).to.be.true();
+					await datePicker.incrementer(datePicker.month).click();
+					const {month: value} = await extractValues(datePicker);
 					const expected = month < 12 ? month + 1 : 1;
 					expect(value).to.equal(expected);
 				});
 
-				it('should decrease the month when decrementing the picker', function () {
-					const {month} = extractValues(datePicker);
-					datePicker.month.click();
-					expect(datePicker.month.isFocused()).to.be.true();
-					datePicker.decrementer(datePicker.month).click();
-					const {month: value} = extractValues(datePicker);
+				it('should decrease the month when decrementing the picker', async function () {
+					const {month} = await extractValues(datePicker);
+					await datePicker.month.click();
+					expect(await datePicker.month.isFocused()).to.be.true();
+					await datePicker.decrementer(datePicker.month).click();
+					const {month: value} = await extractValues(datePicker);
 					const expected = month > 1 ? month - 1 : 12;
 					expect(value).to.equal(expected);
 				});
 
-				it('should increase the day when incrementing the picker', function () {
-					const {day, month, year} = extractValues(datePicker);
+				it('should increase the day when incrementing the picker', async function () {
+					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
-					datePicker.day.click();
-					expect(datePicker.day.isFocused()).to.be.true();
-					datePicker.incrementer(datePicker.day).click();
-					const {day: value} = extractValues(datePicker);
+					await datePicker.day.click();
+					expect(await datePicker.day.isFocused()).to.be.true();
+					await datePicker.incrementer(datePicker.day).click();
+					const {day: value} = await extractValues(datePicker);
 					const expected = day !== numDays ? day + 1 : 1;
 					expect(value).to.equal(expected);
 				});
 
-				it('should decrease the day when decrementing the picker', function () {
-					const {day, month, year} = extractValues(datePicker);
+				it('should decrease the day when decrementing the picker', async function () {
+					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
-					datePicker.day.click();
-					expect(datePicker.day.isFocused()).to.be.true();
-					datePicker.decrementer(datePicker.day).click();
-					const {day: value} = extractValues(datePicker);
+					await datePicker.day.click();
+					expect(await datePicker.day.isFocused()).to.be.true();
+					await datePicker.decrementer(datePicker.day).click();
+					const {day: value} = await extractValues(datePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
 					expect(value).to.equal(expected);
 				});
 
-				it('should increase the year when incrementing the picker', function () {
-					const {year} = extractValues(datePicker);
-					datePicker.year.click();
-					expect(datePicker.year.isFocused()).to.be.true();
-					datePicker.incrementer(datePicker.year).click();
-					const {year: value} = extractValues(datePicker);
+				it('should increase the year when incrementing the picker', async function () {
+					const {year} = await extractValues(datePicker);
+					await datePicker.year.click();
+					expect(await datePicker.year.isFocused()).to.be.true();
+					await datePicker.incrementer(datePicker.year).click();
+					const {year: value} = await extractValues(datePicker);
 					const expected = year + 1;
 					expect(value).to.equal(expected);
 				});
 
-				it('should decrease the year when decrementing the picker', function () {
-					const {year} = extractValues(datePicker);
-					datePicker.year.click();
-					expect(datePicker.year.isFocused()).to.be.true();
-					datePicker.decrementer(datePicker.year).click();
-					const {year: value} = extractValues(datePicker);
+				it('should decrease the year when decrementing the picker', async function () {
+					const {year} = await extractValues(datePicker);
+					await datePicker.year.click();
+					expect(await datePicker.year.isFocused()).to.be.true();
+					await datePicker.decrementer(datePicker.year).click();
+					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
 					expect(value).to.equal(expected);
 				});
@@ -167,10 +171,10 @@ describe('DatePicker', function () {
 			const datePicker = Page.components.datePickerWithDefaultValue;
 
 			describe('5-way', function () {
-				it('should not update on select', function () {
-					datePicker.focus();
+				it('should not update on select', async function () {
+					await datePicker.focus();
 
-					const {day, month, year} = extractValues(datePicker);
+					const {day, month, year} = await extractValues(datePicker);
 
 					expect(day).to.equal(6);
 					expect(month).to.equal(6); // `Date` uses 0-indexed months, picker displays 1-indexed month values
@@ -179,8 +183,8 @@ describe('DatePicker', function () {
 			});
 
 			describe('pointer', function () {
-				it('should not update on click', function () {
-					const {day, month, year} = extractValues(datePicker);
+				it('should not update on click', async function () {
+					const {day, month, year} = await extractValues(datePicker);
 
 					expect(day).to.equal(6);
 					expect(month).to.equal(6); // `Date` uses 0-indexed months, picker displays 1-indexed month values
@@ -194,28 +198,28 @@ describe('DatePicker', function () {
 		describe('disabled', function () {
 			const datePicker = Page.components.datePickerDisabled;
 
-			it('should focus the disabled month picker', function () {
-				datePicker.month.click();
-				expect(datePicker.month.isFocused()).to.be.true();
+			it('should focus the disabled month picker', async function () {
+				await datePicker.month.click();
+				expect(await datePicker.month.isFocused()).to.be.true();
 			});
 
-			it('should not increase the day when incrementing disabled picker', function () {
-				datePicker.day.click();
-				expect(datePicker.day.isFocused()).to.be.true();
+			it('should not increase the day when incrementing disabled picker', async function () {
+				await datePicker.day.click();
+				expect(await datePicker.day.isFocused()).to.be.true();
 
-				datePicker.incrementer(datePicker.day).click();
+				await datePicker.incrementer(datePicker.day).click();
 				browser.pause(500);
-				const {day: value} = extractValues(datePicker);
+				const {day: value} = await extractValues(datePicker);
 				expect(value).to.equal(1);
 			});
 
-			it('should not decrease the day when decrementing disabled picker', function () {
-				datePicker.day.click();
-				expect(datePicker.day.isFocused()).to.be.true();
+			it('should not decrease the day when decrementing disabled picker', async function () {
+				await datePicker.day.click();
+				expect(await datePicker.day.isFocused()).to.be.true();
 
-				datePicker.decrementer(datePicker.day).click();
+				await datePicker.decrementer(datePicker.day).click();
 				browser.pause(500);
-				const {day: value} = extractValues(datePicker);
+				const {day: value} = await extractValues(datePicker);
 				expect(value).to.equal(1);
 			});
 
@@ -224,8 +228,8 @@ describe('DatePicker', function () {
 		describe('disabled with \'defaultValue\'', function () {
 			const datePicker = Page.components.datePickerDisabledWithDefaultValue;
 
-			it('should display default date', function () {
-				const {day, month, year} = extractValues(datePicker);
+			it('should display default date', async function () {
+				const {day, month, year} = await extractValues(datePicker);
 
 				expect(day).to.equal(6);
 				expect(month).to.equal(6); // `Date` uses 0-indexed months, picker displays 1-indexed month values
@@ -233,46 +237,46 @@ describe('DatePicker', function () {
 
 			});
 
-			it('should not update \'defaultValue\' on decrementing disabled picker', function () {
-				const {day, month, year} = extractValues(datePicker);
-				datePicker.month.click();
-				expect(datePicker.month.isFocused()).to.be.true();
-				datePicker.decrementer(datePicker.month).click();
+			it('should not update \'defaultValue\' on decrementing disabled picker', async function () {
+				const {day, month, year} = await extractValues(datePicker);
+				await datePicker.month.click();
+				expect(await datePicker.month.isFocused()).to.be.true();
+				await datePicker.decrementer(datePicker.month).click();
 
-				datePicker.day.click();
-				expect(datePicker.day.isFocused()).to.be.true();
-				datePicker.decrementer(datePicker.day).click();
+				await datePicker.day.click();
+				expect(await datePicker.day.isFocused()).to.be.true();
+				await datePicker.decrementer(datePicker.day).click();
 
-				datePicker.year.click();
-				expect(datePicker.year.isFocused()).to.be.true();
-				datePicker.decrementer(datePicker.year).click();
+				await datePicker.year.click();
+				expect(await datePicker.year.isFocused()).to.be.true();
+				await datePicker.decrementer(datePicker.year).click();
 
 				browser.pause(500);
 
-				expect(day).to.equal(6);
-				expect(month).to.equal(6);
-				expect(year).to.equal(2009);
+				expect(await day).to.equal(6);
+				expect(await month).to.equal(6);
+				expect(await year).to.equal(2009);
 			});
 
-			it('should not update \'defaultValue\' on incrementing disabled picker', function () {
-				const {day, month, year} = extractValues(datePicker);
+			it('should not update \'defaultValue\' on incrementing disabled picker', async function () {
+				const {day, month, year} = await extractValues(datePicker);
 
-				datePicker.month.click();
-				expect(datePicker.month.isFocused()).to.be.true();
-				datePicker.incrementer(datePicker.month).click();
+				await datePicker.month.click();
+				expect(await datePicker.month.isFocused()).to.be.true();
+				await datePicker.incrementer(datePicker.month).click();
 
-				datePicker.day.click();
-				expect(datePicker.day.isFocused()).to.be.true();
-				datePicker.incrementer(datePicker.day).click();
+				await datePicker.day.click();
+				expect(await datePicker.day.isFocused()).to.be.true();
+				await datePicker.incrementer(datePicker.day).click();
 
-				datePicker.year.click();
-				expect(datePicker.year.isFocused()).to.be.true();
-				datePicker.incrementer(datePicker.year).click();
+				await datePicker.year.click();
+				expect(await datePicker.year.isFocused()).to.be.true();
+				await datePicker.incrementer(datePicker.year).click();
 
 				browser.pause(500);
-				expect(day).to.equal(6);
-				expect(month).to.equal(6);
-				expect(year).to.equal(2009);
+				expect(await day).to.equal(6);
+				expect(await month).to.equal(6);
+				expect(await year).to.equal(2009);
 			});
 		});
 
@@ -285,16 +289,16 @@ describe('DatePicker', function () {
 			Page.open('?locale=ar-SA');
 		});
 
-		it('should focus rightmost picker (day) when selected', function () {
-			expect(datePicker.day.isFocused()).to.be.true();
+		it('should focus rightmost picker (day) when selected', async function () {
+			expect(await datePicker.day.isFocused()).to.be.true();
 		});
 
-		it('should have day-month-year order', function () {
-			expect(datePicker.day.isFocused()).to.be.true();
-			Page.spotlightLeft();
-			expect(datePicker.month.isFocused()).to.be.true();
-			Page.spotlightLeft();
-			expect(datePicker.year.isFocused()).to.be.true();
+		it('should have day-month-year order', async function () {
+			expect(await datePicker.day.isFocused()).to.be.true();
+			await Page.spotlightLeft();
+			expect(await datePicker.month.isFocused()).to.be.true();
+			await Page.spotlightLeft();
+			expect(await datePicker.year.isFocused()).to.be.true();
 		});
 	});
 

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -4,8 +4,8 @@ const {daysInMonth, extractValues, validateTitle} = require('./DatePicker-utils.
 describe('DatePicker', function () {
 
 	describe('LTR locale', function () {
-		beforeEach(function () {
-			Page.open();
+		beforeEach(async function () {
+			await Page.open();
 		});
 
 		describe('default', function () {
@@ -285,8 +285,8 @@ describe('DatePicker', function () {
 	describe('RTL locale', function () {
 		const datePicker = Page.components.datePickerDefault;
 
-		beforeEach(function () {
-			Page.open('?locale=ar-SA');
+		beforeEach(async function () {
+			await Page.open('?locale=ar-SA');
 		});
 
 		it('should focus rightmost picker (day) when selected', async function () {

--- a/tests/ui/specs/DatePicker/DatePicker-utils.js
+++ b/tests/ui/specs/DatePicker/DatePicker-utils.js
@@ -3,18 +3,18 @@
 // adapted from https://stackoverflow.com/questions/1184334/get-number-days-in-a-specified-month-using-javascript
 const daysInMonth = ({month, year}) => new Date(year, month, 0).getDate();
 
-const extractValues = (picker) => {
-	const day = parseInt(picker.item(picker.day).getText());
-	const month = parseInt(picker.item(picker.month).getText());
-	const year = parseInt(picker.item(picker.year).getText());
+const extractValues = async (picker) => {
+	const day = parseInt(await picker.item(picker.day).getText());
+	const month = parseInt(await picker.item(picker.month).getText());
+	const year = parseInt(await picker.item(picker.year).getText());
 
 	return {day, month, year};
 };
 
 // Validations are self-contained 'it' statements
 function validateTitle (picker, title) {
-	it('should have correct title', function () {
-		expect(picker.titleText).to.equal(title);
+	it('should have correct title', async function () {
+		expect(await picker.titleText).to.equal(title);
 	});
 }
 

--- a/tests/ui/specs/DatePicker/DatePickerPage.js
+++ b/tests/ui/specs/DatePicker/DatePickerPage.js
@@ -8,8 +8,8 @@ class PickerInterface {
 		this.id = id;
 	}
 
-	focus () {
-		return browser.execute((el) => el.focus(), $(`#${this.id}>div`));
+	async focus () {
+		return browser.execute((el) => el.focus(), await $(`#${this.id}>div`));
 	}
 
 	get      self () {

--- a/tests/ui/specs/DatePicker/DatePickerPage.js
+++ b/tests/ui/specs/DatePicker/DatePickerPage.js
@@ -57,8 +57,8 @@ class DatePickerPage extends Page {
 		this.components.datePickerDisabledWithDefaultValue = new PickerInterface('datePickerDisabledWithDefaultValue');
 	}
 
-	open (urlExtra) {
-		super.open('DatePicker-View', urlExtra);
+	async open (urlExtra) {
+		await super.open('DatePicker-View', urlExtra);
 	}
 }
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
@wdio/sync was depreacted on node 16.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix ui-test TC to use async mode
To resolve intermittent TC fail "stale element reference: element is not attached to the page", I add `await` when Page.open()
 
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-14979

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
