### PR TITLE
WRN-13623: Fix touch detection condition logic in MediaPlayer and VideoPlayer

### DIFF
--- a/MediaPlayer/MediaSliderDecorator.js
+++ b/MediaPlayer/MediaSliderDecorator.js
@@ -86,7 +86,7 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {
 			this.handleMouseOver = this.handleMouseOver.bind(this);
 			this.handleMouseOut = this.handleMouseOut.bind(this);
 			this.handleMouseMove = this.handleMouseMove.bind(this);
-			if (platform.touch) {
+			if (platform.touchscreen) {
 				this.handleTouchMove = this.handleTouchMove.bind(this);
 			}
 
@@ -196,7 +196,7 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {
 
 			delete rest.onKnobMove;
 
-			if (platform.touch) {
+			if (platform.touchscreen) {
 				rest.onTouchMove = this.handleTouchMove;
 			}
 

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -832,7 +832,7 @@ const VideoPlayerBase = class extends Component {
 
 	componentDidMount () {
 		on('mousemove', this.activityDetected);
-		if (platform.touch) {
+		if (platform.touchscreen) {
 			on('touchmove', this.activityDetected);
 		}
 		document.addEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
@@ -930,7 +930,7 @@ const VideoPlayerBase = class extends Component {
 
 	componentWillUnmount () {
 		off('mousemove', this.activityDetected);
-		if (platform.touch) {
+		if (platform.touchscreen) {
 			off('touchmove', this.activityDetected);
 		}
 		document.removeEventListener('keydown', this.handleGlobalKeyDown, {capture: true});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Whether to enable touch-related logic in MediaPlayer and VideoPlayer should be determined by `platform.touchscreen` instead of `platform.touch`.
(Related PR: https://github.com/enactjs/enact/pull/3008)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use `platform.touchscreen` instead of `platform.touch` to invoke touch-related logic only in the touchscreen environments.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-13623

### Comments