### PR TITLE
Feature/wrn 12925

### DIFF
--- a/BodyText/BodyText.module.less
+++ b/BodyText/BodyText.module.less
@@ -17,10 +17,6 @@
 		.enact-locale-tallglyph({
 			font-size: @sand-tallglyph-body-small-font-size;
 		});
-
-		.sand-locale-non-latin({
-			font-size: @sand-non-latin-body-small-font-size;
-		});
 	}
 
 	.enact-locale-rtl({

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -97,7 +97,7 @@
 		}
 
 		.title {
-			.sand-font-size(@sand-input-fullscreen-title-font-size, @sand-non-latin-input-fullscreen-title-font-size);
+			.sand-font-size(@sand-input-fullscreen-title-font-size);
 		}
 
 		.numberCell {
@@ -172,7 +172,7 @@
 		.title {
 			margin: @sand-input-overlay-title-margin;
 
-			.sand-font-size(@sand-input-overlay-title-font-size, @sand-non-latin-input-overlay-title-font-size);
+			.sand-font-size(@sand-input-overlay-title-font-size);
 		}
 
 		.inputArea {

--- a/Panels/Header.module.less
+++ b/Panels/Header.module.less
@@ -139,7 +139,7 @@
 		}
 
 		.title {
-			.sand-font-size(@sand-header-compact-title-font-size, @sand-non-latin-header-compact-title-font-size);
+			.sand-font-size(@sand-header-compact-title-font-size);
 		}
 	}
 
@@ -158,7 +158,7 @@
 		}
 
 		.title {
-			.sand-font-size(@sand-header-wizard-title-font-size, @sand-non-latin-header-wizard-title-font-size);
+			.sand-font-size(@sand-header-wizard-title-font-size);
 			padding: @sand-header-wizard-title-padding;
 		}
 
