### PR TITLE
Feature/WRN-19924: Add color picker control in storybook

### DIFF
--- a/Drawing/ColorPicker.js
+++ b/Drawing/ColorPicker.js
@@ -172,6 +172,8 @@ const ColorPickerBase = kind({
 			}
 
 			useEffect(() => {
+				if (color[0] !== '#') return;
+
 				let {r, g, b} = hexToRgb(color);
 
 				setInputColor(color);

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -258,8 +258,8 @@ const DrawingBase = kind({
 
 		useEffect(() => {
 			setBrushColorValue(brushColor);
-			!showDrawingControls && window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor)); // eslint-disable-line 
-		}, [brushColor]); // eslint-disable-line react-hooks/exhaustive-deps
+			!showDrawingControls && window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
+		}, [brushColor]);
 
 		useEffect(() => {
 			setBrushSizeValue(brushSize);
@@ -271,13 +271,13 @@ const DrawingBase = kind({
 
 		useEffect(() => {
 			setFillColorValue(fillColor);
-			!showDrawingControls && window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor)); // eslint-disable-line 
-		}, [fillColor]); // eslint-disable-line react-hooks/exhaustive-deps
+			!showDrawingControls && window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
+		}, [fillColor]);
 
 		useEffect(() => {
 			setCanvasColorValue(canvasColor);
-			!showDrawingControls && window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor)); // eslint-disable-line 
-		}, [canvasColor]); // eslint-disable-line react-hooks/exhaustive-deps
+			!showDrawingControls && window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
+		}, [canvasColor]);
 
 		useEffect(() => {
 			const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -1,4 +1,4 @@
-/* eslint-disable react-hooks/rules-of-hooks, react/jsx-no-bind */
+/* eslint-disable react-hooks/rules-of-hooks, react/jsx-no-bind, babel/no-unused-expressions, react-hooks/exhaustive-deps */
 
 /**
  * Sandstone styled drawing components and behaviors.

--- a/Drawing/Drawing.js
+++ b/Drawing/Drawing.js
@@ -258,8 +258,8 @@ const DrawingBase = kind({
 
 		useEffect(() => {
 			setBrushColorValue(brushColor);
-			!showDrawingControls && window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor));
-		}, [brushColor]);
+			!showDrawingControls && window.localStorage.setItem('lastBrushColor', JSON.stringify(brushColor)); // eslint-disable-line 
+		}, [brushColor]); // eslint-disable-line react-hooks/exhaustive-deps
 
 		useEffect(() => {
 			setBrushSizeValue(brushSize);
@@ -271,13 +271,13 @@ const DrawingBase = kind({
 
 		useEffect(() => {
 			setFillColorValue(fillColor);
-			!showDrawingControls && window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor));
-		}, [fillColor]);
+			!showDrawingControls && window.localStorage.setItem('lastFillColor', JSON.stringify(fillColor)); // eslint-disable-line 
+		}, [fillColor]); // eslint-disable-line react-hooks/exhaustive-deps
 
 		useEffect(() => {
 			setCanvasColorValue(canvasColor);
-			!showDrawingControls && window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor));
-		}, [canvasColor]);
+			!showDrawingControls && window.localStorage.setItem('lastCanvasColor', JSON.stringify(canvasColor)); // eslint-disable-line 
+		}, [canvasColor]); // eslint-disable-line react-hooks/exhaustive-deps
 
 		useEffect(() => {
 			const storedBrushColors = JSON.parse(window.localStorage.getItem('brushColors'));

--- a/samples/sampler/stories/default/Drawing.js
+++ b/samples/sampler/stories/default/Drawing.js
@@ -42,9 +42,9 @@ export const _Drawing = (args) => {
 	);
 };
 
-color('brushColor', _Drawing, Config, '#00FF00');
+color('brushColor', _Drawing, Config, '#FFFFFF');
 range('brushSize', _Drawing, Config, {min: 1, max: 30}, 5);
-color('canvasColor', _Drawing, Config, '#00FF00');
+color('canvasColor', _Drawing, Config, '#000000');
 number('canvasHeight', _Drawing, Config, 800);
 number('canvasWidth', _Drawing, Config, 1200);
 boolean('disabled', _Drawing, Config);

--- a/samples/sampler/stories/default/Drawing.js
+++ b/samples/sampler/stories/default/Drawing.js
@@ -1,7 +1,7 @@
 import BodyText from '@enact/sandstone/BodyText';
 import Drawing, {DrawingBase} from '@enact/sandstone/Drawing';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, number, range, select} from '@enact/storybook-utils/addons/controls';
+import {color, boolean, number, range, select} from '@enact/storybook-utils/addons/controls';
 import UIDrawing, {DrawingBase as UIDrawingBase} from '@enact/ui/Drawing';
 
 Drawing.displayName = 'Drawing';
@@ -42,14 +42,14 @@ export const _Drawing = (args) => {
 	);
 };
 
-select('brushColor', _Drawing, ['', '#000000', '#FFFFFF', '#FF0000', '#00FF00'], Config, '');
+color('brushColor', _Drawing, Config, '#00FF00');
 range('brushSize', _Drawing, Config, {min: 1, max: 30}, 5);
-select('canvasColor', _Drawing, ['', '#000000', '#FFFFFF', '#FF0000', '#00FF00'], Config, '');
+color('canvasColor', _Drawing, Config, '#00FF00');
 number('canvasHeight', _Drawing, Config, 800);
 number('canvasWidth', _Drawing, Config, 1200);
 boolean('disabled', _Drawing, Config);
 select('drawingTool', _Drawing, ['brush', 'fill', 'triangle', 'rectangle', 'circle', 'erase'], Config, '');
-select('fillColor', _Drawing, ['', '#000000', '#FFFFFF', '#FF0000', '#00FF00'], Config, '');
+color('fillColor', _Drawing, Config, '#00FF00');
 boolean('showDrawingControls', _Drawing, Config);
 boolean('showDrawingUtils', _Drawing, Config);
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added storybook color picker control for changing brush, canvas and fill color for drawing component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-19924

### Comments
