### PR TITLE
WRN-18729: Added `editable` prop to Scroller to support editing items

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -1,11 +1,3 @@
-/**
- * Sandstone styled EditableWrapper components
- *
- * @module sandstone/EditableWrapper
- * @memberof sandstone/Scroller
- * @exports EditableWrapper
- */
-
 import {forwardCustom} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -182,7 +182,7 @@ const EditableWrapper = (props) => {
 							addRearrangedItems({moveDirection, toIndex});
 						}
 					} else {
-						addRearrangedItems({moveDirection, toIndex}); // addRearrangedItems
+						addRearrangedItems({moveDirection, toIndex});
 					}
 
 					mutableRef.current.prevToIndex = toIndex;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -17,10 +17,7 @@ import css from './EditableWrapper.module.less';
  */
 const EditableWrapper = (props) => {
 	const {children, editable, scrollContainerHandle, scrollContentRef} = props;
-	let centered = true;
-	if (editable.centered != null) {
-		centered = editable.centered;
-	}
+	let centerd = editable.centered != null ? editable.centered : true;
 	const dataSize = children?.length;
 
 	// Mutable value

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -17,7 +17,7 @@ import css from './EditableWrapper.module.less';
  */
 const EditableWrapper = (props) => {
 	const {children, editable, scrollContainerHandle, scrollContentRef} = props;
-	let centerd = editable.centered != null ? editable.centered : true;
+	let centered = editable.centered != null ? editable.centered : true;
 	const dataSize = children?.length;
 
 	// Mutable value
@@ -167,8 +167,6 @@ const EditableWrapper = (props) => {
 				const offset = (toIndex - fromIndex) * itemWidth;
 				wrapperRef.current.style.setProperty('--selected-item-offset', offset + 'px');
 
-				// Reset addable flag to true
-				let addable = true;
 
 				// If the current toIndex is new,
 				if (toIndex !== prevToIndex) {
@@ -176,11 +174,6 @@ const EditableWrapper = (props) => {
 					const moveDirection = Math.sign(toIndex - prevToIndex);
 					// If the direction is changed and there are rearranged items, we remove them first.
 					if (lastMoveDirection && moveDirection !== lastMoveDirection && rearrangedItems.length > 0) {
-						addable = false;
-					}
-					if (addable) {
-						addRearrangedItems({moveDirection, toIndex}); // addRearrangedItems
-					} else {
 						const numToRemove = moveDirection > 0 ? toIndex - prevToIndex : prevToIndex - toIndex;
 						removeRearrangedItems(numToRemove);
 
@@ -188,6 +181,8 @@ const EditableWrapper = (props) => {
 						if (numToRemove > rearrangedItems.length) {
 							addRearrangedItems({moveDirection, toIndex});
 						}
+					} else {
+						addRearrangedItems({moveDirection, toIndex}); // addRearrangedItems
 					}
 
 					mutableRef.current.prevToIndex = toIndex;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -1,0 +1,312 @@
+/**
+ * Sandstone styled EditableWrapper components
+ *
+ *
+ * @module sandstone/EditableWrapper
+ * @memberof sandstone/Scroller
+ * @exports EditableWrapper
+ */
+
+import {forwardCustom} from '@enact/core/handle';
+import {is} from '@enact/core/keymap';
+import {clamp} from '@enact/core/util';
+import classNames from 'classnames';
+import {useCallback, useEffect, useRef} from 'react';
+
+import css from './EditableWrapper.module.less';
+
+const EditableWrapper = (props) => {
+	const {children, editable, scrollContainerRef, scrollContainerHandle, scrollContentRef} = props;
+
+	if (editable == null) {
+		return children;
+	}
+
+	const {centered} = editable;
+	const dataSize = children?.length;
+
+	// Mutable value
+
+	const wrapperRef = useRef();
+	const mutableRef = useRef({
+		// Constants
+		itemWidth: null,
+		centeredOffset: 0,
+
+		// DOM elements
+		selectedItem: null,
+		rearrangedItems: [],
+
+		// Indices
+		fromIndex: null,
+		prevToIndex: null,
+
+		// Flags
+		addable: true,
+		lastMoveDirection: null
+	});
+
+	console.log("dataSize: ", dataSize);
+
+	// Functions
+
+	// Reset values
+	const reset = useCallback(() => {
+		const {selectedItem} = mutableRef.current;
+
+		selectedItem?.classList.remove(css.selected);
+		selectedItem?.classList.remove(css.rearranged);
+		selectedItem?.classList.remove(css.selectedTransform);
+
+		mutableRef.current.selectedItem = null;
+		mutableRef.current.lastMoveDirection = null;
+		mutableRef.current.prevToIndex = null;
+		scrollContainerRef.current.style.setProperty('--selected-item-offset', '0px');
+	}, [scrollContainerRef]);
+
+	// Finalize the order
+	const finalizeOrders = useCallback(() => {
+		const {fromIndex, lastMoveDirection, prevToIndex, rearrangedItems, selectedItem} = mutableRef.current;
+		let orders = Array.from({length: dataSize}, (_, i) => i + 1);
+
+		if (rearrangedItems.length > 0) {
+			let selectedOrder = selectedItem.style.order;
+			const changedOrder = [];
+
+			console.log("lastMoveDirection: " , lastMoveDirection);
+
+			rearrangedItems.forEach((item) => {
+				const order = Number(item.style.order);
+				console.log("forEach ", order);
+				selectedOrder = order;
+				item.style.order = order - lastMoveDirection;
+				item.classList.remove(css.rearrangedTransform);
+				item.classList.remove(css.rearranged);
+				if (lastMoveDirection > 0) {
+					changedOrder.push(order);
+				} else {
+					changedOrder.unshift(order);
+				}
+			});
+			console.log(changedOrder);
+
+			if (lastMoveDirection > 0) {
+				changedOrder.push(Number(selectedItem.style.order));
+			} else {
+				changedOrder.unshift(Number(selectedItem.style.order));
+			}
+
+			mutableRef.current.rearrangedItems = [];
+			selectedItem.style.order = selectedOrder;
+
+			//create order array
+			console.log(orders);
+			console.log("changed Orders:", changedOrder);
+			console.log("fromIndex: ", fromIndex);
+			console.log("prevToIndex: ", prevToIndex);
+			orders.splice(Math.min(fromIndex, prevToIndex), changedOrder.length, ...changedOrder);
+			console.log(orders);
+		}
+
+		return orders;
+
+	}, [dataSize]);
+
+	const startEditing = useCallback((item) => {
+		// FIXME: Need to figure out the right element
+		if (item.classList.contains('spottable')) {
+			item.classList.add(css.selected);
+			item.classList.add(css.selectedTransform);
+			mutableRef.current.selectedItem = item;
+
+			mutableRef.current.fromIndex = Number(item.style.order) - 1;
+			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
+			console.log("fromIndex:", mutableRef.current.fromIndex);
+		}
+	}, []);
+
+	const handleClick = useCallback((ev) => {
+		if (mutableRef.current.selectedItem) {
+			// Finalize orders and forward `onComplete` event
+			const orders = finalizeOrders();
+			forwardCustom('onComplete', (ev) => ({orders}))({}, editable);
+			reset();
+		} else {
+			// Start editing by adding selected transition to selected item
+			startEditing(ev.target.parentElement);
+		}
+	}, [finalizeOrders, startEditing, props]);
+
+	// Move siblings
+	const moveSiblings = useCallback(({direction, toIndex}) => {
+		// Set the direction to css variable
+		scrollContainerRef.current.style.setProperty('--move-direction', direction);
+
+		const {fromIndex, rearrangedItems, selectedItem} = mutableRef.current;
+		const getNextElement = (item) => direction > 0 ? item.nextElementSibling : item.previousElementSibling;
+		let sibling = getNextElement(selectedItem);
+		let start = direction > 0 ? toIndex : fromIndex;
+		let end =  direction > 0 ? fromIndex : toIndex;
+
+		while (start > end && sibling) {
+			sibling?.classList.add(css.rearranged);
+			sibling?.classList.add(css.rearrangedTransform);
+
+			if (!rearrangedItems.includes(sibling)) {
+				rearrangedItems.push(sibling);
+			}
+
+			sibling = getNextElement(sibling);
+			start--;
+		}
+
+		mutableRef.current.lastMoveDirection = direction;
+
+	}, []);
+
+	// Move items
+	const moveItems = useCallback((toIndex) => {
+		const {selectedItem} = mutableRef.current;
+
+		if (selectedItem) {
+			// Bail out when index is out of scope
+			if (toIndex < dataSize && toIndex >= 0) {
+				const {fromIndex, itemWidth, lastMoveDirection, prevToIndex, rearrangedItems} = mutableRef.current;
+
+				// Set the selected item's offset to css variable
+				const offset = (toIndex - fromIndex) * itemWidth;
+				scrollContainerRef.current.style.setProperty('--selected-item-offset', offset + 'px');
+
+				// Reset addable flag to true
+				mutableRef.current.addable = true;
+
+				// If the current toIndex is new,
+				if (toIndex !== prevToIndex) {
+					console.log("prevToIndex:", prevToIndex);
+					console.log("toIndex: ", toIndex);
+					// Determine the direcion of move from the latest from index
+					const direction = Math.sign(toIndex - prevToIndex);
+					console.log("direction: ", direction);
+					console.log("lastMoveDirection to compare: ", lastMoveDirection);
+					// If the direction is changed and there are rearranged items, we remove them first.
+					if (lastMoveDirection && direction !== lastMoveDirection && rearrangedItems.length > 0) {
+						mutableRef.current.addable = false;
+					}
+					if (mutableRef.current.addable) {
+						moveSiblings({direction, toIndex});
+						console.log("Added complete ", rearrangedItems.length);
+					} else {
+						console.log("Cant' add, we should remove ", rearrangedItems.length);
+						const numToRemove = direction > 0 ? toIndex - prevToIndex : prevToIndex - toIndex;
+						if (rearrangedItems.length > 0) {
+							console.log("removing", numToRemove);
+							for (let i = 0; i < numToRemove; i++) {
+								const toItem = rearrangedItems.pop();
+								toItem?.classList.remove(css.rearrangedTransform);
+							}
+						}
+						// When there's jump, meaning, numToRemove is bigger than 0, we need to add an item
+						if (numToRemove > rearrangedItems.length) {
+							moveSiblings({direction, toIndex});
+						}
+					}
+
+					mutableRef.current.prevToIndex = toIndex;
+				}
+			}
+		}
+	}, [dataSize, moveSiblings]);
+
+	// Remove an item
+	const removeItem = useCallback(() => {
+		const {prevToIndex} = mutableRef.current;
+		const orders = finalizeOrders();
+		console.log(orders);
+		console.log("prevToIndex: ", prevToIndex);
+		orders.splice(prevToIndex, 1);
+		console.log(orders);
+		forwardCustom('onComplete', (ev) => ({orders}))({}, editable);
+
+		reset();
+	}, [finalizeOrders, props]);
+
+	const handleMouseMove = useCallback((ev) => {
+		const {centeredOffset, itemWidth, selectedItem} = mutableRef.current;
+		if (selectedItem) {
+			// Determine toIndex with mouse client x position
+			const toIndex = Math.floor((ev.clientX + scrollContentRef.current.scrollLeft - centeredOffset) / itemWidth);
+
+			console.log("toIndex: ", toIndex);
+			moveItems(toIndex);
+		}
+	}, [moveItems, props]);
+
+	const handleKeyDown = useCallback((ev) => {
+		const {keyCode, target} = ev;
+		const {selectedItem} = mutableRef.current;
+		if (is('enter', keyCode)) {
+			if (selectedItem) {
+				const orders = finalizeOrders();
+				forwardCustom('onComplete', (ev) => ({orders}))({}, editable);
+				reset();
+			} else {
+				startEditing(target);
+			}
+		} else if (is('left', keyCode) || is('right', keyCode)) {
+			if (selectedItem) {
+				const container = scrollContentRef.current;
+				const {itemWidth, prevToIndex} = mutableRef.current;
+				const toIndex = is('left', keyCode) ? prevToIndex - 1 : prevToIndex + 1;
+
+				const itemLeft = toIndex * itemWidth - container.scrollLeft;
+				console.log("x", itemLeft);
+				let left;
+				if (itemLeft > container.offsetLeft + container.clientWidth - itemWidth) {
+					left = itemLeft - (container.clientWidth - itemWidth) + container.scrollLeft;
+				} else if(itemLeft < 0) {
+					left = container.scrollLeft + itemLeft;
+				}
+
+				scrollContainerHandle.current.start({
+					targetX: left,
+					targetY: 0
+				});
+
+				moveItems(toIndex);
+
+				ev.preventDefault();
+				ev.stopPropagation();
+			}
+		}
+	}, [finalizeOrders, startEditing, moveItems, props]);
+
+	useEffect(() => {
+		// Calculate the item width once
+		if (!mutableRef.current.itemWidth) {
+			const item = wrapperRef.current?.children[0];
+			const neighbor = item.nextElementSibling || item.previousElementSibling;
+			mutableRef.current.itemWidth = Math.abs(item.offsetLeft - neighbor?.offsetLeft);
+			mutableRef.current.centeredOffset = centered ? item.getBoundingClientRect().x : 0;
+			scrollContainerRef.current?.style.setProperty('--item-width', mutableRef.current.itemWidth + 'px');
+		}
+	}, []);
+
+	// Return
+
+	return (
+		<div
+			className={classNames(css.wrapper, {[css.centered]: centered})}
+			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+			onMouseMove={handleMouseMove}
+			ref={wrapperRef}
+		>
+			{children}
+		</div>
+	);
+}
+
+export default EditableWrapper;
+export {
+	EditableWrapper
+};

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -117,7 +117,7 @@ const EditableWrapper = (props) => {
 		}
 	}, [editable, finalizeOrders, reset, startEditing]);
 
-	// Move siblings
+	// Add rearranged items
 	const addRearrangedItems = useCallback(({moveDirection, toIndex}) => {
 		// Set the moveDirection to css variable
 		wrapperRef.current.style.setProperty('--move-direction', moveDirection);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -16,7 +16,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import css from './EditableWrapper.module.less';
 
 const EditableWrapper = (props) => {
-	const {children, editable, scrollContainerRef, scrollContainerHandle, scrollContentRef} = props;
+	const {children, editable, scrollContainerHandle, scrollContentRef} = props;
 
 	if (editable == null) {
 		return children;
@@ -61,8 +61,8 @@ const EditableWrapper = (props) => {
 		mutableRef.current.selectedItem = null;
 		mutableRef.current.lastMoveDirection = null;
 		mutableRef.current.prevToIndex = null;
-		scrollContainerRef.current.style.setProperty('--selected-item-offset', '0px');
-	}, [scrollContainerRef]);
+		wrapperRef.current.style.setProperty('--selected-item-offset', '0px');
+	}, []);
 
 	// Finalize the order
 	const finalizeOrders = useCallback(() => {
@@ -140,7 +140,7 @@ const EditableWrapper = (props) => {
 	// Move siblings
 	const moveSiblings = useCallback(({direction, toIndex}) => {
 		// Set the direction to css variable
-		scrollContainerRef.current.style.setProperty('--move-direction', direction);
+		wrapperRef.current.style.setProperty('--move-direction', direction);
 
 		const {fromIndex, rearrangedItems, selectedItem} = mutableRef.current;
 		const getNextElement = (item) => direction > 0 ? item.nextElementSibling : item.previousElementSibling;
@@ -175,7 +175,7 @@ const EditableWrapper = (props) => {
 
 				// Set the selected item's offset to css variable
 				const offset = (toIndex - fromIndex) * itemWidth;
-				scrollContainerRef.current.style.setProperty('--selected-item-offset', offset + 'px');
+				wrapperRef.current.style.setProperty('--selected-item-offset', offset + 'px');
 
 				// Reset addable flag to true
 				mutableRef.current.addable = true;
@@ -287,7 +287,7 @@ const EditableWrapper = (props) => {
 			const neighbor = item.nextElementSibling || item.previousElementSibling;
 			mutableRef.current.itemWidth = Math.abs(item.offsetLeft - neighbor?.offsetLeft);
 			mutableRef.current.centeredOffset = centered ? item.getBoundingClientRect().x : 0;
-			scrollContainerRef.current?.style.setProperty('--item-width', mutableRef.current.itemWidth + 'px');
+			wrapperRef.current?.style.setProperty('--item-width', mutableRef.current.itemWidth + 'px');
 		}
 	}, []);
 

--- a/Scroller/EditableWrapper.module.less
+++ b/Scroller/EditableWrapper.module.less
@@ -1,0 +1,32 @@
+// EditableWrapper.module.less
+//
+
+.wrapper {
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+    padding-top: 60px;
+}
+
+.centered {
+	justify-content: center;
+}
+
+.selected {
+	transition: transform 360ms;
+	transform: translateY(-48px);
+	will-change: transform;
+	z-index: 1;
+}
+
+.selectedTransform {
+	transform: translate(var(--selected-item-offset), -48px);
+}
+
+.rearranged {
+	transition: transform 360ms;
+}
+
+.rearrangedTransform {
+	transform: translateX(calc((-1) * var(--move-direction) * var(--item-width)));
+}

--- a/Scroller/EditableWrapper.module.less
+++ b/Scroller/EditableWrapper.module.less
@@ -14,13 +14,9 @@
 
 .selected {
 	transition: transform 360ms;
-	transform: translateY(-48px);
+	transform: translate(var(--selected-item-offset), -48px);
 	will-change: transform;
 	z-index: 1;
-}
-
-.selectedTransform {
-	transform: translate(var(--selected-item-offset), -48px);
 }
 
 .rearranged {

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -88,11 +88,6 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 	} = useScroll(rest);
 
 	const {
-		className: containerClasses,
-		...scrollContainerRest
-	} = scrollContainerProps;
-
-	const {
 		className,
 		...scrollContentWrapperRest
 	} = scrollContentWrapperProps;
@@ -109,7 +104,7 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 	// Render
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>
-			<ScrollContentWrapper className={classnames(containerClasses, css.scrollContainer)} {...scrollContainerRest} {...scrollContentWrapperRest}>
+			<ScrollContentWrapper {...scrollContainerProps} {...scrollContentWrapperRest}>
 				<ScrollBody {...focusableBodyProps}>
 					<UiScrollerBasic {...themeScrollContentProps} aria-label={ariaLabel} id={id} ref={scrollContentHandle}>
 						<EditableWrapper {...editableWrapperProps} />

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -14,6 +14,7 @@
  *
  * @module sandstone/Scroller
  * @exports Scroller
+ * @exports EditableShape
  */
 
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
@@ -33,8 +34,6 @@ import Skinnable from '../Skinnable';
 import EditableWrapper from './EditableWrapper';
 import useThemeScroller from './useThemeScroller';
 
-import css from './Scroller.module.less';
-
 const nop = () => {};
 const SpottableDiv = Spottable('div');
 let scrollerId = 0;
@@ -42,13 +41,13 @@ let scrollerId = 0;
 /**
  * The shape for editable of [Scroller]{@link sandstone/Scroller}.
  *
- * @typedef {Object} editableShape
+ * @typedef {Object} EditableShape
  * @memberof sandstone/Scroller
  * @property {Function} onComplete The callback function called when editing is finished.
  * @property {Boolean} centered Centers the contents of the scroller.
  * @public
  */
-const editableShape = PropTypes.shape({
+const EditableShape = PropTypes.shape({
 	onComplete: PropTypes.func.isRequired,
 	centered: PropTypes.bool
 });
@@ -98,6 +97,8 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 		themeScrollContentProps
 	} = useThemeScroller(rest, {...scrollContentProps, className: classnames(className, scrollContentProps.className)}, id, isHorizontalScrollbarVisible, isVerticalScrollbarVisible);
 
+	const {children, direction, editable} = rest;
+
 	// To apply spotlight navigableFilter, SpottableDiv should be in scrollContainer.
 	const ScrollBody = rest.focusableScrollbar === 'byEnter' ? SpottableDiv : Fragment;
 
@@ -107,7 +108,10 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 			<ScrollContentWrapper {...scrollContainerProps} {...scrollContentWrapperRest}>
 				<ScrollBody {...focusableBodyProps}>
 					<UiScrollerBasic {...themeScrollContentProps} aria-label={ariaLabel} id={id} ref={scrollContentHandle}>
-						<EditableWrapper {...editableWrapperProps} />
+						{(editable == null || direction !== 'horizontal') ?
+							children :
+							<EditableWrapper {...editableWrapperProps} />
+						}
 					</UiScrollerBasic>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 					{isHorizontalScrollbarVisible ? <Scrollbar {...horizontalScrollbarProps} /> : null}
@@ -199,10 +203,10 @@ Scroller.propTypes = /** @lends sandstone/Scroller.Scroller.prototype */ {
 	/**
 	 * TBD: Enables editing items in the scroller.
 	 *
-	 * @type {sandstone.Scroller/editableShape}
+	 * @type {sandstone/Scroller.EditableShape}
 	 * @public
 	 */
-	editable: editableShape,
+	editable: EditableShape,
 
 	/**
 	 * Adds fade-out effect on the scroller.
@@ -459,5 +463,6 @@ Scroller.defaultProps = {
 
 export default Scroller;
 export {
+	EditableShape,
 	Scroller
 };

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -30,11 +30,28 @@ import HoverToScroll from '../useScroll/HoverToScroll';
 import Scrollbar from '../useScroll/Scrollbar';
 import Skinnable from '../Skinnable';
 
+import EditableWrapper from './EditableWrapper';
 import useThemeScroller from './useThemeScroller';
+
+import css from './Scroller.module.less';
 
 const nop = () => {};
 const SpottableDiv = Spottable('div');
 let scrollerId = 0;
+
+/**
+ * The shape for editable of [Scroller]{@link sandstone/Scroller}.
+ *
+ * @typedef {Object} editableShape
+ * @memberof sandstone/Scroller
+ * @property {Function} onComplete The callback function called when editing is finished.
+ * @property {Boolean} centered Centers the contents of the scroller.
+ * @public
+ */
+const editableShape = PropTypes.shape({
+	onComplete: PropTypes.func.isRequired,
+	centered: PropTypes.bool
+});
 
 /**
  * A Sandstone-styled Scroller, useScroll applied.
@@ -71,11 +88,17 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 	} = useScroll(rest);
 
 	const {
+		className: containerClasses,
+		...scrollContainerRest
+	} = scrollContainerProps;
+
+	const {
 		className,
 		...scrollContentWrapperRest
 	} = scrollContentWrapperProps;
 
 	const {
+		editableWrapperProps,
 		focusableBodyProps,
 		themeScrollContentProps
 	} = useThemeScroller(rest, {...scrollContentProps, className: classnames(className, scrollContentProps.className)}, id, isHorizontalScrollbarVisible, isVerticalScrollbarVisible);
@@ -86,9 +109,11 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 	// Render
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>
-			<ScrollContentWrapper {...scrollContainerProps} {...scrollContentWrapperRest}>
+			<ScrollContentWrapper className={classnames(containerClasses, css.scrollContainer)} {...scrollContainerRest} {...scrollContentWrapperRest}>
 				<ScrollBody {...focusableBodyProps}>
-					<UiScrollerBasic {...themeScrollContentProps} aria-label={ariaLabel} id={id} ref={scrollContentHandle} />
+					<UiScrollerBasic {...themeScrollContentProps} aria-label={ariaLabel} id={id} ref={scrollContentHandle}>
+						<EditableWrapper {...editableWrapperProps} />
+					</UiScrollerBasic>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 					{isHorizontalScrollbarVisible ? <Scrollbar {...horizontalScrollbarProps} /> : null}
 					{hoverToScroll ? <HoverToScroll {...hoverToScrollProps} /> : null}
@@ -175,6 +200,14 @@ Scroller.propTypes = /** @lends sandstone/Scroller.Scroller.prototype */ {
 	 * @public
 	 */
 	direction: PropTypes.oneOf(['both', 'horizontal', 'vertical']),
+
+	/**
+	 * TBD: Enables editing items in the scroller.
+	 *
+	 * @type {sandstone.Scroller/editableShape}
+	 * @public
+	 */
+	editable: editableShape,
 
 	/**
 	 * Adds fade-out effect on the scroller.

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -108,9 +108,9 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 			<ScrollContentWrapper {...scrollContainerProps} {...scrollContentWrapperRest}>
 				<ScrollBody {...focusableBodyProps}>
 					<UiScrollerBasic {...themeScrollContentProps} aria-label={ariaLabel} id={id} ref={scrollContentHandle}>
-						{(editable == null || direction !== 'horizontal') ?
-							children :
-							<EditableWrapper {...editableWrapperProps} />
+						{(editable && direction === 'horizontal') ?
+							<EditableWrapper {...editableWrapperProps} /> :
+							children
 						}
 					</UiScrollerBasic>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}

--- a/Scroller/Scroller.module.less
+++ b/Scroller/Scroller.module.less
@@ -4,12 +4,6 @@
 @import "../styles/mixins.less";
 @import "../styles/variables.less";
 
-.scrollContainer {
-	--selected-item-offset: 0px;
-	--item-width: 0px;
-	--move-direction: 1;
-}
-
 .focusableBody {
 	display: flex;
 	flex-direction: column;

--- a/Scroller/Scroller.module.less
+++ b/Scroller/Scroller.module.less
@@ -4,6 +4,12 @@
 @import "../styles/mixins.less";
 @import "../styles/variables.less";
 
+.scrollContainer {
+	--selected-item-offset: 0px;
+	--item-width: 0px;
+	--move-direction: 1;
+}
+
 .focusableBody {
 	display: flex;
 	flex-direction: column;

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -346,8 +346,8 @@ const useSpottable = (props, instances) => {
 };
 
 const useThemeScroller = (props, scrollContentProps, contentId, isHorizontalScrollbarVisible, isVerticalScrollbarVisible) => {
-	const {className, fadeOut, scrollContainerRef, ...rest} = scrollContentProps;
-	const {scrollContentHandle, scrollContentRef} = rest;
+	const {className, children, editable, fadeOut, scrollContainerRef, ...rest} = scrollContentProps;
+	const {scrollContainerHandle, scrollContentHandle, scrollContentRef} = rest;
 
 	delete rest.onUpdate;
 	delete rest.scrollContainerContainsDangerously;
@@ -368,7 +368,6 @@ const useThemeScroller = (props, scrollContentProps, contentId, isHorizontalScro
 		}
 	}, [props.focusableScrollbar, scrollContainerRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
 
-
 	scrollContentProps.setThemeScrollContentHandle({
 		calculatePositionOnFocus,
 		focusOnNode,
@@ -383,7 +382,17 @@ const useThemeScroller = (props, scrollContentProps, contentId, isHorizontalScro
 		isHorizontalScrollbarVisible && !isVerticalScrollbarVisible && fadeOut ? css.horizontalFadeout : null
 	);
 
-	return {focusableBodyProps, themeScrollContentProps: rest};
+	return {
+		editableWrapperProps: {
+			children,
+			editable,
+			scrollContainerHandle,
+			scrollContainerRef,
+			scrollContentRef
+		},
+		focusableBodyProps,
+		themeScrollContentProps: {...rest}
+	};
 };
 
 export default useThemeScroller;

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -387,7 +387,6 @@ const useThemeScroller = (props, scrollContentProps, contentId, isHorizontalScro
 			children,
 			editable,
 			scrollContainerHandle,
-			scrollContainerRef,
 			scrollContentRef
 		},
 		focusableBodyProps,

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -12,7 +12,7 @@ import Group from '@enact/ui/Group';
 import ri from '@enact/ui/resolution';
 import {Scroller as UiScroller, ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
-import {Component} from 'react';
+import {Component, useCallback, useLayoutEffect, useState} from 'react';
 
 import css from './Scroller.module.less';
 
@@ -195,6 +195,97 @@ boolean('spotlightDisabled', ListOfThings, Config, false);
 select('verticalScrollbar', ListOfThings, prop.scrollbarOption, Config);
 
 ListOfThings.storyName = 'List of things';
+
+let itemsArr = [];
+const populateItems = ({index}) => {
+	const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);
+	const source = {
+		hd: `http://via.placeholder.com/200x200/${color}/ffffff/png?text=Image+${index}`,
+		fhd: `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${index}`,
+		uhd: `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${index}`
+	};
+
+	return {src: source, index};
+};
+
+for (let i = 0; i < 20; i++) {
+	itemsArr.push(populateItems({index: i}));
+}
+
+export const EditableList = (args) => {
+	const dataSize = args['editableDataSize'];
+	const [items, setItems] = useState(itemsArr);
+
+	useLayoutEffect(() => {
+		itemsArr = [];
+		for (let i = 0; i < dataSize; i++) {
+			itemsArr.push(populateItems({index: i}));
+		}
+		setItems(itemsArr);
+	}, [dataSize]);
+
+	const handleComplete = useCallback((ev) => {
+		const {orders} = ev;
+		console.log("@@@@ ", orders);
+		// change data from the new orders
+		console.log("old items", items);
+		const newItems = [];
+		orders.forEach(order => {newItems.push(items[order - 1]);});
+		console.log(newItems);
+		setItems(newItems);
+	}, [items]);
+
+	return (
+		<Scroller
+			direction="horizontal"
+			editable={{
+				centered: args['editableCentered'],
+				onComplete: handleComplete
+			}}
+			focusableScrollbar={args['focusableScrollbar']}
+			horizontalScrollbar={args['horizontalScrollbar']}
+			hoverToScroll={args['hoverToScroll']}
+			key={args['scrollMode']}
+			noScrollByWheel={args['noScrollByWheel']}
+			onKeyDown={action('onKeyDown')}
+			onScrollStart={action('onScrollStart')}
+			onScrollStop={action('onScrollStop')}
+			scrollMode={args['scrollMode']}
+			spotlightDisabled={args['spotlightDisabled']}
+			verticalScrollbar={args['verticalScrollbar']}
+		>
+			{
+				items.map((item, index) => {
+					return (
+						<ImageItem
+							src={item.src}
+							key={item.index}
+							style={{
+								width: ri.scaleToRem(768),
+								height: ri.scaleToRem(588),
+								order: index + 1
+							}}
+						>
+							{`Image ${item.index}`}
+						</ImageItem>
+					);
+				})
+			}
+		</Scroller>
+	);
+};
+
+boolean('editableCentered', EditableList, Config, true);
+number('editableDataSize', EditableList, Config, 20);
+select('focusableScrollbar', EditableList, prop.focusableScrollbarOption, Config);
+select('horizontalScrollbar', EditableList, prop.scrollbarOption, Config);
+boolean('hoverToScroll', EditableList, Config);
+boolean('noScrollByWheel', EditableList, Config);
+select('scrollMode', EditableList, prop.scrollModeOption, Config);
+boolean('spotlightDisabled', EditableList, Config, false);
+select('verticalScrollbar', EditableList, prop.scrollbarOption, Config);
+
+EditableList.storyName = 'with editable items';
 
 const imageItems = [];
 

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -226,12 +226,13 @@ export const EditableList = (args) => {
 
 	const handleComplete = useCallback((ev) => {
 		const {orders} = ev;
-		console.log("@@@@ ", orders);
 		// change data from the new orders
-		console.log("old items", items);
 		const newItems = [];
-		orders.forEach(order => {newItems.push(items[order - 1]);});
-		console.log(newItems);
+
+		orders.forEach(order => {
+			newItems.push(items[order - 1]);
+		});
+
 		setItems(newItems);
 	}, [items]);
 

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -296,6 +296,7 @@ const useScroll = (props) => {
 			'data-spotlight-container': spotlightContainer,
 			'data-spotlight-container-disabled': spotlightContainerDisabled,
 			'data-spotlight-id': spotlightId,
+			editable,
 			focusableScrollbar,
 			fadeOut,
 			horizontalScrollThumbAriaLabel,
@@ -454,7 +455,7 @@ const useScroll = (props) => {
 	});
 
 	assignProperties('scrollContentProps', {
-		...(props.itemRenderer ? {itemRefs, noAffordance, snapToCenter} : {fadeOut}),
+		...(props.itemRenderer ? {itemRefs, noAffordance, snapToCenter} : {editable, fadeOut}),
 		className: [
 			(props.direction === 'both' || props.direction === 'vertical') ? overscrollCss.vertical : overscrollCss.horizontal,
 			css.scrollContent


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added `editable` prop to Scroller to support editing items

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To support editing, added a flex wrapper and used flex `order` to order items. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-18729

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)