### PR TITLE
WRN-16710: Fix Scroller and VirtualList to focus the topmost element after scroll in pointer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` and `sandstone/VirtualList` to focus the topmost element after scroll in pointer mode
+
 ## [2.1.4] - 2022-03-24
 
 ### Added
@@ -35,7 +41,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` to show title and keypad properly when `type` is `number` and screen width is narrow
 - `sandstone/Picker` horizontal joined behavior going to the next item by touch
 - `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales
-- `sandstone/Scroller` and `sandstone/VirtualList` to focus the topmost element after scroll in pointer mode
 - `sandstone/VirtualList` to scroll properly by hover after changing `dataSize` when `hoverToScroll` is `true`
 
 ## [2.1.2] - 2021-12-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Input` to show title and keypad properly when `type` is `number` and screen width is narrow
 - `sandstone/Picker` horizontal joined behavior going to the next item by touch
 - `sandstone/Scroller` to scroll correctly on Android Chrome 85 or higher in RTL locales
+- `sandstone/Scroller` and `sandstone/VirtualList` to focus the topmost element after scroll in pointer mode
 - `sandstone/VirtualList` to scroll properly by hover after changing `dataSize` when `hoverToScroll` is `true`
 
 ## [2.1.2] - 2021-12-22

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -203,7 +203,7 @@ export const ListOfThingsInFixedPopupPanels = (args) => (
 		index={0}
 	>
 		<Panel>
-			<Header title='Panel1' />
+			<Header title="Panel1" />
 			<Scroller
 				focusableScrollbar={args['focusableScrollbar']}
 				horizontalScrollbar={args['horizontalScrollbar']}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -5,6 +5,8 @@ import Button from '@enact/sandstone/Button';
 import BodyText from '@enact/sandstone/BodyText';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
+import {Header} from '@enact/sandstone/Panels';
+import {FixedPopupPanels, Panel} from '@enact/sandstone/FixedPopupPanels';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Group from '@enact/ui/Group';
@@ -194,6 +196,42 @@ boolean('spotlightDisabled', ListOfThings, Config, false);
 select('verticalScrollbar', ListOfThings, prop.scrollbarOption, Config);
 
 ListOfThings.storyName = 'List of things';
+
+export const ListOfThingsInFixedPopupPanels = (args) => (
+	<FixedPopupPanels
+		open
+		index={0}
+	>
+		<Panel>
+			<Header title='Panel1' />
+			<Scroller
+				focusableScrollbar={args['focusableScrollbar']}
+				horizontalScrollbar={args['horizontalScrollbar']}
+				hoverToScroll={args['hoverToScroll']}
+				key={args['scrollMode']}
+				noScrollByWheel={args['noScrollByWheel']}
+				onKeyDown={action('onKeyDown')}
+				onScrollStart={action('onScrollStart')}
+				onScrollStop={action('onScrollStop')}
+				scrollMode={args['scrollMode']}
+				spotlightDisabled={args['spotlightDisabled']}
+				verticalScrollbar={args['verticalScrollbar']}
+			>
+				<Group childComponent={Item}>{itemData}</Group>
+			</Scroller>
+		</Panel>
+	</FixedPopupPanels>
+);
+
+select('focusableScrollbar', ListOfThingsInFixedPopupPanels, prop.focusableScrollbarOption, Config);
+select('horizontalScrollbar', ListOfThingsInFixedPopupPanels, prop.scrollbarOption, Config);
+boolean('hoverToScroll', ListOfThingsInFixedPopupPanels, Config);
+boolean('noScrollByWheel', ListOfThingsInFixedPopupPanels, Config);
+select('scrollMode', ListOfThingsInFixedPopupPanels, prop.scrollModeOption, Config);
+boolean('spotlightDisabled', ListOfThingsInFixedPopupPanels, Config, false);
+select('verticalScrollbar', ListOfThingsInFixedPopupPanels, prop.scrollbarOption, Config);
+
+ListOfThingsInFixedPopupPanels.storyName = 'List of things in FixedPopupPanels';
 
 export const HorizontalScroll = (args) => (
 	<Scroller

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -5,6 +5,7 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import Button from '@enact/sandstone/Button';
 import Item from '@enact/sandstone/Item';
 import {Header, Panel, Panels} from '@enact/sandstone/Panels';
+import {FixedPopupPanels, Panel as FixedPopupPanel} from '@enact/sandstone/FixedPopupPanels';
 import Scroller from '@enact/sandstone/Scroller';
 import SwitchItem from '@enact/sandstone/SwitchItem';
 import VirtualList from '@enact/sandstone/VirtualList';
@@ -361,6 +362,52 @@ _InPanels.parameters = {
 	props: {
 		noPanels: true
 	}
+};
+
+export const InFixedPopupPanels = (args) => {
+	return (
+		<FixedPopupPanels
+			open
+			index={0}
+		>
+			<FixedPopupPanel>
+				<Header title="Panel1" />
+				<VirtualList
+					dataSize={updateDataSize(args['dataSize'])}
+					horizontalScrollbar={args['horizontalScrollbar']}
+					hoverToScroll={args['hoverToScroll']}
+					itemRenderer={renderItem(Item, ri.scale(args['itemSize']), true)}
+					itemSize={ri.scale(args['itemSize'])}
+					key={args['scrollMode']}
+					noScrollByWheel={args['noScrollByWheel']}
+					onKeyDown={action('onKeyDown')}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					scrollMode={args['scrollMode']}
+					spacing={ri.scale(args['spacing'])}
+					spotlightDisabled={args['spotlightDisabled']}
+					verticalScrollbar={args['verticalScrollbar']}
+					wrap={args['wrap']}
+				/>
+			</FixedPopupPanel>
+		</FixedPopupPanels>
+	);
+};
+
+number('dataSize', InFixedPopupPanels, Config, defaultDataSize);
+select('horizontalScrollbar', InFixedPopupPanels, prop.scrollbarOption, Config);
+boolean('hoverToScroll', InFixedPopupPanels, Config);
+number('itemSize', InFixedPopupPanels, Config, 156);
+select('scrollMode', InFixedPopupPanels, prop.scrollModeOption, Config);
+boolean('noScrollByWheel', InFixedPopupPanels, Config);
+number('spacing', InFixedPopupPanels, Config);
+boolean('spotlightDisabled', InFixedPopupPanels, Config, false);
+select('verticalScrollbar', InFixedPopupPanels, prop.scrollbarOption, Config);
+select('wrap', InFixedPopupPanels, prop.wrapOption, Config);
+
+InFixedPopupPanels.storyName = 'in FixedPopupPanels';
+InFixedPopupPanels.parameters = {
+	propTables: [Config]
 };
 
 export const ScrollingTo0WheneverDataSizeChanges = (args) => {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -172,14 +172,18 @@ const useThemeScroll = (props, instances) => {
 	}
 
 	function focusOnItem () {
+		let isItemFocused = false;
+
 		if (mutableRef.current.indexToFocus !== null && typeof themeScrollContentHandle.current.focusByIndex === 'function') {
 			themeScrollContentHandle.current.focusByIndex(mutableRef.current.indexToFocus);
 			mutableRef.current.indexToFocus = null;
+			isItemFocused = true;
 		}
 
 		if (mutableRef.current.nodeToFocus !== null && typeof themeScrollContentHandle.current.focusOnNode === 'function') {
 			themeScrollContentHandle.current.focusOnNode(mutableRef.current.nodeToFocus);
 			mutableRef.current.nodeToFocus = null;
+			isItemFocused = true;
 		}
 
 		if (mutableRef.current.pointToFocus !== null) {
@@ -196,10 +200,15 @@ const useThemeScroll = (props, instances) => {
 
 				if (target) {
 					Spotlight.focus(target);
+					isItemFocused = true;
 				}
 			}
 
 			mutableRef.current.pointToFocus = null;
+		}
+
+		if (Spotlight.getPointerMode() && !isItemFocused) {
+			Spotlight.focus(scrollContainerRef.current, {enterTo: 'topmost'});
 		}
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is new 2023 TV UX about the restoring focus after scroll.  Focus should be set on the current visible top-most item in pointer mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In pointer mode, reset last-focus to the item currently visible

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-16710, WRN-12780, https://github.com/enactjs/sandstone/pull/1118

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)