### PR TITLE
WRN-19246: WizardPanels: Allow preventDefault on onTransition to prevent spotlight to panel element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Icon` public class name `icon`
 
+### Fixed
+
+- `sandstone/WizardPanels` to allow preventDefault on `onTransition` and `onWillTransition` to prevent focus assignment
+
 ## [2.1.3] - 2022-03-07
 
 - Updated to use `forwardCustom` and add `type` when forwarding custom events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/WizardPanels` to allow preventDefault on `onTransition` and `onWillTransition` to prevent focus assignment
+- `sandstone/WizardPanels` to provide a way to prevent focusing on Panel again by allowing preventDefault when `onTransition` and `onWillTransition`
 
 ## [2.1.3] - 2022-03-07
 

--- a/WizardPanels/useFocusOnTransition.js
+++ b/WizardPanels/useFocusOnTransition.js
@@ -1,11 +1,11 @@
-import handle, {forward} from '@enact/core/handle';
+import handle, {forwardWithPrevent} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import Spotlight from '@enact/spotlight';
 import {useRef} from 'react';
 
 const transitionHandlers = {
 	onTransition: handle(
-		forward('onTransition'),
+		forwardWithPrevent('onTransition'),
 		(ev, {spotlightId}, {current}) => {
 			current.timerId = setTimeout(() => {
 				const currentSpotlight = Spotlight.getCurrent();
@@ -16,7 +16,7 @@ const transitionHandlers = {
 		}
 	),
 	onWillTransition: handle(
-		forward('onWillTransition'),
+		forwardWithPrevent('onWillTransition'),
 		(ev, props, {current}) => {
 			clearTimeout(current.timerId);
 			current.timerId = null;

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -316,7 +316,6 @@ WithPureComponent.parameters = {
 	}
 };
 
-
 class WizardPanelsWithAlert extends Component {
 	constructor () {
 		super();
@@ -353,10 +352,10 @@ class WizardPanelsWithAlert extends Component {
 	);
 }
 
-export const TestApp = () => <WizardPanelsWithAlert />;
+export const _WizardPanelsWithAlert = () => <WizardPanelsWithAlert />;
 
-TestApp.storyName = 'with Alert';
-TestApp.parameters = {
+_WizardPanelsWithAlert.storyName = 'with Alert';
+_WizardPanelsWithAlert.parameters = {
 	props: {
 		noPanel: true
 	}

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -1,6 +1,7 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
+import Alert from '@enact/sandstone/Alert';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Icon from '@enact/sandstone/Icon';
@@ -310,6 +311,54 @@ number('total', WithPureComponent, Config, 0);
 
 WithPureComponent.storyName = 'with pure component';
 WithPureComponent.parameters = {
+	props: {
+		noPanel: true
+	}
+};
+
+
+class WizardPanelsWithAlert extends Component {
+	constructor () {
+		super();
+		this.state = {
+			open: false
+		};
+	}
+
+	handleClose = () => {
+		this.setState({open: false});
+	};
+
+	handleTransition = (e) => {
+		if (e.index === 1) {
+			this.setState({open: true});
+			e.preventDefault();	// Prevent to focus on panel
+		}
+	};
+
+	render = () => (
+		<>
+			<WizardPanels onTransition={this.handleTransition}>
+				<Panel title="title 0">
+					<Button>Button1</Button>
+					<Button>Button2</Button>
+				</Panel>
+				<Panel title="title 1">
+					<Alert open={this.state.open} type="overlay">
+						<Button onClick={this.handleClose}>close</Button>
+					</Alert>
+					<Button>Button3</Button>
+					<Button>Button4</Button>
+				</Panel>
+			</WizardPanels>
+		</>
+	);
+}
+
+export const TestApp = () => <WizardPanelsWithAlert />;
+
+TestApp.storyName = 'with Alert';
+TestApp.parameters = {
 	props: {
 		noPanel: true
 	}

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -337,21 +337,19 @@ class WizardPanelsWithAlert extends Component {
 	};
 
 	render = () => (
-		<>
-			<WizardPanels onTransition={this.handleTransition}>
-				<Panel title="title 0">
-					<Button>Button1</Button>
-					<Button>Button2</Button>
-				</Panel>
-				<Panel title="title 1">
-					<Alert open={this.state.open} type="overlay">
-						<Button onClick={this.handleClose}>close</Button>
-					</Alert>
-					<Button>Button3</Button>
-					<Button>Button4</Button>
-				</Panel>
-			</WizardPanels>
-		</>
+		<WizardPanels onTransition={this.handleTransition}>
+			<Panel title="title 0">
+				<Button>Button1</Button>
+				<Button>Button2</Button>
+			</Panel>
+			<Panel title="title 1">
+				<Alert open={this.state.open} type="overlay">
+					<Button onClick={this.handleClose}>close</Button>
+				</Alert>
+				<Button>Button3</Button>
+				<Button>Button4</Button>
+			</Panel>
+		</WizardPanels>
 	);
 }
 


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If app change focus on onTransition,  WizardPanel re-change the focus to panel element.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Allow preventDefault on onTransition to prevent spotlight to panel element.
So, App should call the ev.preventDefault() to resolve the previous bug.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-19246

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
