### PR TITLE
WRN-19289: Preload Videos: need to change position of 'videoPlayerOpt…

### DIFF
--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -8,8 +8,8 @@ import {Component} from 'react';
 const videoPlayerOption =  [
 	'',
 	'Next Preload Video',
-	'Non Preload Video',
 	'Next Preload Video without changing preload',
+	'Non Preload Video',
 	'Change Preload without changing video',
 	'Reset Sources'
 ];


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to change position 'videoPlayerOption' in the storybook control for Test Case

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- For the test case, the locations of 'Non Preload Video' and 'Next Preload Video without changing preload' have been changed in the storybook control.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]:# (Related issues, references)
WRN-19289
QWT-2335
### Comments
Fix for test QWT-2335.