### PR TITLE
WRN-15868 : Horizontal Picker with left/right key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/Picker` prop `noIndicator` to provide a way to control with left and right keys in horizontal-joined Picker 
 - `sandstone/VideoPlayer` prop `backButtonAriaLabel`
 - `sandstone/VideoPlayer` prop `onBack` to provide a way to exit video player via touch
 

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -128,7 +128,7 @@ const PickerBase = kind({
 		inlineTitle: PropTypes.bool,
 
 		/**
-		 * Allows the user to use the arrow keys to adjust the picker's value.
+		 * Allows the user to use the arrow keys or Enter key to adjust the picker's value.
 		 *
 		 * Key presses are captured in the directions of the increment and decrement buttons but
 		 * others are unaffected. A non-joined Picker allows navigation in any direction, but
@@ -159,6 +159,21 @@ const PickerBase = kind({
 		 * @public
 		 */
 		noAnimation: PropTypes.bool,
+
+		/**
+		 * Sets rules to show the indicator and to determine the user interaction of the control
+		 * at a horizontal-joined Picker case.
+		 *
+		 * When `false`, the indicator are shown and allow the user to use the Enter keys to adjust the picker's value.
+		 * When `true`, the increment and the decrement icons are shown instead of the indicator and
+		 * allow the user to use the left/right keys to adjust the picker's value.
+		 * If [orientation]{@link sandstone/Picker.Picker#orientation} is 'vertical' or
+		 * [joined]{@link sandstone/Picker.Picker#joined} is not assinged or is false, this prop is ignored.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		noIndicator: PropTypes.bool,
 
 		/**
 		 * Called when the `value` changes.

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -98,7 +98,23 @@
 			order: 2;
 		}
 	}
+	
+	&.noindicator {
+		.enact-locale-rtl({
+			flex-direction: row-reverse;
+		});
 
+		.incrementer {
+			order: 3;
+		}
+		.decrementer {
+			order: 1;
+		}
+		.valueWrapper {
+			order: 2;
+		}
+	}
+	
 	&.vertical {
 		height: @sand-picker-vertical-height;
 	}
@@ -115,11 +131,6 @@
 			font-weight: @sand-picker-joined-font-weight;
 		}
 
-		.valueWrapper {
-			height: @sand-picker-joined-value-height;
-			line-height: @sand-picker-joined-value-height;
-		}
-
 		.icon {
 			margin: 0;
 		}
@@ -133,8 +144,14 @@
 			}
 
 			.sizingPlaceholder,
+
 			.valueWrapper {
 				font-size: @sand-picker-joined-font-size;
+			}
+			
+			.valueWrapper {
+				height: @sand-picker-joined-value-height;
+				line-height: @sand-picker-joined-value-height;
 			}
 
 			.valueWrapper {
@@ -170,10 +187,28 @@
 				}
 			}
 		}
-
+		
+		&.noindicator {
+			&::before {
+				border-radius: @sand-picker-joined-vertical-border-radius;
+			}
+			
+			.incrementer,
+			.decrementer {
+				line-height: (@sand-button-small-height - (2 * @sand-button-border-width));
+				height: @sand-button-small-height;
+				margin: @sand-button-small-focusexpand-margin;
+				padding: @sand-button-icon-small-padding;
+			}
+		}
+		
 		&.vertical {
 			&::before {
 				border-radius: @sand-picker-joined-vertical-border-radius;
+			}
+			.valueWrapper {
+				height: @sand-picker-joined-value-height;
+				line-height: @sand-picker-joined-value-height;
 			}
 		}
 	}
@@ -212,6 +247,18 @@
 				}
 			}
 
+			&.noindicator {
+				&::before {
+					.sand-spotlight-resting-bg-colors();
+				}
+
+				.incrementer,
+				.decrementer {
+					color: @sand-picker-joined-incrementer-color;
+				}
+				
+			}
+			
 			&.vertical {
 				&::before {
 					.sand-spotlight-resting-bg-colors();
@@ -234,6 +281,17 @@
 					}
 				}
 
+				&.noindicator {
+					&::before {
+						.sand-spotlight-focus-bg-colors();
+					}
+
+					.incrementer,
+					.decrementer {
+						color: @sand-picker-joined-focus-incrementer-color;
+					}
+				}
+				
 				&.vertical {
 					&::before {
 						.sand-spotlight-focus-bg-colors();

--- a/internal/Picker/SpottablePicker.js
+++ b/internal/Picker/SpottablePicker.js
@@ -9,19 +9,21 @@ const SpottablePicker = kind({
 
 	propTypes: {
 		disabled: PropTypes.bool,
+		noIndicator: PropTypes.bool,
 		pickerOrientation: PropTypes.string
 	},
 
 	computed: {
-		selectionKeys: ({disabled, pickerOrientation}) => {
-			if (disabled || pickerOrientation === 'horizontal') return;
+		selectionKeys: ({disabled, noIndicator, pickerOrientation}) => {
+			if (disabled || (pickerOrientation === 'horizontal' && !noIndicator)) return;
 
-			return [38, 40];
+			return pickerOrientation === 'horizontal' ? [37, 39] : [38, 40];
 		}
 	},
 
 	render: ({selectionKeys, ...rest}) => {
 		delete rest.pickerOrientation;
+		delete rest.noIndicator;
 
 		return (
 			<Div {...rest} selectionKeys={selectionKeys} />

--- a/samples/sampler/stories/default/Picker.js
+++ b/samples/sampler/stories/default/Picker.js
@@ -47,6 +47,7 @@ export const _Picker = (args) => (
 		inlineTitle={args['inlineTitle']}
 		joined={args['joined']}
 		noAnimation={args['noAnimation']}
+		noIndicator={args['noIndicator']}
 		onChange={action('onChange')}
 		orientation={args['orientation']}
 		reverse={prop.reverse[args['reverse']]}
@@ -67,6 +68,7 @@ text('incrementAriaLabel', _Picker, Config, '');
 select('incrementIcon', _Picker, ['', ...incrementIcons], Config);
 boolean('inlineTitle', _Picker, Config);
 boolean('joined', _Picker, Config);
+boolean('noIndicator', _Picker, Config);
 boolean('noAnimation', _Picker, Config);
 select('orientation', _Picker, prop.orientation, Config, prop.orientation[0]);
 select('reverse', _Picker, [' ', 'false', 'true'], Config);


### PR DESCRIPTION
…Picker

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Support to control with left/right key in joined horizontal Picker

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `noIndicator` prop to provide way to control with left/right key in joined horizontal Picker and 
show the increment and the decrement icons instead of the indicator.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-15868

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)