### PR TITLE
WRN-18649: [Drawing POC] - Set/Get preset colors to/from localStorage

### DIFF
--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind, react-hooks/rules-of-hooks */
 
 import kind from '@enact/core/kind';
+import platform from '@enact/core/platform';
 import Spottable from '@enact/spotlight/Spottable';
 import {Cell, Column, Row} from '@enact/ui/Layout';
 import Toggleable from '@enact/ui/Toggleable';
@@ -149,14 +150,21 @@ const ColorPickerBase = kind({
 			const [red, setRed] = useState('');
 			const [green, setGreen] = useState('');
 			const [blue, setBlue] = useState('');
-
+			const [inputColor, setInputColor] = useState('');
+			const presetColorsSet1 = presetColors.slice(0, 4);
+			const presetColorsSet2 = presetColors.slice(4, 9);
 			useEffect(() => {
 				let {r, g, b} = hexToRgb(color);
 
+				setInputColor(color);
 				setRed(r);
 				setGreen(g);
 				setBlue(b);
 			}, [color]);
+
+			const onInputBlur = () => {
+				colorHandler(inputColor);
+			};
 
 			const onSliderBlur = () => {
 				colorHandler(rgbToHex(red, green, blue));
@@ -165,7 +173,7 @@ const ColorPickerBase = kind({
 			return (
 				<Cell className={css.colorPicker}>
 					<Row>
-						{presetColors?.map((presetColor) => (
+						{presetColorsSet1?.map((presetColor) => (
 							<SpottableButton
 								className={css.coloredButton}
 								key={presetColor}
@@ -179,36 +187,73 @@ const ColorPickerBase = kind({
 							/>
 						))}
 					</Row>
-					<Column className={css.colorPickerSliders}>
-						<Slider
-							className={componentCss.colorSlider}
-							max={255}
-							min={0}
-							onBlur={onSliderBlur}
-							onChange={(ev) => setRed(ev.value)}
-							value={red}
-						/>
-						<BodyText css={css}>{red} Red</BodyText>
-						<Slider
-							className={componentCss.colorSlider}
-							max={255}
-							min={0}
-							onBlur={onSliderBlur}
-							onChange={(ev) => setGreen(ev.value)}
-							value={green}
-						/>
-						<BodyText css={css}>{green} Green</BodyText>
-						<Slider
-							className={componentCss.colorSlider}
-							max={255}
-							min={0}
-							onBlur={onSliderBlur}
-							onChange={(ev) => setBlue(ev.value)}
-							value={blue}
-						/>
-						<BodyText css={css}>{blue} Blue</BodyText>
-					</Column>
-					<div className={componentCss.coloredDiv} style={{backgroundColor: `rgb(${red} ,${green}, ${blue})`}} />
+					<Row>
+						{presetColorsSet2?.map((presetColor) => (
+							<SpottableButton
+								className={css.coloredButton}
+								key={presetColor}
+								minWidth={false}
+								onClick={() => {
+									colorHandler(presetColor);
+									onTogglePopup();
+								}}
+								style={{backgroundColor: presetColor}}
+								type="color"
+							/>
+						))}
+					</Row>
+					{platform.webos !== undefined ?	// eslint-disable-line no-undefined
+						<div>
+							<Column className={css.colorPickerSliders}>
+								<Slider
+									className={componentCss.colorSlider}
+									max={255}
+									min={0}
+									onBlur={onSliderBlur}
+									onChange={(ev) => setRed(ev.value)}
+									value={red}
+								/>
+								<BodyText css={css}>{red} Red</BodyText>
+								<Slider
+									className={componentCss.colorSlider}
+									max={255}
+									min={0}
+									onBlur={onSliderBlur}
+									onChange={(ev) => setGreen(ev.value)}
+									value={green}
+								/>
+								<BodyText css={css}>{green} Green</BodyText>
+								<Slider
+									className={componentCss.colorSlider}
+									max={255}
+									min={0}
+									onBlur={onSliderBlur}
+									onChange={(ev) => setBlue(ev.value)}
+									value={blue}
+								/>
+								<BodyText css={css}>{blue} Blue</BodyText>
+							</Column>
+							<div className={componentCss.coloredDiv} style={{backgroundColor: `rgb(${red} ,${green}, ${blue})`}} />
+						</div> :
+						<SpottableButton
+							className={componentCss.coloredDiv}
+							css={css}
+							minWidth={false}
+							onClick={() => document.getElementById('inputColorPicker').click()}
+							style={{backgroundColor: `${inputColor}`}}
+						>
+							<Cell>
+								<input
+									className={componentCss.coloredInput}
+									id="inputColorPicker"
+									onBlur={onInputBlur}
+									onChange={(ev) => setInputColor(ev.target.value)}
+									type="color"
+									value={inputColor}
+								/>
+							</Cell>
+						</SpottableButton>
+					}
 				</Cell>
 			);
 		}

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -188,7 +188,7 @@ const ColorPickerBase = kind({
 				<Cell className={css.colorPicker}>
 					<Row className={css.colorsRow} wrap>
 						{presetColors?.map((presetColor, presetColorIndex) => (
-							<Cell key={`${presetColor}-${presetColorIndex}`} size="25%">
+							<Cell key={presetColor + '-' + presetColorIndex} size="25%">
 								<SpottableButton
 									className={css.coloredButton}
 									minWidth={false}

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -192,7 +192,7 @@ const ColorPickerBase = kind({
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [red, green, blue]);
 
-			const onSliderBlur = () => {
+			const onSliderValueChange = () => {
 				colorHandler(rgbToHex(red, green, blue), index);
 			};
 
@@ -220,7 +220,8 @@ const ColorPickerBase = kind({
 									className={componentCss.colorSlider}
 									max={255}
 									min={0}
-									onBlur={onSliderBlur}
+									onBlur={onSliderValueChange}
+									onClick={onSliderValueChange}
 									onChange={(ev) => setRed(ev.value)}
 									value={red}
 								/>
@@ -229,7 +230,8 @@ const ColorPickerBase = kind({
 									className={componentCss.colorSlider}
 									max={255}
 									min={0}
-									onBlur={onSliderBlur}
+									onBlur={onSliderValueChange}
+									onClick={onSliderValueChange}
 									onChange={(ev) => setGreen(ev.value)}
 									value={green}
 								/>
@@ -238,7 +240,8 @@ const ColorPickerBase = kind({
 									className={componentCss.colorSlider}
 									max={255}
 									min={0}
-									onBlur={onSliderBlur}
+									onBlur={onSliderValueChange}
+									onClick={onSliderValueChange}
 									onChange={(ev) => setBlue(ev.value)}
 									value={blue}
 								/>

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -189,7 +189,7 @@ const ColorPickerBase = kind({
 				}
 
 				window.localStorage.setItem(`${text}Colors`, JSON.stringify(colors));
-			}, [red, green, blue])
+			}, [red, green, blue, index, text]);
 
 			const onSliderBlur = () => {
 				colorHandler(rgbToHex(red, green, blue), index);

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -154,12 +154,15 @@ const ColorPickerBase = kind({
 	},
 
 	computed: {
-		renderComponent: ({color, colorHandler, css, index, text}) => {
+		renderComponent: ({color, colorHandler, css, index, presetColors, text}) => {
 			const [red, setRed] = useState('');
 			const [green, setGreen] = useState('');
 			const [blue, setBlue] = useState('');
 			const [inputColor, setInputColor] = useState('');
-			const presetColors = JSON.parse(window.localStorage.getItem(`${text}Colors`));
+
+			if (typeof window !== 'undefined' && window.localStorage) {
+				presetColors = JSON.parse(window.localStorage.getItem(`${text}Colors`));
+			}
 
 			function setInputColorToStorage (selectedColor) {
 				setInputColor(selectedColor);
@@ -179,6 +182,10 @@ const ColorPickerBase = kind({
 				setGreen(g);
 				setBlue(b);
 			}, [color]);
+
+			const onInputBlur = () => {
+				colorHandler(inputColor);
+			};
 
 			const onSliderBlur = () => {
 				colorHandler(rgbToHex(red, green, blue));
@@ -245,6 +252,7 @@ const ColorPickerBase = kind({
 								<input
 									className={componentCss.coloredInput}
 									id="inputColorPicker"
+									onBlur={onInputBlur}
 									onChange={(ev) => setInputColorToStorage(ev.target.value)}
 									type="color"
 									value={inputColor}

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -154,22 +154,19 @@ const ColorPickerBase = kind({
 	},
 
 	computed: {
-		renderComponent: ({color, colorHandler, css, index, presetColors, text}) => {
+		renderComponent: ({color, colorHandler, css, index, text}) => {
 			const [red, setRed] = useState('');
 			const [green, setGreen] = useState('');
 			const [blue, setBlue] = useState('');
 			const [inputColor, setInputColor] = useState('');
-
-			if (typeof window !== 'undefined' && window.localStorage) {
-				presetColors = JSON.parse(window.localStorage.getItem(`${text}Colors`));
-			}
+			const presetColors = JSON.parse(window.localStorage.getItem(`${text}Colors`));
 
 			function setInputColorToStorage (selectedColor) {
 				setInputColor(selectedColor);
 				colorHandler(selectedColor, index);
 
 				let colors = JSON.parse(window.localStorage.getItem(`${text}Colors`));
-				colors[index] = color;
+				colors[index] = selectedColor;
 
 				window.localStorage.setItem(`${text}Colors`, JSON.stringify(colors));
 			}
@@ -182,10 +179,6 @@ const ColorPickerBase = kind({
 				setGreen(g);
 				setBlue(b);
 			}, [color]);
-
-			const onInputBlur = () => {
-				colorHandler(inputColor);
-			};
 
 			const onSliderBlur = () => {
 				colorHandler(rgbToHex(red, green, blue));
@@ -252,7 +245,6 @@ const ColorPickerBase = kind({
 								<input
 									className={componentCss.coloredInput}
 									id="inputColorPicker"
-									onBlur={onInputBlur}
 									onChange={(ev) => setInputColorToStorage(ev.target.value)}
 									type="color"
 									value={inputColor}

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -180,8 +180,19 @@ const ColorPickerBase = kind({
 				setBlue(b);
 			}, [color]);
 
+			useEffect(() => {
+				const hexColor = rgbToHex(red, green, blue);
+				let colors = JSON.parse(window.localStorage.getItem(`${text}Colors`));
+
+				if (colors) {
+					colors[index] = hexColor;
+				}
+
+				window.localStorage.setItem(`${text}Colors`, JSON.stringify(colors));
+			}, [red, green, blue])
+
 			const onSliderBlur = () => {
-				colorHandler(rgbToHex(red, green, blue));
+				colorHandler(rgbToHex(red, green, blue), index);
 			};
 
 			return (

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -188,7 +188,7 @@ const ColorPickerBase = kind({
 				<Cell className={css.colorPicker}>
 					<Row className={css.colorsRow} wrap>
 						{presetColors?.map((presetColor, presetColorIndex) => (
-							<Cell key={presetColor} size="25%">
+							<Cell key={`${presetColor}-${presetColorIndex}`} size="25%">
 								<SpottableButton
 									className={css.coloredButton}
 									minWidth={false}

--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -189,7 +189,8 @@ const ColorPickerBase = kind({
 				}
 
 				window.localStorage.setItem(`${text}Colors`, JSON.stringify(colors));
-			}, [red, green, blue, index, text]);
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+			}, [red, green, blue]);
 
 			const onSliderBlur = () => {
 				colorHandler(rgbToHex(red, green, blue), index);

--- a/Drawing/ColorPicker.module.less
+++ b/Drawing/ColorPicker.module.less
@@ -10,6 +10,11 @@
 		font-size: 24px;
 		margin: 0;
 		padding-left: 21px;
+		text-transform: capitalize;
+	}
+
+	.colorsRow {
+		width: 522px;
 	}
 
 	.coloredButton {
@@ -70,6 +75,7 @@
 
 	.popupHeader {
 		margin-bottom: 21px;
+		text-transform: capitalize;
 	}
 
 	.body {

--- a/Drawing/ColorPicker.module.less
+++ b/Drawing/ColorPicker.module.less
@@ -31,9 +31,29 @@
 }
 
 .coloredDiv {
+	display: block;
+	height: 81px;
+	border: 3px solid white;
 	border-radius: 24px;
+
+	&.button, &.focusExpand {
+		margin: 24px;
+	}
+
+	.focus({
+		transform: scale(1.05);
+	});
+}
+
+.coloredInput {
+	border-radius: 24px;
+	opacity: 0;
 	height: 81px;
 	margin: 24px;
+
+	&:hover {
+		cursor: pointer;
+	}
 }
 
 .colorPickerSliders {

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -174,10 +174,11 @@ const DrawingBase = kind({
 				window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
 			}
 
-			setBrushColor(lastBrushColor);
-			setCanvasColor(lastCanvasColor);
-			setFillColor(lastFillColor);
-
+			if (lastBrushColor && lastFillColor && lastCanvasColor) {
+				setBrushColor(lastBrushColor);
+				setCanvasColor(lastCanvasColor);
+				setFillColor(lastFillColor);
+			}
 		}, [brushColor, canvasColor, fillColor]);
 
 		function setBrushColorAndIndex (color, index) {

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -263,10 +263,6 @@ const DrawingBase = kind({
 		}, [drawingTool]);
 
 		useEffect(() => {
-			setBrushColorValue(brushColor);
-		}, [brushColor]);
-
-		useEffect(() => {
 			setFillColorValue(fillColor);
 		}, [fillColor]);
 
@@ -348,13 +344,10 @@ const DrawingBase = kind({
 								disabled={disabled}
 								fillColor={fillColorValue}
 								fillColorIndex={fillColorIndex}
-								setBrushColor={setBrushColorValue}
 								setBrushColorAndIndex={setBrushColorAndIndex}
 								setBrushSize={setBrushSizeValue}
-								setCanvasColor={setCanvasColorValue}
 								setCanvasColorAndIndex={setCanvasColorAndIndex}
 								setDrawingTool={setDrawingToolValue}
-								setFillColor={setFillColorValue}
 								setFillColorAndIndex={setFillColorAndIndex}
 							/>
 						) :

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -1,4 +1,4 @@
-/* eslint-disable react-hooks/rules-of-hooks */
+/* eslint-disable react-hooks/rules-of-hooks, react/jsx-no-bind */
 
 /**
  * Sandstone styled drawing components and behaviors.
@@ -340,16 +340,22 @@ const DrawingBase = kind({
 						{showDrawingControls ? (
 							<ComponentOverride
 								brushColor={brushColorValue}
+								brushColorIndex={brushColorIndex}
 								brushSize={brushSizeValue}
 								canvasColor={canvasColorValue}
+								canvasColorIndex={canvasColorIndex}
 								component={drawingControlsComponent}
 								disabled={disabled}
 								fillColor={fillColorValue}
+								fillColorIndex={fillColorIndex}
 								setBrushColor={setBrushColorValue}
+								setBrushColorAndIndex={setBrushColorAndIndex}
 								setBrushSize={setBrushSizeValue}
 								setCanvasColor={setCanvasColorValue}
+								setCanvasColorAndIndex={setCanvasColorAndIndex}
 								setDrawingTool={setDrawingToolValue}
 								setFillColor={setFillColorValue}
+								setFillColorAndIndex={setFillColorAndIndex}
 							/>
 						) :
 							null

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -129,8 +129,8 @@ const DrawingBase = kind({
 		const [fillColor, setFillColor] = useState('#D0BB22');
 		const drawingRef = useRef();
 
-		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
-		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
+		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 		const drawingTools = [
 			{icon: 'edit', key: 1, tooltipText: 'brush'},
 			{icon: 'heart', key: 2, tooltipText: 'fill'},
@@ -139,7 +139,7 @@ const DrawingBase = kind({
 			{icon: 'newfeature', key: 5, tooltipText: 'circle'},
 			{icon: 'square', key: 6, tooltipText: 'erase'}
 		];
-		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
+		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 
 		return (
 			<Scroller>

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -255,6 +255,11 @@ const DrawingBase = kind({
 		const drawingRef = useRef();
 
 		useEffect(() => {
+			setBrushColorValue(brushColor);
+			window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
+		}, [brushColor]);
+
+		useEffect(() => {
 			setBrushSizeValue(brushSize);
 		}, [brushSize]);
 
@@ -264,10 +269,12 @@ const DrawingBase = kind({
 
 		useEffect(() => {
 			setFillColorValue(fillColor);
+			window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
 		}, [fillColor]);
 
 		useEffect(() => {
 			setCanvasColorValue(canvasColor);
+			window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
 		}, [canvasColor]);
 
 		useEffect(() => {

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -132,46 +132,8 @@ const DrawingBase = kind({
 		const [fillColorIndex, setFillColorIndex] = useState(null);
 		const drawingRef = useRef();
 
-		useEffect(() => {
-			const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));
-			const storedCanvasColors = JSON.parse(window.localStorage.getItem('canvasColors'));
-			const storedFillColors = JSON.parse(window.localStorage.getItem('fillColors'));
-			const defaultColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
-
-			if (!storedBrushColors) {
-				window.localStorage.setItem('brushColors', JSON.stringify(defaultColors));
-			}
-			if (!storedCanvasColors) {
-				window.localStorage.setItem('canvasColors', JSON.stringify(defaultColors));
-			}
-			if (!storedFillColors) {
-				window.localStorage.setItem('fillColors', JSON.stringify(defaultColors));
-			}
-		}, []);
-
-		useEffect(() => {
-			const lastBrushColor = JSON.parse(window.localStorage.getItem('lastBrushColor'));
-			const lastCanvasColor = JSON.parse(window.localStorage.getItem('lastCanvasColor'));
-			const lastFillColor = JSON.parse(window.localStorage.getItem('lastFillColor'));
-
-			if (!lastBrushColor) {
-				window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
-			}
-
-			if (!lastCanvasColor) {
-				window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
-			}
-
-			if (!lastFillColor) {
-				window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
-			}
-			
-			setBrushColor(lastBrushColor);
-			setCanvasColor(lastCanvasColor);
-			setFillColor(lastFillColor);
-
-		}, [brushColor, canvasColor, fillColor]);
-		
+		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 		const drawingTools = [
 			{icon: 'edit', key: 1, tooltipText: 'brush'},
 			{icon: 'heart', key: 2, tooltipText: 'fill'},
@@ -180,23 +142,73 @@ const DrawingBase = kind({
 			{icon: 'newfeature', key: 5, tooltipText: 'circle'},
 			{icon: 'square', key: 6, tooltipText: 'erase'}
 		];
+		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+
+		useEffect(() => {
+			if (typeof window !== 'undefined' && window.localStorage) {
+				const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));
+				const storedCanvasColors = JSON.parse(window.localStorage.getItem('canvasColors'));
+				const storedFillColors = JSON.parse(window.localStorage.getItem('fillColors'));
+				const defaultColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+
+				if (!storedBrushColors) {
+					window.localStorage.setItem('brushColors', JSON.stringify(defaultColors));
+				}
+				if (!storedCanvasColors) {
+					window.localStorage.setItem('canvasColors', JSON.stringify(defaultColors));
+				}
+				if (!storedFillColors) {
+					window.localStorage.setItem('fillColors', JSON.stringify(defaultColors));
+				}
+			}
+		}, []);
+
+		useEffect(() => {
+			if (typeof window !== 'undefined' && window.localStorage) {
+				const lastBrushColor = JSON.parse(window.localStorage.getItem('lastBrushColor'));
+				const lastCanvasColor = JSON.parse(window.localStorage.getItem('lastCanvasColor'));
+				const lastFillColor = JSON.parse(window.localStorage.getItem('lastFillColor'));
+
+				if (!lastBrushColor) {
+					window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
+				}
+
+				if (!lastCanvasColor) {
+					window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
+				}
+
+				if (!lastFillColor) {
+					window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
+				}
+
+				setBrushColor(lastBrushColor);
+				setCanvasColor(lastCanvasColor);
+				setFillColor(lastFillColor);
+			}
+		}, [brushColor, canvasColor, fillColor]);
 
 		function setBrushColorAndIndex (color, index) {
 			setBrushColor(color);
 			setBrushColorIndex(index);
-			window.localStorage.setItem('lastBrushColor', JSON.stringify(color));
+			if (typeof window !== 'undefined' && window.localStorage) {
+				window.localStorage.setItem('lastBrushColor', JSON.stringify(color));
+			}
 		}
 
 		function setCanvasColorAndIndex (color, index) {
 			setCanvasColor(color);
 			setCanvasColorIndex(index);
-			window.localStorage.setItem('lastCanvasColor', JSON.stringify(color));
+			if (typeof window !== 'undefined' && window.localStorage) {
+				window.localStorage.setItem('lastCanvasColor', JSON.stringify(color));
+			}
 		}
 
 		function setFillColorAndIndex (color, index) {
 			setFillColor(color);
 			setFillColorIndex(index);
-			window.localStorage.setItem('lastFillColor', JSON.stringify(color));
+			if (typeof window !== 'undefined' && window.localStorage) {
+				window.localStorage.setItem('lastFillColor', JSON.stringify(color));
+			}
 		}
 
 		return (
@@ -244,6 +256,7 @@ const DrawingBase = kind({
 								colorHandler={setBrushColorAndIndex}
 								disabled={disabled}
 								index={brushColorIndex}
+								presetColors={brushColors}
 								text="brush"
 							/>
 							<ColorPicker
@@ -251,6 +264,7 @@ const DrawingBase = kind({
 								colorHandler={setFillColorAndIndex}
 								disabled={disabled}
 								index={fillColorIndex}
+								presetColors={fillColors}
 								text="fill"
 							/>
 							<ColorPicker
@@ -258,6 +272,7 @@ const DrawingBase = kind({
 								colorHandler={setCanvasColorAndIndex}
 								disabled={disabled}
 								index={canvasColorIndex}
+								presetColors={canvasColors}
 								text="canvas"
 							/>
 						</Cell>

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -18,7 +18,7 @@ import Group from '@enact/ui/Group';
 import {Cell, Column, Layout, Row} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import BodyText from '../BodyText';
 import Button from '../Button';
@@ -123,14 +123,32 @@ const DrawingBase = kind({
 	render: ({canvasHeight, canvasWidth, disabled, fileInputHandler, handleSelect, ...rest}) => {
 		const [backgroundImage, setBackgroundImage] = useState(null);
 		const [brushColor, setBrushColor] = useState('#545BCC');
+		const [brushColorIndex, setBrushColorIndex] = useState(null);
 		const [brushSize, setBrushSize] = useState(5);
 		const [canvasColor, setCanvasColor] = useState('#FFFFFF');
+		const [canvasColorIndex, setCanvasColorIndex] = useState(null);
 		const [drawingTool, setDrawingTool] = useState('brush');
 		const [fillColor, setFillColor] = useState('#D0BB22');
+		const [fillColorIndex, setFillColorIndex] = useState(null);
 		const drawingRef = useRef();
 
-		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
-		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+		useEffect(() => {
+			const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));
+			const storedCanvasColors = JSON.parse(window.localStorage.getItem('canvasColors'));
+			const storedFillColors = JSON.parse(window.localStorage.getItem('fillColors'));
+			const defaultColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+
+			if (!storedBrushColors) {
+				window.localStorage.setItem('brushColors', JSON.stringify(defaultColors));
+			}
+			if (!storedCanvasColors) {
+				window.localStorage.setItem('canvasColors', JSON.stringify(defaultColors));
+			}
+			if (!storedFillColors) {
+				window.localStorage.setItem('fillColors', JSON.stringify(defaultColors));
+			}
+		}, []);
+
 		const drawingTools = [
 			{icon: 'edit', key: 1, tooltipText: 'brush'},
 			{icon: 'heart', key: 2, tooltipText: 'fill'},
@@ -139,7 +157,21 @@ const DrawingBase = kind({
 			{icon: 'newfeature', key: 5, tooltipText: 'circle'},
 			{icon: 'square', key: 6, tooltipText: 'erase'}
 		];
-		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+
+		function setBrushColorAndIndex (color, index) {
+			setBrushColor(color);
+			setBrushColorIndex(index);
+		}
+
+		function setCanvasColorAndIndex (color, index) {
+			setCanvasColor(color);
+			setCanvasColorIndex(index);
+		}
+
+		function setFillColorAndIndex (color, index) {
+			setFillColor(color);
+			setFillColorIndex(index);
+		}
 
 		return (
 			<Scroller>
@@ -183,24 +215,24 @@ const DrawingBase = kind({
 							<BodyText css={css} disabled={disabled}>Colors</BodyText>
 							<ColorPicker
 								color={brushColor}
-								colorHandler={setBrushColor}
+								colorHandler={setBrushColorAndIndex}
 								disabled={disabled}
-								presetColors={brushColors}
-								text="Brush"
+								index={brushColorIndex}
+								text="brush"
 							/>
 							<ColorPicker
 								color={fillColor}
-								colorHandler={setFillColor}
+								colorHandler={setFillColorAndIndex}
 								disabled={disabled}
-								presetColors={fillColors}
-								text="Fill"
+								index={fillColorIndex}
+								text="fill"
 							/>
 							<ColorPicker
 								color={canvasColor}
-								colorHandler={setCanvasColor}
+								colorHandler={setCanvasColorAndIndex}
 								disabled={disabled}
-								presetColors={canvasColors}
-								text="Canvas"
+								index={canvasColorIndex}
+								text="canvas"
 							/>
 						</Cell>
 					</Cell>

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -149,6 +149,29 @@ const DrawingBase = kind({
 			}
 		}, []);
 
+		useEffect(() => {
+			const lastBrushColor = JSON.parse(window.localStorage.getItem('lastBrushColor'));
+			const lastCanvasColor = JSON.parse(window.localStorage.getItem('lastCanvasColor'));
+			const lastFillColor = JSON.parse(window.localStorage.getItem('lastFillColor'));
+
+			if (!lastBrushColor) {
+				window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
+			}
+
+			if (!lastCanvasColor) {
+				window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
+			}
+
+			if (!lastFillColor) {
+				window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
+			}
+			
+			setBrushColor(lastBrushColor);
+			setCanvasColor(lastCanvasColor);
+			setFillColor(lastFillColor);
+
+		}, [brushColor, canvasColor, fillColor]);
+		
 		const drawingTools = [
 			{icon: 'edit', key: 1, tooltipText: 'brush'},
 			{icon: 'heart', key: 2, tooltipText: 'fill'},
@@ -161,16 +184,19 @@ const DrawingBase = kind({
 		function setBrushColorAndIndex (color, index) {
 			setBrushColor(color);
 			setBrushColorIndex(index);
+			window.localStorage.setItem('lastBrushColor', JSON.stringify(color));
 		}
 
 		function setCanvasColorAndIndex (color, index) {
 			setCanvasColor(color);
 			setCanvasColorIndex(index);
+			window.localStorage.setItem('lastCanvasColor', JSON.stringify(color));
 		}
 
 		function setFillColorAndIndex (color, index) {
 			setFillColor(color);
 			setFillColorIndex(index);
+			window.localStorage.setItem('lastFillColor', JSON.stringify(color));
 		}
 
 		return (

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -131,9 +131,6 @@ const DrawingBase = kind({
 		const [fillColor, setFillColor] = useState('#D0BB22');
 		const [fillColorIndex, setFillColorIndex] = useState(null);
 		const drawingRef = useRef();
-
-		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
-		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 		const drawingTools = [
 			{icon: 'edit', key: 1, tooltipText: 'brush'},
 			{icon: 'heart', key: 2, tooltipText: 'fill'},
@@ -142,73 +139,63 @@ const DrawingBase = kind({
 			{icon: 'newfeature', key: 5, tooltipText: 'circle'},
 			{icon: 'square', key: 6, tooltipText: 'erase'}
 		];
-		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 
 		useEffect(() => {
-			if (typeof window !== 'undefined' && window.localStorage) {
-				const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));
-				const storedCanvasColors = JSON.parse(window.localStorage.getItem('canvasColors'));
-				const storedFillColors = JSON.parse(window.localStorage.getItem('fillColors'));
-				const defaultColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
+			const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));
+			const storedCanvasColors = JSON.parse(window.localStorage.getItem('canvasColors'));
+			const storedFillColors = JSON.parse(window.localStorage.getItem('fillColors'));
+			const defaultColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 
-				if (!storedBrushColors) {
-					window.localStorage.setItem('brushColors', JSON.stringify(defaultColors));
-				}
-				if (!storedCanvasColors) {
-					window.localStorage.setItem('canvasColors', JSON.stringify(defaultColors));
-				}
-				if (!storedFillColors) {
-					window.localStorage.setItem('fillColors', JSON.stringify(defaultColors));
-				}
+			if (!storedBrushColors) {
+				window.localStorage.setItem('brushColors', JSON.stringify(defaultColors));
+			}
+			if (!storedCanvasColors) {
+				window.localStorage.setItem('canvasColors', JSON.stringify(defaultColors));
+			}
+			if (!storedFillColors) {
+				window.localStorage.setItem('fillColors', JSON.stringify(defaultColors));
 			}
 		}, []);
 
 		useEffect(() => {
-			if (typeof window !== 'undefined' && window.localStorage) {
-				const lastBrushColor = JSON.parse(window.localStorage.getItem('lastBrushColor'));
-				const lastCanvasColor = JSON.parse(window.localStorage.getItem('lastCanvasColor'));
-				const lastFillColor = JSON.parse(window.localStorage.getItem('lastFillColor'));
+			const lastBrushColor = JSON.parse(window.localStorage.getItem('lastBrushColor'));
+			const lastCanvasColor = JSON.parse(window.localStorage.getItem('lastCanvasColor'));
+			const lastFillColor = JSON.parse(window.localStorage.getItem('lastFillColor'));
 
-				if (!lastBrushColor) {
-					window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
-				}
-
-				if (!lastCanvasColor) {
-					window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
-				}
-
-				if (!lastFillColor) {
-					window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
-				}
-
-				setBrushColor(lastBrushColor);
-				setCanvasColor(lastCanvasColor);
-				setFillColor(lastFillColor);
+			if (!lastBrushColor) {
+				window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
 			}
+
+			if (!lastCanvasColor) {
+				window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
+			}
+
+			if (!lastFillColor) {
+				window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
+			}
+
+			setBrushColor(lastBrushColor);
+			setCanvasColor(lastCanvasColor);
+			setFillColor(lastFillColor);
+
 		}, [brushColor, canvasColor, fillColor]);
 
 		function setBrushColorAndIndex (color, index) {
 			setBrushColor(color);
 			setBrushColorIndex(index);
-			if (typeof window !== 'undefined' && window.localStorage) {
-				window.localStorage.setItem('lastBrushColor', JSON.stringify(color));
-			}
+			window.localStorage.setItem('lastBrushColor', JSON.stringify(color));
 		}
 
 		function setCanvasColorAndIndex (color, index) {
 			setCanvasColor(color);
 			setCanvasColorIndex(index);
-			if (typeof window !== 'undefined' && window.localStorage) {
-				window.localStorage.setItem('lastCanvasColor', JSON.stringify(color));
-			}
+			window.localStorage.setItem('lastCanvasColor', JSON.stringify(color));
 		}
 
 		function setFillColorAndIndex (color, index) {
 			setFillColor(color);
 			setFillColorIndex(index);
-			if (typeof window !== 'undefined' && window.localStorage) {
-				window.localStorage.setItem('lastFillColor', JSON.stringify(color));
-			}
+			window.localStorage.setItem('lastFillColor', JSON.stringify(color));
 		}
 
 		return (
@@ -256,7 +243,6 @@ const DrawingBase = kind({
 								colorHandler={setBrushColorAndIndex}
 								disabled={disabled}
 								index={brushColorIndex}
-								presetColors={brushColors}
 								text="brush"
 							/>
 							<ColorPicker
@@ -264,7 +250,6 @@ const DrawingBase = kind({
 								colorHandler={setFillColorAndIndex}
 								disabled={disabled}
 								index={fillColorIndex}
-								presetColors={fillColors}
 								text="fill"
 							/>
 							<ColorPicker
@@ -272,7 +257,6 @@ const DrawingBase = kind({
 								colorHandler={setCanvasColorAndIndex}
 								disabled={disabled}
 								index={canvasColorIndex}
-								presetColors={canvasColors}
 								text="canvas"
 							/>
 						</Cell>

--- a/Drawing/DrawingControls.js
+++ b/Drawing/DrawingControls.js
@@ -33,6 +33,13 @@ const DrawingControls = kind({
 		brushColor: PropTypes.string,
 
 		/**
+		 * Current index of brush color from local storage.
+		 *
+		 * @type {Number}
+		 */
+		brushColorIndex: PropTypes.number,
+
+		/**
 		 * Sets the size of brush.
 		 *
 		 * @type {Number}
@@ -45,6 +52,13 @@ const DrawingControls = kind({
 		 * @type {String}
 		 */
 		canvasColor: PropTypes.string,
+
+		/**
+		 * Current index of canvas color from local storage.
+		 *
+		 * @type {Number}
+		 */
+		canvasColorIndex: PropTypes.number,
 
 		/**
 		 * Applies the `disabled` class.
@@ -63,11 +77,18 @@ const DrawingControls = kind({
 		fillColor: PropTypes.string,
 
 		/**
-		 * Called when `brushColor` changes.
+		 * Current index of fill color from local storage.
+		 *
+		 * @type {Number}
+		 */
+		fillColorIndex: PropTypes.number,
+
+		/**
+		 * Called when a new brush color is saved to local storage.
 		 *
 		 * @type {Function}
 		 */
-		setBrushColor: PropTypes.func,
+		setBrushColorAndIndex: PropTypes.func,
 
 		/**
 		 * Called when `brushSize` changes.
@@ -77,11 +98,11 @@ const DrawingControls = kind({
 		setBrushSize: PropTypes.func,
 
 		/**
-		 * Called when `canvasColor` changes.
+		 * Called when a new canvas color is saved to local storage.
 		 *
 		 * @type {Function}
 		 */
-		setCanvasColor: PropTypes.func,
+		setCanvasColorAndIndex: PropTypes.func,
 
 		/**
 		 * Called when `drawingTool` changes.
@@ -91,11 +112,11 @@ const DrawingControls = kind({
 		setDrawingTool: PropTypes.func,
 
 		/**
-		 * Called when `fillColor` changes.
+		 * Called when a new fill color is saved to local storage.
 		 *
 		 * @type {Function}
 		 */
-		setFillColor: PropTypes.func
+		setFillColorAndIndex: PropTypes.func
 	},
 
 	styles: {
@@ -113,21 +134,21 @@ const DrawingControls = kind({
 
 	render: ({
 		brushColor,
+		brushColorIndex,
 		brushSize,
 		canvasColor,
+		canvasColorIndex,
 		disabled,
 		fillColor,
+		fillColorIndex,
 		handleSelect,
-		setBrushColor,
+		setBrushColorAndIndex,
 		setBrushSize,
-		setCanvasColor,
+		setCanvasColorAndIndex,
 		setDrawingTool,
-		setFillColor,
+		setFillColorAndIndex,
 		...rest
 	}) => {
-		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
-		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
-		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#00FFFF', '#FF00FF'];
 		const drawingTools = [
 			{icon: 'edit', key: 1, tooltipText: 'brush'},
 			{icon: 'heart', key: 2, tooltipText: 'fill'},
@@ -177,24 +198,24 @@ const DrawingControls = kind({
 					<BodyText css={css} disabled={disabled}>Colors</BodyText>
 					<ColorPicker
 						color={brushColor}
-						colorHandler={setBrushColor}
+						colorHandler={setBrushColorAndIndex}
 						disabled={disabled}
-						presetColors={brushColors}
-						text="Brush"
+						index={brushColorIndex}
+						text="brush"
 					/>
 					<ColorPicker
 						color={fillColor}
-						colorHandler={setFillColor}
+						colorHandler={setFillColorAndIndex}
 						disabled={disabled}
-						presetColors={fillColors}
-						text="Fill"
+						index={fillColorIndex}
+						text="fill"
 					/>
 					<ColorPicker
 						color={canvasColor}
-						colorHandler={setCanvasColor}
+						colorHandler={setCanvasColorAndIndex}
 						disabled={disabled}
-						presetColors={canvasColors}
-						text="Canvas"
+						index={canvasColorIndex}
+						text="canvas"
 					/>
 				</Cell>
 			</div>

--- a/Drawing/DrawingControls.js
+++ b/Drawing/DrawingControls.js
@@ -116,7 +116,7 @@ const DrawingControls = kind({
 		 *
 		 * @type {Function}
 		 */
-		setFillColorAndIndex: PropTypes.func
+		setFillColorAndIndex: PropTypes.func,
 	},
 
 	styles: {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Implemented functionality to set/get preset colors to/from localStorage.

### Links
[//]: # (Related issues, references)
WRN-18649

### Comments