@@ -188,7 +188,7 @@
 		}
 
 		.title {
-			.sand-font-size(@sand-header-mini-title-font-size, @sand-non-latin-header-mini-title-font-size);
+			.sand-font-size(@sand-header-mini-title-font-size);
 		}
 
 		&.withSubtitle {

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -188,13 +188,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		// font stylesheet when the locale changes
 		App = I18nDecorator(
 			{
-				...i18n,
-				// We use the latin fonts (with non-Latin fallback) for these languages (even though
-				// their scripts are non-latin)
-				latinLanguageOverrides: ['ko', 'ha', 'el', 'bg', 'mk', 'mn', 'ru', 'uk', 'kk'],
-				// We use the non-latin fonts for these languages (even though their scripts are
-				// technically considered latin)
-				nonLatinLanguageOverrides: ['en-JP']
+				...i18n
 			},
 			I18nFontDecorator(
 				App

--- a/styles/internal/fonts.less
+++ b/styles/internal/fonts.less
@@ -60,7 +60,7 @@
 	th: local("LG Smart UI AR HE TH") normal 300 600 700;
 	zh-HK: local("LG Smart UI TC") normal 300 600 700;
 	zh-TW: local("LG Smart UI TC") normal 300 600 700; // same as `zh-HK`
-	
+
 	// DEV NOTE: This is the closest proximity to a collection of unit tests that we have to test this system.
 	// name:							local("name");
 	// nameRepeat:						local("name"), local("name2");

--- a/styles/internal/fonts.less
+++ b/styles/internal/fonts.less
@@ -60,7 +60,7 @@
 	th: local("LG Smart UI AR HE TH") normal 300 600 700;
 	zh-HK: local("LG Smart UI TC") normal 300 600 700;
 	zh-TW: local("LG Smart UI TC") normal 300 600 700; // same as `zh-HK`
-
+	
 	// DEV NOTE: This is the closest proximity to a collection of unit tests that we have to test this system.
 	// name:							local("name");
 	// nameRepeat:						local("name"), local("name2");

--- a/styles/mixins.less
+++ b/styles/mixins.less
@@ -122,7 +122,6 @@
 // ThemeDecorator to override the target of the rules.
 .sand-text-base(@font-size: @sand-body-font-size; @target: normal) {
 	.sand-font({
-		font-weight: @sand-non-latin-font-weight;
 	}, @target);
 
 	font-weight: normal;
@@ -248,11 +247,7 @@
 	font-weight: @sand-body-font-weight;
 	font-size: @sand-body-font-size;
 	font-style: @sand-body-font-style;
-	.sand-font(@sand-body-font-family; @sand-non-latin-font-family-light; {
-		font-weight: @sand-non-latin-body-font-weight;
-		font-size: @sand-non-latin-body-font-size;
-		font-style: @sand-non-latin-body-font-style;
-	});
+	.sand-font(@sand-body-font-family; @sand-non-latin-font-family-light);
 
 	.enact-locale-line-height(@sand-body-line-height; @sand-tallglyph-body-line-height);
 
@@ -263,11 +258,7 @@
 }
 
 .sand-large-button-text() {
-	.sand-font(@sand-button-font-family; @sand-non-latin-button-font-family; {
-		font-size: @sand-non-latin-button-large-font-size;
-		font-style: @sand-non-latin-button-font-style;
-		font-weight: @sand-non-latin-button-font-weight;
-	});
+	.sand-font(@sand-button-font-family; @sand-non-latin-button-font-family);
 	font-size: @sand-button-font-size;
 	font-style: @sand-button-font-style;
 	font-weight: @sand-button-font-weight;
@@ -275,11 +266,7 @@
 }
 
 .sand-small-button-text() {
-	.sand-font(@sand-button-small-font-family; @sand-non-latin-button-font-family; {
-		font-size: @sand-non-latin-button-small-font-size;
-		font-style: @sand-non-latin-button-small-font-style;
-		font-weight: @sand-non-latin-button-small-font-weight;
-	});
+	.sand-font(@sand-button-small-font-family; @sand-non-latin-button-font-family);
 	font-size: @sand-button-small-font-size;
 	font-style: @sand-button-small-font-style;
 	font-weight: @sand-button-small-font-weight;

--- a/styles/mixins.less
+++ b/styles/mixins.less
@@ -219,20 +219,6 @@
 // Text definitions
 //
 
-.sand-alert-title() {
-	.sand-font(@sand-alert-font-family; @sand-non-latin-font-family-light);
-	.enact-locale-line-height(@sand-alert-line-height; @sand-tallglyph-body-line-height);
-	font-size: @sand-alert-title-font-size;
-	font-weight: @sand-alert-font-weight;
-}
-
-.sand-alert-subtitle() {
-	.sand-font(@sand-alert-font-family; @sand-non-latin-font-family-light);
-	.enact-locale-line-height(@sand-alert-line-height);
-	font-size: @sand-alert-subtitle-font-size;
-	font-weight: @sand-alert-font-weight;
-}
-
 .sand-alert-overlay-content() {
 	.sand-font(@sand-alert-font-family; @sand-non-latin-font-family-light);
 	.enact-locale-line-height(@sand-alert-line-height; @sand-tallglyph-body-line-height);

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -166,20 +166,11 @@
 
 @sand-tallglyph-alert-title-font-size:  @sand-alert-title-font-size;
 @sand-tallglyph-alert-notitle-content-font-size: @sand-alert-notitle-content-font-size;
-@sand-non-latin-body-font-size:         54px;
-@sand-non-latin-body-small-font-size:   48px;
 @sand-tallglyph-body-small-font-size:   48px;
-@sand-non-latin-button-large-font-size: 72px;
-@sand-non-latin-button-small-font-size: 54px;
-@sand-non-latin-header-compact-title-font-size: @sand-header-compact-title-font-size;
-@sand-non-latin-header-mini-title-font-size: @sand-header-mini-title-font-size;
-@sand-non-latin-header-wizard-title-font-size: @sand-header-wizard-title-font-size;
 @sand-tallglyph-heading-subtitle-font-size: (@sand-heading-subtitle-font-size - 6px);
 @sand-tallglyph-heading-title-font-size: 114px;
 @sand-tallglyph-imageitem-caption-font-size: 54px;
 @sand-tallglyph-imageitem-label-font-size: 36px;
-@sand-non-latin-input-fullscreen-title-font-size: @sand-input-fullscreen-title-font-size;
-@sand-non-latin-input-overlay-title-font-size: @sand-input-overlay-title-font-size;
 
 // Other Font Properties
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After refactoring, https://github.com/enactjs/enact/pull/2465 all language glyphs render in ther designated font regardless of the current locale.
Css rules that reduce font style differences between fonts are no longer needed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove css rules in which the selector start with `.enact-locale-non-latin` from .less files

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-12925

### Comments
