### PR TITLE
WRN-14715: add Heading qa-sampler for bidirectional text

### DIFF
--- a/samples/sampler/stories/qa/Heading.js
+++ b/samples/sampler/stories/qa/Heading.js
@@ -130,7 +130,7 @@ export const WithBidirectionalText  = () => {
 			<Heading>{inputPasswordFor}<bdi>{abcDevice}</bdi>, Please</Heading>
 			{/* When cannot use markup, U+2068 FIRST STRONG ISOLATE */}
 			<Heading>{inputPasswordFor}&#x2068;{abcDevice}&#x2069;, Please</Heading>
-			<Heading>{new IString($L('Input Password for {deviceName}, Please')).format({deviceName: '\u2068' + abcDevice + '\u2069'})}</Heading>
+			<Heading>{new IString($L('Input Password for {deviceName}, Please')).format({deviceName: `\u2068${abcDevice}\u2069`})}</Heading>
 			<br />
 
 			{/* auto seems to be determined by the first letter */}

--- a/samples/sampler/stories/qa/Heading.js
+++ b/samples/sampler/stories/qa/Heading.js
@@ -1,5 +1,7 @@
+import IString from 'ilib/lib/IString';
 import {select, text} from '@enact/storybook-utils/addons/controls';
 import Heading from '@enact/sandstone/Heading';
+import $L from '@enact/sandstone/internal/$L';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import ri from '@enact/ui/resolution';
@@ -112,6 +114,8 @@ export const WithBidirectionalText  = () => {
 			{/* See: https://www.w3.org/International/articles/inline-bidi-markup/ */}
 			<Heading>{inputPasswordFor + abcDevice}</Heading>
 			<Heading>{inputPasswordFor}{abcDevice}, Please</Heading>
+			<Heading>{new IString($L('Input Password for {deviceName}, Please')).format({deviceName: abcDevice})}</Heading>
+
 			<br />
 
 			<Heading>{inputPasswordFor}<span dir="ltr">{abcDevice}</span>, Please</Heading>
@@ -124,8 +128,9 @@ export const WithBidirectionalText  = () => {
 			{/* <bdi> same with <span dir=auto> */}
 			<Heading>{inputPasswordFor}<span dir="auto">{abcDevice}</span>, Please</Heading>
 			<Heading>{inputPasswordFor}<bdi>{abcDevice}</bdi>, Please</Heading>
-			{/* When cannot use markup,  U+2068 FIRST STRONG ISOLATE */}
+			{/* When cannot use markup, U+2068 FIRST STRONG ISOLATE */}
 			<Heading>{inputPasswordFor}&#x2068;{abcDevice}&#x2069;, Please</Heading>
+			<Heading>{new IString($L('Input Password for {deviceName}, Please')).format({deviceName: '\u2068' + abcDevice + '\u2069'})}</Heading>
 			<br />
 
 			{/* auto seems to be determined by the first letter */}

--- a/samples/sampler/stories/qa/Heading.js
+++ b/samples/sampler/stories/qa/Heading.js
@@ -101,3 +101,45 @@ MultipleScroller.parameters = {
 		hideNoControlsWarning: true
 	}
 };
+
+export const WithBidirectionalText  = () => {
+	const inputPasswordFor = 'Input Password for ';
+	const inputPasswordForAr = 'الرجاء إدخال كلمة المرور لـ ';
+	const abcDevice = 'ABC جهاز';
+
+	return (
+		<Scroller>
+			{/* See: https://www.w3.org/International/articles/inline-bidi-markup/ */}
+			<Heading>{inputPasswordFor + abcDevice}</Heading>
+			<Heading>{inputPasswordFor}{abcDevice}, Please</Heading>
+			<br />
+
+			<Heading>{inputPasswordFor}<span dir="ltr">{abcDevice}</span>, Please</Heading>
+			{/* When cannot use markup, U+2067 RIGHT-TO-LEFT ISOLATE (RLI) or U+2066 LEFT-TO-RIGHT ISOLATE (LRI)
+				These are placed in the same location as the opening <span dir="..."> tag.
+				U+2069 POP DIRECTIONAL ISOLATE (PDI), and it corresponds to the </span> in the markup. */}
+			<Heading>{inputPasswordFor}&#x2066;{abcDevice}&#x2069;, Please</Heading>
+			<br />
+
+			{/* <bdi> same with <span dir=auto> */}
+			<Heading>{inputPasswordFor}<span dir="auto">{abcDevice}</span>, Please</Heading>
+			<Heading>{inputPasswordFor}<bdi>{abcDevice}</bdi>, Please</Heading>
+			{/* When cannot use markup,  U+2068 FIRST STRONG ISOLATE */}
+			<Heading>{inputPasswordFor}&#x2068;{abcDevice}&#x2069;, Please</Heading>
+			<br />
+
+			{/* auto seems to be determined by the first letter */}
+			<Heading>{inputPasswordFor}<bdi>جهاز ABC صباح</bdi>, Please</Heading>
+
+			<br />
+			{/* If there is any rtl character, set the direction of the marquee to rtl.  */}
+			<Heading>{inputPasswordFor}<bdi>{abcDevice}</bdi>, Please. long text long text long text long text long text long text long text</Heading>
+
+			<br />
+			<Heading>{inputPasswordForAr}{abcDevice}</Heading>
+			<Heading>{inputPasswordForAr}<bdi>{abcDevice}</bdi></Heading>
+		</Scroller>
+	);
+};
+
+WithBidirectionalText.storyName = 'with bidirectional text';


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Words scattered when LTR and RTL characters are mixed

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To guide the way of binding proper noun, add a Heading qa-sampler for bidirectional text.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-14715

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
