### PR TITLE
WRN-18652: Make drawing controls optional

### DIFF
--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -16,21 +16,15 @@ import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import ComponentOverride from '@enact/ui/ComponentOverride';
 import {Drawing as UiDrawing} from '@enact/ui/Drawing';
-import Group from '@enact/ui/Group';
 import {Cell, Column, Layout, Row} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {useRef, useState} from 'react';
+import {useRef, useState, useEffect} from 'react';
 
-import BodyText from '../BodyText';
-import Button from '../Button';
 import DrawingControls from './DrawingControls';
 import DrawingUtils from './DrawingUtils';
 import Scroller from '../Scroller';
 import Skinnable from '../Skinnable';
-import Slider from '../Slider';
-
-import ColorPicker from './ColorPicker';
 
 import css from './Drawing.module.less';
 
@@ -84,6 +78,11 @@ const DrawingBase = kind({
 		showDrawingControls: PropTypes.bool,
 		drawingUtilsComponent: EnactPropTypes.componentOverride,
 		showDrawingUtils: PropTypes.bool,
+		brushSize: PropTypes.number,
+		drawingTool: PropTypes.string,
+		brushColor: PropTypes.string,
+		fillColor: PropTypes.string,
+		canvasColor: PropTypes.string
 	},
 
 	defaultProps: {
@@ -94,6 +93,11 @@ const DrawingBase = kind({
 		showDrawingControls: false,
 		drawingUtilsComponent: DrawingUtils,
 		showDrawingUtils: false,
+		brushSize: 5,
+		drawingTool: 'brush',
+		brushColor: '#545BCC',
+		fillColor: '#D0BB22',
+		canvasColor: '#FFFFFF'
 	},
 
 	handlers: {
@@ -113,12 +117,6 @@ const DrawingBase = kind({
 			} catch (err) {
 				// failing silently
 			}
-		},
-
-		handleSelect: (ev) => {
-			const e = ev?.event;
-			const setDrawingTool = ev?.setDrawingTool;
-			setDrawingTool(e.data);
 		}
 	},
 
@@ -133,36 +131,49 @@ const DrawingBase = kind({
 	},
 
 	render: ({
+		brushColor,
+		brushSize,
+		canvasColor,
 		canvasHeight,
 		canvasWidth,
 		disabled,
+		drawingControlsComponent,
+		drawingUtilsComponent,
+		drawingTool,
 		fileInputHandler,
+		fillColor,
 		handleSelect,
 		showDrawingControls,
-		drawingControlsComponent,
 		showDrawingUtils,
-		drawingUtilsComponent,
 		...rest
 	}) => {
 		const [backgroundImage, setBackgroundImage] = useState(null);
-		const [brushColor, setBrushColor] = useState('#545BCC');
-		const [brushSize, setBrushSize] = useState(5);
-		const [canvasColor, setCanvasColor] = useState('#FFFFFF');
-		const [drawingTool, setDrawingTool] = useState('brush');
-		const [fillColor, setFillColor] = useState('#D0BB22');
+		const [brushColorValue, setBrushColorValue] = useState(brushColor);
+		const [brushSizeValue, setBrushSizeValue] = useState(brushSize);
+		const [canvasColorValue, setCanvasColorValue] = useState(canvasColor);
+		const [drawingToolValue, setDrawingToolValue] = useState(drawingTool);
+		const [fillColorValue, setFillColorValue] = useState(fillColor);
 		const drawingRef = useRef();
 
-		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
-		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
-		const drawingTools = [
-			{icon: 'edit', key: 1, tooltipText: 'brush'},
-			{icon: 'heart', key: 2, tooltipText: 'fill'},
-			{icon: 'play', key: 3, tooltipText: 'triangle'},
-			{icon: 'popupscale', key: 4, tooltipText: 'rectangle'},
-			{icon: 'newfeature', key: 5, tooltipText: 'circle'},
-			{icon: 'square', key: 6, tooltipText: 'erase'}
-		];
-		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
+		useEffect(() => {
+			setBrushSizeValue(brushSize);
+		}, [brushSize]);
+
+		useEffect(() => {
+			setDrawingToolValue(drawingTool);
+		}, [drawingTool]);
+
+		useEffect(() => {
+			setBrushColorValue(brushColor);
+		}, [brushColor]);
+
+		useEffect(() => {
+			setFillColorValue(fillColor);
+		}, [fillColor]);
+
+		useEffect(() => {
+			setCanvasColorValue(canvasColor);
+		}, [canvasColor]);
 
 		return (
 			<Scroller>
@@ -172,95 +183,33 @@ const DrawingBase = kind({
 							<ComponentOverride
 								component={drawingControlsComponent}
 								disabled={disabled}
-								brushSize={brushSize}
-								setBrushSize={setBrushSize}
-								setDrawingTool={setDrawingTool}
-								drawingTools={drawingTools}
+								brushSize={brushSizeValue}
+								setBrushSize={setBrushSizeValue}
+								setDrawingTool={setDrawingToolValue}
 								brushColor={brushColor}
-								setBrushColor={setBrushColor}
-								brushColors={brushColors}
+								setBrushColor={setBrushColorValue}
 								fillColor={fillColor}
-								setFillColor={setFillColor}
-								fillColors={fillColors}
+								setFillColor={setFillColorValue}
 								canvasColor={canvasColor}
-								setCanvasColor={setCanvasColor}
-								canvasColors={canvasColors}
-								handleSelect={handleSelect}
+								setCanvasColor={setCanvasColorValue}
 							/>
-						) :
-						null}
-						{/*<Cell>*/}
-						{/*	<BodyText css={css} disabled={disabled}>Drawing tools</BodyText>*/}
-						{/*	<Group*/}
-						{/*		childComponent={Button}*/}
-						{/*		childProp="tooltipText"*/}
-						{/*		className={css.drawingTools}*/}
-						{/*		defaultSelected={0}*/}
-						{/*		itemProps={{*/}
-						{/*			disabled: disabled,*/}
-						{/*			size: 'small'*/}
-						{/*		}}*/}
-						{/*		onSelect={(event) => handleSelect({event, setDrawingTool})}*/}
-						{/*		select={'radio'}*/}
-						{/*		selectedProp="selected"*/}
-						{/*	>*/}
-						{/*		{drawingTools}*/}
-						{/*	</Group>*/}
-						{/*</Cell>*/}
-						{/*<Cell>*/}
-						{/*	<BodyText css={css} disabled={disabled}>Brush size</BodyText>*/}
-						{/*	<Slider*/}
-						{/*		backgroundProgress={0}*/}
-						{/*		css={css}*/}
-						{/*		defaultValue={brushSize}*/}
-						{/*		disabled={disabled}*/}
-						{/*		max={30}*/}
-						{/*		min={0}*/}
-						{/*		onChange={(e) => {*/}
-						{/*			setBrushSize(e.value);*/}
-						{/*		}}*/}
-						{/*		step={1}*/}
-						{/*		tooltip={false}*/}
-						{/*	/>*/}
-						{/*</Cell>*/}
-						{/*<Cell className={css.colors}>*/}
-						{/*	<BodyText css={css} disabled={disabled}>Colors</BodyText>*/}
-						{/*	<ColorPicker*/}
-						{/*		color={brushColor}*/}
-						{/*		colorHandler={setBrushColor}*/}
-						{/*		disabled={disabled}*/}
-						{/*		presetColors={brushColors}*/}
-						{/*		text="Brush"*/}
-						{/*	/>*/}
-						{/*	<ColorPicker*/}
-						{/*		color={fillColor}*/}
-						{/*		colorHandler={setFillColor}*/}
-						{/*		disabled={disabled}*/}
-						{/*		presetColors={fillColors}*/}
-						{/*		text="Fill"*/}
-						{/*	/>*/}
-						{/*	<ColorPicker*/}
-						{/*		color={canvasColor}*/}
-						{/*		colorHandler={setCanvasColor}*/}
-						{/*		disabled={disabled}*/}
-						{/*		presetColors={canvasColors}*/}
-						{/*		text="Canvas"*/}
-						{/*	/>*/}
-						{/*</Cell>*/}
+							) :
+							null
+						}
 					</Cell>
 					<Cell>
 						<Row>
 							<UiDrawing
 								{...rest}
 								backgroundImage={backgroundImage}
-								brushColor={brushColor}
-								brushSize={brushSize}
-								canvasColor={canvasColor}
+								brushColor={brushColorValue}
+								brushSize={brushSizeValue}
+								canvasColor={canvasColorValue}
 								canvasHeight={canvasHeight}
 								canvasWidth={canvasWidth}
 								disabled={disabled}
-								drawingTool={drawingTool}
-								fillColor={fillColor}
+								drawingTool={drawingToolValue}
+								fillColor={fillColorValue}
 								ref={drawingRef}
 							/>
 						</Row>
@@ -278,25 +227,9 @@ const DrawingBase = kind({
 										setBackgroundImage={setBackgroundImage}
 									/>
 								) :
-								null
+									null
 							}
 						</Column>
-						{/*<Column align="center space-between" className={css.canvasOptions}>*/}
-						{/*	<Button css={css} disabled={disabled} icon="refresh" onClick={() => drawingRef.current.clearCanvas()} size="small" tooltipText="Clear all" />*/}
-						{/*	<Button css={css} disabled={disabled} icon="plus" onClick={() => document.getElementById('fileInput').click()} size="small" tooltipText="Import image" />*/}
-						{/*	<input*/}
-						{/*		accept="image/*"*/}
-						{/*		className={css.inputFile}*/}
-						{/*		id="fileInput"*/}
-						{/*		onChange={(ev) => fileInputHandler({backgroundImage, ev, setBackgroundImage})}*/}
-						{/*		onClick={(e) => {*/}
-						{/*			e.target.value = null;*/}
-						{/*		}}*/}
-						{/*		type="file"*/}
-						{/*	/>*/}
-						{/*	<Button css={css} disabled={disabled} icon="trash" onClick={() => setBackgroundImage(null)} size="small" tooltipText="Clear image" />*/}
-						{/*	<Button css={css} disabled={disabled} icon="download" onClick={() => drawingRef.current.saveCanvas()} size="small" tooltipText="Save canvas" />*/}
-						{/*</Column>*/}
 					</Cell>
 				</Layout>
 			</Scroller>

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -25,6 +25,7 @@ import {useRef, useState} from 'react';
 import BodyText from '../BodyText';
 import Button from '../Button';
 import DrawingControls from './DrawingControls';
+import DrawingUtils from './DrawingUtils';
 import Scroller from '../Scroller';
 import Skinnable from '../Skinnable';
 import Slider from '../Slider';
@@ -81,7 +82,8 @@ const DrawingBase = kind({
 		disabled: PropTypes.bool,
 		drawingControlsComponent: EnactPropTypes.componentOverride,
 		showDrawingControls: PropTypes.bool,
-		brushSize: PropTypes.number
+		drawingUtilsComponent: EnactPropTypes.componentOverride,
+		showDrawingUtils: PropTypes.bool,
 	},
 
 	defaultProps: {
@@ -89,7 +91,9 @@ const DrawingBase = kind({
 		canvasWidth: 1200,
 		disabled: false,
 		drawingControlsComponent: DrawingControls,
-		showDrawingControls: false
+		showDrawingControls: false,
+		drawingUtilsComponent: DrawingUtils,
+		showDrawingUtils: false,
 	},
 
 	handlers: {
@@ -128,7 +132,18 @@ const DrawingBase = kind({
 		publicClassNames: true
 	},
 
-	render: ({canvasHeight, canvasWidth, disabled, fileInputHandler, handleSelect, showDrawingControls, drawingControlsComponent, ...rest}) => {
+	render: ({
+		canvasHeight,
+		canvasWidth,
+		disabled,
+		fileInputHandler,
+		handleSelect,
+		showDrawingControls,
+		drawingControlsComponent,
+		showDrawingUtils,
+		drawingUtilsComponent,
+		...rest
+	}) => {
 		const [backgroundImage, setBackgroundImage] = useState(null);
 		const [brushColor, setBrushColor] = useState('#545BCC');
 		const [brushSize, setBrushSize] = useState(5);
@@ -170,6 +185,7 @@ const DrawingBase = kind({
 								canvasColor={canvasColor}
 								setCanvasColor={setCanvasColor}
 								canvasColors={canvasColors}
+								handleSelect={handleSelect}
 							/>
 						) :
 						null}
@@ -251,21 +267,36 @@ const DrawingBase = kind({
 					</Cell>
 					<Cell shrink size="10%">
 						<Column align="center space-between" className={css.canvasOptions}>
-							<Button css={css} disabled={disabled} icon="refresh" onClick={() => drawingRef.current.clearCanvas()} size="small" tooltipText="Clear all" />
-							<Button css={css} disabled={disabled} icon="plus" onClick={() => document.getElementById('fileInput').click()} size="small" tooltipText="Import image" />
-							<input
-								accept="image/*"
-								className={css.inputFile}
-								id="fileInput"
-								onChange={(ev) => fileInputHandler({backgroundImage, ev, setBackgroundImage})}
-								onClick={(e) => {
-									e.target.value = null;
-								}}
-								type="file"
-							/>
-							<Button css={css} disabled={disabled} icon="trash" onClick={() => setBackgroundImage(null)} size="small" tooltipText="Clear image" />
-							<Button css={css} disabled={disabled} icon="download" onClick={() => drawingRef.current.saveCanvas()} size="small" tooltipText="Save canvas" />
+							{showDrawingUtils ?
+								(
+									<ComponentOverride
+										component={drawingUtilsComponent}
+										disabled={disabled}
+										drawingRef={drawingRef}
+										fileInputHandler={fileInputHandler}
+										backgroundImage={backgroundImage}
+										setBackgroundImage={setBackgroundImage}
+									/>
+								) :
+								null
+							}
 						</Column>
+						{/*<Column align="center space-between" className={css.canvasOptions}>*/}
+						{/*	<Button css={css} disabled={disabled} icon="refresh" onClick={() => drawingRef.current.clearCanvas()} size="small" tooltipText="Clear all" />*/}
+						{/*	<Button css={css} disabled={disabled} icon="plus" onClick={() => document.getElementById('fileInput').click()} size="small" tooltipText="Import image" />*/}
+						{/*	<input*/}
+						{/*		accept="image/*"*/}
+						{/*		className={css.inputFile}*/}
+						{/*		id="fileInput"*/}
+						{/*		onChange={(ev) => fileInputHandler({backgroundImage, ev, setBackgroundImage})}*/}
+						{/*		onClick={(e) => {*/}
+						{/*			e.target.value = null;*/}
+						{/*		}}*/}
+						{/*		type="file"*/}
+						{/*	/>*/}
+						{/*	<Button css={css} disabled={disabled} icon="trash" onClick={() => setBackgroundImage(null)} size="small" tooltipText="Clear image" />*/}
+						{/*	<Button css={css} disabled={disabled} icon="download" onClick={() => drawingRef.current.saveCanvas()} size="small" tooltipText="Save canvas" />*/}
+						{/*</Column>*/}
 					</Cell>
 				</Layout>
 			</Scroller>

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -13,6 +13,8 @@
  */
 
 import kind from '@enact/core/kind';
+import EnactPropTypes from '@enact/core/internal/prop-types';
+import ComponentOverride from '@enact/ui/ComponentOverride';
 import {Drawing as UiDrawing} from '@enact/ui/Drawing';
 import Group from '@enact/ui/Group';
 import {Cell, Column, Layout, Row} from '@enact/ui/Layout';
@@ -22,6 +24,7 @@ import {useRef, useState} from 'react';
 
 import BodyText from '../BodyText';
 import Button from '../Button';
+import DrawingControls from './DrawingControls';
 import Scroller from '../Scroller';
 import Skinnable from '../Skinnable';
 import Slider from '../Slider';
@@ -75,13 +78,18 @@ const DrawingBase = kind({
 		 * @default false
 		 * @public
 		 */
-		disabled: PropTypes.bool
+		disabled: PropTypes.bool,
+		drawingControlsComponent: EnactPropTypes.componentOverride,
+		showDrawingControls: PropTypes.bool,
+		brushSize: PropTypes.number
 	},
 
 	defaultProps: {
 		canvasHeight: 800,
 		canvasWidth: 1200,
-		disabled: false
+		disabled: false,
+		drawingControlsComponent: DrawingControls,
+		showDrawingControls: false
 	},
 
 	handlers: {
@@ -120,7 +128,7 @@ const DrawingBase = kind({
 		publicClassNames: true
 	},
 
-	render: ({canvasHeight, canvasWidth, disabled, fileInputHandler, handleSelect, ...rest}) => {
+	render: ({canvasHeight, canvasWidth, disabled, fileInputHandler, handleSelect, showDrawingControls, drawingControlsComponent, ...rest}) => {
 		const [backgroundImage, setBackgroundImage] = useState(null);
 		const [brushColor, setBrushColor] = useState('#545BCC');
 		const [brushSize, setBrushSize] = useState(5);
@@ -145,64 +153,84 @@ const DrawingBase = kind({
 			<Scroller>
 				<Layout {...rest}>
 					<Cell className={css.toolbar} shrink size="15%">
-						<Cell>
-							<BodyText css={css} disabled={disabled}>Drawing tools</BodyText>
-							<Group
-								childComponent={Button}
-								childProp="tooltipText"
-								className={css.drawingTools}
-								defaultSelected={0}
-								itemProps={{
-									disabled: disabled,
-									size: 'small'
-								}}
-								onSelect={(event) => handleSelect({event, setDrawingTool})}
-								select={'radio'}
-								selectedProp="selected"
-							>
-								{drawingTools}
-							</Group>
-						</Cell>
-						<Cell>
-							<BodyText css={css} disabled={disabled}>Brush size</BodyText>
-							<Slider
-								backgroundProgress={0}
-								css={css}
-								defaultValue={brushSize}
+						{showDrawingControls ? (
+							<ComponentOverride
+								component={drawingControlsComponent}
 								disabled={disabled}
-								max={30}
-								min={0}
-								onChange={(e) => {
-									setBrushSize(e.value);
-								}}
-								step={1}
-								tooltip={false}
+								brushSize={brushSize}
+								setBrushSize={setBrushSize}
+								setDrawingTool={setDrawingTool}
+								drawingTools={drawingTools}
+								brushColor={brushColor}
+								setBrushColor={setBrushColor}
+								brushColors={brushColors}
+								fillColor={fillColor}
+								setFillColor={setFillColor}
+								fillColors={fillColors}
+								canvasColor={canvasColor}
+								setCanvasColor={setCanvasColor}
+								canvasColors={canvasColors}
 							/>
-						</Cell>
-						<Cell className={css.colors}>
-							<BodyText css={css} disabled={disabled}>Colors</BodyText>
-							<ColorPicker
-								color={brushColor}
-								colorHandler={setBrushColor}
-								disabled={disabled}
-								presetColors={brushColors}
-								text="Brush"
-							/>
-							<ColorPicker
-								color={fillColor}
-								colorHandler={setFillColor}
-								disabled={disabled}
-								presetColors={fillColors}
-								text="Fill"
-							/>
-							<ColorPicker
-								color={canvasColor}
-								colorHandler={setCanvasColor}
-								disabled={disabled}
-								presetColors={canvasColors}
-								text="Canvas"
-							/>
-						</Cell>
+						) :
+						null}
+						{/*<Cell>*/}
+						{/*	<BodyText css={css} disabled={disabled}>Drawing tools</BodyText>*/}
+						{/*	<Group*/}
+						{/*		childComponent={Button}*/}
+						{/*		childProp="tooltipText"*/}
+						{/*		className={css.drawingTools}*/}
+						{/*		defaultSelected={0}*/}
+						{/*		itemProps={{*/}
+						{/*			disabled: disabled,*/}
+						{/*			size: 'small'*/}
+						{/*		}}*/}
+						{/*		onSelect={(event) => handleSelect({event, setDrawingTool})}*/}
+						{/*		select={'radio'}*/}
+						{/*		selectedProp="selected"*/}
+						{/*	>*/}
+						{/*		{drawingTools}*/}
+						{/*	</Group>*/}
+						{/*</Cell>*/}
+						{/*<Cell>*/}
+						{/*	<BodyText css={css} disabled={disabled}>Brush size</BodyText>*/}
+						{/*	<Slider*/}
+						{/*		backgroundProgress={0}*/}
+						{/*		css={css}*/}
+						{/*		defaultValue={brushSize}*/}
+						{/*		disabled={disabled}*/}
+						{/*		max={30}*/}
+						{/*		min={0}*/}
+						{/*		onChange={(e) => {*/}
+						{/*			setBrushSize(e.value);*/}
+						{/*		}}*/}
+						{/*		step={1}*/}
+						{/*		tooltip={false}*/}
+						{/*	/>*/}
+						{/*</Cell>*/}
+						{/*<Cell className={css.colors}>*/}
+						{/*	<BodyText css={css} disabled={disabled}>Colors</BodyText>*/}
+						{/*	<ColorPicker*/}
+						{/*		color={brushColor}*/}
+						{/*		colorHandler={setBrushColor}*/}
+						{/*		disabled={disabled}*/}
+						{/*		presetColors={brushColors}*/}
+						{/*		text="Brush"*/}
+						{/*	/>*/}
+						{/*	<ColorPicker*/}
+						{/*		color={fillColor}*/}
+						{/*		colorHandler={setFillColor}*/}
+						{/*		disabled={disabled}*/}
+						{/*		presetColors={fillColors}*/}
+						{/*		text="Fill"*/}
+						{/*	/>*/}
+						{/*	<ColorPicker*/}
+						{/*		color={canvasColor}*/}
+						{/*		colorHandler={setCanvasColor}*/}
+						{/*		disabled={disabled}*/}
+						{/*		presetColors={canvasColors}*/}
+						{/*		text="Canvas"*/}
+						{/*	/>*/}
+						{/*</Cell>*/}
 					</Cell>
 					<Cell>
 						<Row>

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -19,7 +19,7 @@ import {Drawing as UiDrawing} from '@enact/ui/Drawing';
 import {Cell, Column, Layout, Row} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {useRef, useState, useEffect} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import DrawingControls from './DrawingControls';
 import DrawingUtils from './DrawingUtils';
@@ -46,6 +46,33 @@ const DrawingBase = kind({
 	functional: true,
 
 	propTypes: /** @lends sandstone/Drawing.DrawingBase.prototype */ {
+		/**
+		 * Sets the color of brush.
+		 *
+		 * @type {String}
+		 * @default #545BCC
+		 * @public
+		 */
+		brushColor: PropTypes.string,
+
+		/**
+		 * Sets the size of brush.
+		 *
+		 * @type {Number}
+		 * @default 5
+		 * @public
+		 */
+		brushSize: PropTypes.number,
+
+		/**
+		 * Sets the color of canvas.
+		 *
+		 * @type {String}
+		 * @default #FFFFFF
+		 * @public
+		 */
+		canvasColor: PropTypes.string,
+
 		/**
 		 * Sets the height of canvas.
 		 *
@@ -74,30 +101,99 @@ const DrawingBase = kind({
 		 * @public
 		 */
 		disabled: PropTypes.bool,
+
+		/**
+		 * Overrides the default Drawing control component to support customized behaviors.
+		 *
+		 * The provided component will receive the following props from `Drawing`:
+		 *
+		 * * `brushColor` - Color used for brush
+		 * * `brushSize` - Value used for brush size
+		 * * `canvasColor` - Color of canvas
+		 * * `disabled` - Disables drawing controls
+		 * * `fillColor` - Color used when `drawingTool=fill`
+		 * * `setBrushColor` - Called when `brushColor` is changed
+		 * * `setBrushSize` - Called when `brushSize` is changed
+		 * * `setDrawingTool` - Called when `drawingTool` is changed
+		 * * `setFillColor` - Called when `fillColor` is changed
+		 *
+		 * @type {Component|Element}
+		 * @default sandstone/Drawing.DrawingControls
+		 * @public
+		 */
 		drawingControlsComponent: EnactPropTypes.componentOverride,
-		showDrawingControls: PropTypes.bool,
-		drawingUtilsComponent: EnactPropTypes.componentOverride,
-		showDrawingUtils: PropTypes.bool,
-		brushSize: PropTypes.number,
+
+		/**
+		 * Sets the tool of drawing.
+		 *
+		 * @type {String}
+		 * @default brush
+		 * @public
+		 */
 		drawingTool: PropTypes.string,
-		brushColor: PropTypes.string,
+
+		/**
+		 * Overrides the default Drawing utils component to support customized behaviors.
+		 *
+		 * The provided component will receive the following props from `Drawing`:
+		 *
+		 * * `backgroundImage` - Sets an image as canvas background
+		 * * `disabled` - Disables drawing utils
+		 * * `drawingRef` - Reference of drawing
+		 * * `fileInputHandler` - Called when user selects an image as canvas background
+		 * * `setBackgroundImage` - Called when the background of canvas is changed
+		 *
+		 * @type {Component|Element}
+		 * @default sandstone/Drawing.DrawingUtils
+		 * @public
+		 */
+		drawingUtilsComponent: EnactPropTypes.componentOverride,
+
+		/**
+		 * Sets the color of fill.
+		 *
+		 * @type {String}
+		 * @default #D0BB22
+		 * @public
+		 */
 		fillColor: PropTypes.string,
-		canvasColor: PropTypes.string
+
+		/**
+		 * Displays the drawing controls.
+		 *
+		 * When `true`, the drawing controls is displayed.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		showDrawingControls: PropTypes.bool,
+
+		/**
+		 * Displays the drawing utils.
+		 *
+		 * When `true`, the drawing utils is displayed.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		showDrawingUtils: PropTypes.bool
 	},
 
 	defaultProps: {
+		brushColor: '#545BCC',
+		brushSize: 5,
+		canvasColor: '#FFFFFF',
 		canvasHeight: 800,
 		canvasWidth: 1200,
 		disabled: false,
 		drawingControlsComponent: DrawingControls,
-		showDrawingControls: false,
-		drawingUtilsComponent: DrawingUtils,
-		showDrawingUtils: false,
-		brushSize: 5,
 		drawingTool: 'brush',
-		brushColor: '#545BCC',
+		drawingUtilsComponent: DrawingUtils,
 		fillColor: '#D0BB22',
-		canvasColor: '#FFFFFF'
+		showDrawingControls: false,
+		showDrawingUtils: false
 	},
 
 	handlers: {
@@ -138,11 +234,10 @@ const DrawingBase = kind({
 		canvasWidth,
 		disabled,
 		drawingControlsComponent,
-		drawingUtilsComponent,
 		drawingTool,
-		fileInputHandler,
+		drawingUtilsComponent,
 		fillColor,
-		handleSelect,
+		fileInputHandler,
 		showDrawingControls,
 		showDrawingUtils,
 		...rest
@@ -181,19 +276,19 @@ const DrawingBase = kind({
 					<Cell className={css.toolbar} shrink size="15%">
 						{showDrawingControls ? (
 							<ComponentOverride
+								brushColor={brushColor}
+								brushSize={brushSizeValue}
+								canvasColor={canvasColor}
 								component={drawingControlsComponent}
 								disabled={disabled}
-								brushSize={brushSizeValue}
-								setBrushSize={setBrushSizeValue}
-								setDrawingTool={setDrawingToolValue}
-								brushColor={brushColor}
-								setBrushColor={setBrushColorValue}
 								fillColor={fillColor}
-								setFillColor={setFillColorValue}
-								canvasColor={canvasColor}
+								setBrushColor={setBrushColorValue}
+								setBrushSize={setBrushSizeValue}
 								setCanvasColor={setCanvasColorValue}
+								setDrawingTool={setDrawingToolValue}
+								setFillColor={setFillColorValue}
 							/>
-							) :
+						) :
 							null
 						}
 					</Cell>
@@ -216,18 +311,17 @@ const DrawingBase = kind({
 					</Cell>
 					<Cell shrink size="10%">
 						<Column align="center space-between" className={css.canvasOptions}>
-							{showDrawingUtils ?
-								(
-									<ComponentOverride
-										component={drawingUtilsComponent}
-										disabled={disabled}
-										drawingRef={drawingRef}
-										fileInputHandler={fileInputHandler}
-										backgroundImage={backgroundImage}
-										setBackgroundImage={setBackgroundImage}
-									/>
-								) :
-									null
+							{showDrawingUtils ? (
+								<ComponentOverride
+									backgroundImage={backgroundImage}
+									component={drawingUtilsComponent}
+									disabled={disabled}
+									drawingRef={drawingRef}
+									fileInputHandler={fileInputHandler}
+									setBackgroundImage={setBackgroundImage}
+								/>
+							) :
+								null
 							}
 						</Column>
 					</Cell>
@@ -255,7 +349,12 @@ const DrawingDecorator = compose(
  *
  * Usage:
  * ```
- * <Drawing />
+ * <Drawing
+ * 	brushColor="#545BCC"
+ * 	brushSize={5}
+ * 	canvasColor="#FFFFFF"
+ * 	drawingTool="brush"
+ * />
  * ```
  *
  * @class Drawing

--- a/Drawing/Drawing.module.less
+++ b/Drawing/Drawing.module.less
@@ -14,37 +14,4 @@
 	.toolbar, .canvasOptions {
 		padding: 24px;
 	}
-
-	.toolbar {
-		.colors {
-			padding: 24px 0;
-		}
-	}
-
-	.bodyText {
-		font-size: 36px;
-		margin: 0;
-	}
-
-	.slider {
-		margin: 0;
-		padding: 24px 0;
-	}
-
-	.drawingTools {
-		margin: 0;
-
-		& > * {
-			font-size: 36px;
-		}
-	}
-
-	.button {
-		min-width: 144px;
-		font-size: 36px;
-	}
-
-	.inputFile {
-		display: none;
-	}
 }

--- a/Drawing/DrawingControls.js
+++ b/Drawing/DrawingControls.js
@@ -12,12 +12,14 @@ import ColorPicker from "./ColorPicker";
 const DrawingControls = kind({
 	name: 'DrawingControls',
 
+	functional: true,
+
 	propTypes: {
 		disabled: PropTypes.bool,
 		brushSize: PropTypes.number,
 		setBrushSize: PropTypes.func,
 		setDrawingTool: PropTypes.func,
-		drawingTools: PropTypes.object,
+		drawingTools: PropTypes.array,
 		brushColor: PropTypes.string,
 		setBrushColor: PropTypes.func,
 		brushColors: PropTypes.array,
@@ -26,16 +28,17 @@ const DrawingControls = kind({
 		fillColors: PropTypes.array,
 		canvasColor: PropTypes.string,
 		setCanvasColor: PropTypes.func,
-		canvasColors: PropTypes.array
+		canvasColors: PropTypes.array,
+		handleSelect: PropTypes.func
 	},
 
-	handlers: {
-		handleSelect: (ev) => {
-			const e = ev?.event;
-			const setDrawingTool = ev?.setDrawingTool;
-			setDrawingTool(e.data);
-		}
-	},
+	// handlers: {
+	// 	handleSelect: (ev) => {
+	// 		const e = ev?.event;
+	// 		const setDrawingTool = ev?.setDrawingTool;
+	// 		setDrawingTool(e.data);
+	// 	}
+	// },
 
 	render: ({
 		brushColor,
@@ -55,6 +58,8 @@ const DrawingControls = kind({
 		canvasColors,
 		...rest
 	}) => {
+
+		delete rest.brushSize;
 
 		return (
 			<div>

--- a/Drawing/DrawingControls.js
+++ b/Drawing/DrawingControls.js
@@ -1,35 +1,105 @@
+/* eslint-disable react/jsx-no-bind */
+
 import kind from '@enact/core/kind';
+import Group from '@enact/ui/Group';
+import {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 
 import Button from '../Button';
-import {Cell} from "../../enact/packages/ui/Layout/Cell";
-import BodyText from "../BodyText";
-import css from "./Drawing.module.less";
-import Group from "../../enact/packages/ui/Group";
-import Slider from "../Slider";
-import ColorPicker from "./ColorPicker";
+import BodyText from '../BodyText';
+import ColorPicker from './ColorPicker';
+import Slider from '../Slider';
 
+import css from './DrawingControls.module.less';
+
+/**
+ * A set of components for controlling drawing toolbar and rendering additional components.
+ *
+ * @class DrawingControls
+ * @memberof sandstone/Drawing
+ * @ui
+ * @private
+ */
 const DrawingControls = kind({
 	name: 'DrawingControls',
 
-	functional: true,
-
-	propTypes: {
-		disabled: PropTypes.bool,
-		brushSize: PropTypes.number,
-		setBrushSize: PropTypes.func,
-		setDrawingTool: PropTypes.func,
-		// drawingTools: PropTypes.array,
+	propTypes: /** @lends sandstone/DrawingControls.DrawingControls.prototype */ {
+		/**
+		 * Sets the color of brush.
+		 *
+		 * @type {String}
+		 */
 		brushColor: PropTypes.string,
-		setBrushColor: PropTypes.func,
-		// brushColors: PropTypes.array,
-		fillColor: PropTypes.string,
-		setFillColor: PropTypes.func,
-		// fillColors: PropTypes.array,
+
+		/**
+		 * Sets the size of brush.
+		 *
+		 * @type {Number}
+		 */
+		brushSize: PropTypes.number,
+
+		/**
+		 * Sets the color of canvas.
+		 *
+		 * @type {String}
+		 */
 		canvasColor: PropTypes.string,
+
+		/**
+		 * Applies the `disabled` class.
+		 *
+		 * When `true`, the canvas is shown as disabled.
+		 *
+		 * @type {Boolean}
+		 */
+		disabled: PropTypes.bool,
+
+		/**
+		 * Sets the color of fill.
+		 *
+		 * @type {String}
+		 */
+		fillColor: PropTypes.string,
+
+		/**
+		 * Called when `brushColor` changes.
+		 *
+		 * @type {Function}
+		 */
+		setBrushColor: PropTypes.func,
+
+		/**
+		 * Called when `brushSize` changes.
+		 *
+		 * @type {Function}
+		 */
+		setBrushSize: PropTypes.func,
+
+		/**
+		 * Called when `canvasColor` changes.
+		 *
+		 * @type {Function}
+		 */
 		setCanvasColor: PropTypes.func,
-		// canvasColors: PropTypes.array,
-		handleSelect: PropTypes.func,
+
+		/**
+		 * Called when `drawingTool` changes.
+		 *
+		 * @type {Function}
+		 */
+		setDrawingTool: PropTypes.func,
+
+		/**
+		 * Called when `fillColor` changes.
+		 *
+		 * @type {Function}
+		 */
+		setFillColor: PropTypes.func
+	},
+
+	styles: {
+		css,
+		className: 'drawingControls'
 	},
 
 	handlers: {
@@ -42,23 +112,18 @@ const DrawingControls = kind({
 
 	render: ({
 		brushColor,
-		// brushColors,
-		fillColor,
-		setFillColor,
-		setBrushColor,
-		// fillColors,
 		brushSize,
-		disabled,
-		// drawingTools,
-		handleSelect,
-		setDrawingTool,
-		setBrushSize,
 		canvasColor,
+		disabled,
+		fillColor,
+		handleSelect,
+		setBrushColor,
+		setBrushSize,
 		setCanvasColor,
-		// canvasColors,
+		setDrawingTool,
+		setFillColor,
 		...rest
 	}) => {
-
 		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
 		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
 		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
@@ -72,7 +137,7 @@ const DrawingControls = kind({
 		];
 
 		return (
-			<div>
+			<div {...rest}>
 				<Cell>
 					<BodyText css={css} disabled={disabled}>Drawing tools</BodyText>
 					<Group
@@ -101,7 +166,7 @@ const DrawingControls = kind({
 						max={30}
 						min={1}
 						onChange={(e) => {
-							setBrushSize(e.value)
+							setBrushSize(e.value);
 						}}
 						step={1}
 						tooltip={false}
@@ -132,7 +197,7 @@ const DrawingControls = kind({
 					/>
 				</Cell>
 			</div>
-		)
+		);
 	}
 });
 

--- a/Drawing/DrawingControls.js
+++ b/Drawing/DrawingControls.js
@@ -1,0 +1,124 @@
+import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
+
+import Button from '../Button';
+import {Cell} from "../../enact/packages/ui/Layout/Cell";
+import BodyText from "../BodyText";
+import css from "./Drawing.module.less";
+import Group from "../../enact/packages/ui/Group";
+import Slider from "../Slider";
+import ColorPicker from "./ColorPicker";
+
+const DrawingControls = kind({
+	name: 'DrawingControls',
+
+	propTypes: {
+		disabled: PropTypes.bool,
+		brushSize: PropTypes.number,
+		setBrushSize: PropTypes.func,
+		setDrawingTool: PropTypes.func,
+		drawingTools: PropTypes.object,
+		brushColor: PropTypes.string,
+		setBrushColor: PropTypes.func,
+		brushColors: PropTypes.array,
+		fillColor: PropTypes.string,
+		setFillColor: PropTypes.func,
+		fillColors: PropTypes.array,
+		canvasColor: PropTypes.string,
+		setCanvasColor: PropTypes.func,
+		canvasColors: PropTypes.array
+	},
+
+	handlers: {
+		handleSelect: (ev) => {
+			const e = ev?.event;
+			const setDrawingTool = ev?.setDrawingTool;
+			setDrawingTool(e.data);
+		}
+	},
+
+	render: ({
+		brushColor,
+		brushColors,
+		fillColor,
+		setFillColor,
+		setBrushColor,
+		fillColors,
+		brushSize,
+		disabled,
+		drawingTools,
+		handleSelect,
+		setDrawingTool,
+		setBrushSize,
+		canvasColor,
+		setCanvasColor,
+		canvasColors,
+		...rest
+	}) => {
+
+		return (
+			<div>
+				<Cell>
+					<BodyText css={css} disabled={disabled}>Drawing tools</BodyText>
+					<Group
+						childComponent={Button}
+						childProp="tooltipText"
+						className={css.drawingTools}
+						defaultSelected={0}
+						itemProps={{
+							disabled: disabled,
+							size: 'small'
+						}}
+						onSelect={(event) => handleSelect({event, setDrawingTool})}
+						select={'radio'}
+						selectedProp="selected"
+					>
+						{drawingTools}
+					</Group>
+				</Cell>
+				<Cell>
+					<BodyText css={css} disabled={disabled}>Brush size</BodyText>
+					<Slider
+						backgroundProgress={0}
+						css={css}
+						defaultValue={brushSize}
+						disabled={disabled}
+						max={30}
+						min={0}
+						onChange={(e) => {
+							setBrushSize(e.value);
+						}}
+						step={1}
+						tooltip={false}
+					/>
+				</Cell>
+				<Cell className={css.colors}>
+					<BodyText css={css} disabled={disabled}>Colors</BodyText>
+					<ColorPicker
+						color={brushColor}
+						colorHandler={setBrushColor}
+						disabled={disabled}
+						presetColors={brushColors}
+						text="Brush"
+					/>
+					<ColorPicker
+						color={fillColor}
+						colorHandler={setFillColor}
+						disabled={disabled}
+						presetColors={fillColors}
+						text="Fill"
+					/>
+					<ColorPicker
+						color={canvasColor}
+						colorHandler={setCanvasColor}
+						disabled={disabled}
+						presetColors={canvasColors}
+						text="Canvas"
+					/>
+				</Cell>
+			</div>
+		)
+	}
+});
+
+export default DrawingControls;

--- a/Drawing/DrawingControls.js
+++ b/Drawing/DrawingControls.js
@@ -19,47 +19,57 @@ const DrawingControls = kind({
 		brushSize: PropTypes.number,
 		setBrushSize: PropTypes.func,
 		setDrawingTool: PropTypes.func,
-		drawingTools: PropTypes.array,
+		// drawingTools: PropTypes.array,
 		brushColor: PropTypes.string,
 		setBrushColor: PropTypes.func,
-		brushColors: PropTypes.array,
+		// brushColors: PropTypes.array,
 		fillColor: PropTypes.string,
 		setFillColor: PropTypes.func,
-		fillColors: PropTypes.array,
+		// fillColors: PropTypes.array,
 		canvasColor: PropTypes.string,
 		setCanvasColor: PropTypes.func,
-		canvasColors: PropTypes.array,
-		handleSelect: PropTypes.func
+		// canvasColors: PropTypes.array,
+		handleSelect: PropTypes.func,
 	},
 
-	// handlers: {
-	// 	handleSelect: (ev) => {
-	// 		const e = ev?.event;
-	// 		const setDrawingTool = ev?.setDrawingTool;
-	// 		setDrawingTool(e.data);
-	// 	}
-	// },
+	handlers: {
+		handleSelect: (ev) => {
+			const e = ev?.event;
+			const setDrawingTool = ev?.setDrawingTool;
+			setDrawingTool(e.data);
+		}
+	},
 
 	render: ({
 		brushColor,
-		brushColors,
+		// brushColors,
 		fillColor,
 		setFillColor,
 		setBrushColor,
-		fillColors,
+		// fillColors,
 		brushSize,
 		disabled,
-		drawingTools,
+		// drawingTools,
 		handleSelect,
 		setDrawingTool,
 		setBrushSize,
 		canvasColor,
 		setCanvasColor,
-		canvasColors,
+		// canvasColors,
 		...rest
 	}) => {
 
-		delete rest.brushSize;
+		const brushColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
+		const canvasColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
+		const fillColors = ['#000000', '#FFFFFF', '#FF0000', '#00FF00'];
+		const drawingTools = [
+			{icon: 'edit', key: 1, tooltipText: 'brush'},
+			{icon: 'heart', key: 2, tooltipText: 'fill'},
+			{icon: 'play', key: 3, tooltipText: 'triangle'},
+			{icon: 'popupscale', key: 4, tooltipText: 'rectangle'},
+			{icon: 'newfeature', key: 5, tooltipText: 'circle'},
+			{icon: 'square', key: 6, tooltipText: 'erase'}
+		];
 
 		return (
 			<div>
@@ -89,9 +99,9 @@ const DrawingControls = kind({
 						defaultValue={brushSize}
 						disabled={disabled}
 						max={30}
-						min={0}
+						min={1}
 						onChange={(e) => {
-							setBrushSize(e.value);
+							setBrushSize(e.value)
 						}}
 						step={1}
 						tooltip={false}

--- a/Drawing/DrawingControls.module.less
+++ b/Drawing/DrawingControls.module.less
@@ -1,0 +1,25 @@
+.drawingControls {
+	.bodyText {
+		font-size: 36px;
+		margin: 0;
+	}
+
+	.drawingTools {
+		margin: 0;
+
+		& > * {
+			font-size: 36px;
+		}
+	}
+
+	.slider {
+		margin: 0;
+		padding: 24px 0;
+	}
+
+	.toolbar {
+		.colors {
+			padding: 24px 0;
+		}
+	}
+}

--- a/Drawing/DrawingUtils.js
+++ b/Drawing/DrawingUtils.js
@@ -1,23 +1,72 @@
-import kind from '@enact/core/kind';
-import PropTypes from 'prop-types';
-import css from "./Drawing.module.less";
-import Button from "../Button";
-import {Column} from "@enact/ui/Layout";
+/* eslint-disable react/jsx-no-bind */
 
+import kind from '@enact/core/kind';
+import {Column} from '@enact/ui/Layout';
+import PropTypes from 'prop-types';
+
+import Button from '../Button';
+
+import css from './DrawingUtils.module.less';
+
+/**
+ * A set of components for controlling drawing utils and rendering additional components.
+ *
+ * @class DrawingControls
+ * @memberof sandstone/Drawing
+ * @ui
+ * @private
+ */
 const DrawingUtils = kind({
 	name: 'DrawingUtils',
 
-	propTypes: {
-		disabled: PropTypes.bool,
-		drawingRef: PropTypes.object,
-		fileInputHandler: PropTypes.func,
+	propTypes: /** @lends sandstone/DrawingUtils.DrawingUtils.prototype */ {
+		/**
+		 * Sets an image as canvas background.
+		 *
+		 * @type {any}
+		 */
 		backgroundImage: PropTypes.any,
+
+		/**
+		 * Applies the `disabled` class.
+		 *
+		 * When `true`, the drawing utils is shown as disabled.
+		 *
+		 * @type {Boolean}
+		 */
+		disabled: PropTypes.bool,
+
+		/**
+		 * Canvas reference.
+		 *
+		 * @type {Object}
+		 */
+		drawingRef: PropTypes.object,
+
+		/**
+		 * Called when user clicks import input.
+		 *
+		 * @type {Function}
+		 */
+		fileInputHandler: PropTypes.func,
+
+		/**
+		 * Called when background of canvas is changed.
+		 *
+		 * @type {Function}
+		 */
 		setBackgroundImage: PropTypes.func
 	},
 
-	render: ({disabled, drawingRef, fileInputHandler, backgroundImage, setBackgroundImage}) => {
+	styles: {
+		css,
+		className: 'drawingUtils'
+	},
+
+	render: ({backgroundImage, disabled, drawingRef, fileInputHandler, setBackgroundImage, ...rest}) => {
+
 		return (
-			<Column align="center space-between" className={css.canvasOptions}>
+			<Column align="center space-between" {...rest}>
 				<Button css={css} disabled={disabled} icon="refresh" onClick={() => drawingRef.current.clearCanvas()} size="small" tooltipText="Clear all" />
 				<Button css={css} disabled={disabled} icon="plus" onClick={() => document.getElementById('fileInput').click()} size="small" tooltipText="Import image" />
 				<input

--- a/Drawing/DrawingUtils.js
+++ b/Drawing/DrawingUtils.js
@@ -1,0 +1,40 @@
+import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
+import css from "./Drawing.module.less";
+import Button from "../Button";
+import {Column} from "@enact/ui/Layout";
+
+const DrawingUtils = kind({
+	name: 'DrawingUtils',
+
+	propTypes: {
+		disabled: PropTypes.bool,
+		drawingRef: PropTypes.object,
+		fileInputHandler: PropTypes.func,
+		backgroundImage: PropTypes.any,
+		setBackgroundImage: PropTypes.func
+	},
+
+	render: ({disabled, drawingRef, fileInputHandler, backgroundImage, setBackgroundImage}) => {
+		return (
+			<Column align="center space-between" className={css.canvasOptions}>
+				<Button css={css} disabled={disabled} icon="refresh" onClick={() => drawingRef.current.clearCanvas()} size="small" tooltipText="Clear all" />
+				<Button css={css} disabled={disabled} icon="plus" onClick={() => document.getElementById('fileInput').click()} size="small" tooltipText="Import image" />
+				<input
+					accept="image/*"
+					className={css.inputFile}
+					id="fileInput"
+					onChange={(ev) => fileInputHandler({backgroundImage, ev, setBackgroundImage})}
+					onClick={(e) => {
+						e.target.value = null;
+					}}
+					type="file"
+				/>
+				<Button css={css} disabled={disabled} icon="trash" onClick={() => setBackgroundImage(null)} size="small" tooltipText="Clear image" />
+				<Button css={css} disabled={disabled} icon="download" onClick={() => drawingRef.current.saveCanvas()} size="small" tooltipText="Save canvas" />
+			</Column>
+		);
+	}
+});
+
+export default DrawingUtils;

--- a/Drawing/DrawingUtils.module.less
+++ b/Drawing/DrawingUtils.module.less
@@ -1,0 +1,10 @@
+.drawingUtils {
+	.button {
+		min-width: 144px;
+		font-size: 36px;
+	}
+
+	.inputFile {
+		display: none;
+	}
+}

--- a/samples/sampler/stories/default/Drawing.js
+++ b/samples/sampler/stories/default/Drawing.js
@@ -1,7 +1,7 @@
 import BodyText from '@enact/sandstone/BodyText';
 import Drawing, {DrawingBase} from '@enact/sandstone/Drawing';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, number} from '@enact/storybook-utils/addons/controls';
+import {boolean, number, range} from '@enact/storybook-utils/addons/controls';
 import UIDrawing, {DrawingBase as UIDrawingBase} from '@enact/ui/Drawing';
 
 Drawing.displayName = 'Drawing';
@@ -12,6 +12,7 @@ const Config = mergeComponentMetadata(
 	DrawingBase,
 	Drawing
 );
+const DrawingConfig = mergeComponentMetadata('DrawingConfig', UIDrawing, UIDrawingBase, Drawing);
 
 
 export default {
@@ -21,8 +22,10 @@ export default {
 
 export const _Drawing = (args) => {
 	const disabled = args['disabled'];
+	const brushSize = args['brushSize'];
 	const canvasHeight = args['canvasHeight'];
 	const canvasWidth = args['canvasWidth'];
+	const showDrawingControls = args['showDrawingControls'];
 
 	return (
 		<section>
@@ -30,9 +33,11 @@ export const _Drawing = (args) => {
 				<sup>*</sup>Drawing is not allowed while <code>disabled</code> is true.
 			</BodyText>
 			<Drawing
+				brushSize={brushSize}
 				canvasHeight={canvasHeight}
 				canvasWidth={canvasWidth}
 				disabled={disabled}
+				showDrawingControls={showDrawingControls}
 			/>
 		</section>
 	);
@@ -41,6 +46,8 @@ export const _Drawing = (args) => {
 number('canvasHeight', _Drawing, Config, 800);
 number('canvasWidth', _Drawing, Config, 1200);
 boolean('disabled', _Drawing, Config);
+boolean('showDrawingControls', _Drawing, Config);
+range('brushSize', _Drawing, Config, {min: 1, max: 30}, 4);
 
 _Drawing.storyName = 'Drawing';
 _Drawing.parameters = {

--- a/samples/sampler/stories/default/Drawing.js
+++ b/samples/sampler/stories/default/Drawing.js
@@ -1,12 +1,10 @@
 import BodyText from '@enact/sandstone/BodyText';
 import Drawing, {DrawingBase} from '@enact/sandstone/Drawing';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, number, range} from '@enact/storybook-utils/addons/controls';
+import {boolean, number, range, select} from '@enact/storybook-utils/addons/controls';
 import UIDrawing, {DrawingBase as UIDrawingBase} from '@enact/ui/Drawing';
-import DrawingControls from '@enact/sandstone/Drawing/DrawingControls';
 
 Drawing.displayName = 'Drawing';
-DrawingControls.displayName = 'DrawingControls';
 const Config = mergeComponentMetadata(
 	'Drawing',
 	UIDrawingBase,
@@ -14,8 +12,6 @@ const Config = mergeComponentMetadata(
 	DrawingBase,
 	Drawing
 );
-const DrawingControlsConfig = mergeComponentMetadata('DrawingControls', DrawingControls, Drawing, DrawingBase, UIDrawing, UIDrawingBase);
-
 
 export default {
 	component: 'Drawing',
@@ -24,11 +20,6 @@ export default {
 
 export const _Drawing = (args) => {
 	const disabled = args['disabled'];
-	const brushSizeNumber = args['brushSize'];
-	const canvasHeight = args['canvasHeight'];
-	const canvasWidth = args['canvasWidth'];
-	const showDrawingControls = args['showDrawingControls'];
-	const showDrawingUtils = args['showDrawingUtils'];
 
 	return (
 		<section>
@@ -36,12 +27,16 @@ export const _Drawing = (args) => {
 				<sup>*</sup>Drawing is not allowed while <code>disabled</code> is true.
 			</BodyText>
 			<Drawing
-				brushSize={brushSizeNumber}
-				canvasHeight={canvasHeight}
-				canvasWidth={canvasWidth}
+				brushSize={args['brushSize']}
+				canvasHeight={args['canvasHeight']}
+				canvasWidth={args['canvasWidth']}
 				disabled={disabled}
-				showDrawingControls={showDrawingControls}
-				showDrawingUtils={showDrawingUtils}
+				showDrawingControls={args['showDrawingControls']}
+				showDrawingUtils={args['showDrawingUtils']}
+				drawingTool={args['drawingTool']}
+				brushColor={args['brushColor']}
+				fillColor={args['fillColor']}
+				canvasColor={args['canvasColor']}
 			/>
 		</section>
 	);
@@ -52,7 +47,11 @@ number('canvasWidth', _Drawing, Config, 1200);
 boolean('disabled', _Drawing, Config);
 boolean('showDrawingControls', _Drawing, Config);
 boolean('showDrawingUtils', _Drawing, Config);
-range('brushSize', _Drawing, DrawingControlsConfig, {min: 1, max: 30}, 5);
+range('brushSize', _Drawing, Config, {min: 1, max: 30}, 5);
+select('brushColor', _Drawing, ['', '#000000', '#FFFFFF', '#FF0000', '#00FF00'], Config, '');
+select('canvasColor', _Drawing, ['', '#000000', '#FFFFFF', '#FF0000', '#00FF00'], Config, '');
+select('drawingTool', _Drawing, ['brush', 'fill', 'triangle', 'rectangle', 'circle', 'erase'], Config, '');
+select('fillColor', _Drawing, ['', '#000000', '#FFFFFF', '#FF0000', '#00FF00'], Config, '');
 
 _Drawing.storyName = 'Drawing';
 _Drawing.parameters = {

--- a/samples/sampler/stories/default/Drawing.js
+++ b/samples/sampler/stories/default/Drawing.js
@@ -3,8 +3,10 @@ import Drawing, {DrawingBase} from '@enact/sandstone/Drawing';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, number, range} from '@enact/storybook-utils/addons/controls';
 import UIDrawing, {DrawingBase as UIDrawingBase} from '@enact/ui/Drawing';
+import DrawingControls from '@enact/sandstone/Drawing/DrawingControls';
 
 Drawing.displayName = 'Drawing';
+DrawingControls.displayName = 'DrawingControls';
 const Config = mergeComponentMetadata(
 	'Drawing',
 	UIDrawingBase,
@@ -12,7 +14,7 @@ const Config = mergeComponentMetadata(
 	DrawingBase,
 	Drawing
 );
-const DrawingConfig = mergeComponentMetadata('DrawingConfig', UIDrawing, UIDrawingBase, Drawing);
+const DrawingControlsConfig = mergeComponentMetadata('DrawingControls', DrawingControls, Drawing, DrawingBase, UIDrawing, UIDrawingBase);
 
 
 export default {
@@ -22,10 +24,11 @@ export default {
 
 export const _Drawing = (args) => {
 	const disabled = args['disabled'];
-	const brushSize = args['brushSize'];
+	const brushSizeNumber = args['brushSize'];
 	const canvasHeight = args['canvasHeight'];
 	const canvasWidth = args['canvasWidth'];
 	const showDrawingControls = args['showDrawingControls'];
+	const showDrawingUtils = args['showDrawingUtils'];
 
 	return (
 		<section>
@@ -33,11 +36,12 @@ export const _Drawing = (args) => {
 				<sup>*</sup>Drawing is not allowed while <code>disabled</code> is true.
 			</BodyText>
 			<Drawing
-				brushSize={brushSize}
+				brushSize={brushSizeNumber}
 				canvasHeight={canvasHeight}
 				canvasWidth={canvasWidth}
 				disabled={disabled}
 				showDrawingControls={showDrawingControls}
+				showDrawingUtils={showDrawingUtils}
 			/>
 		</section>
 	);
@@ -47,7 +51,8 @@ number('canvasHeight', _Drawing, Config, 800);
 number('canvasWidth', _Drawing, Config, 1200);
 boolean('disabled', _Drawing, Config);
 boolean('showDrawingControls', _Drawing, Config);
-range('brushSize', _Drawing, Config, {min: 1, max: 30}, 4);
+boolean('showDrawingUtils', _Drawing, Config);
+range('brushSize', _Drawing, DrawingControlsConfig, {min: 1, max: 30}, 5);
 
 _Drawing.storyName = 'Drawing';
 _Drawing.parameters = {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
drawingControls and drawingUtils are rendered optionally

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-18652

### Comments
