### PR TITLE
WRN-18494: Add a story to test two floating layers in FixedPopupPanel qa-sampler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch="feature/WRN-18494" --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRN-18494 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch="feature/WRN-18494" --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=feature/WRN-18494 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -264,12 +264,12 @@ export const WithDropdown = (args) => {
 	return (
 		<>
 			<Dropdown
-				title="A dropdown"
+				title="Dropdown"
 				onOpen={handleOpenDropdown}
 			>
 				{['a', 'b', 'c', 'd']}
 			</Dropdown>
-			<Button onClick={handleOpen}>open</Button>
+			<Button onClick={handleOpen}>Open</Button>
 			<FixedPopupPanels
 				open={open}
 				position={args['position']}

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -247,25 +247,25 @@ WithPauseAndAutoFocusNone.parameters = {
 export const WithDropdown = (args) => {
 	const [open, setOpen] = useState(false);
 
-    const handleOpenDropdown = useCallback(() => {
-        setTimeout(() => {
-            setOpen(true);
-        }, 1000);
-    },[]);
+	const handleOpenDropdown = useCallback(() => {
+		setTimeout(() => {
+			setOpen(true);
+		}, 1000);
+	}, []);
 
-    const handleOpen = useCallback(() => {
-        setOpen(true);
-    },[]);
+	const handleOpen = useCallback(() => {
+		setOpen(true);
+	}, []);
 
-    const handleClose = useCallback(() => {
-        setOpen(false);
-    },[]);
+	const handleClose = useCallback(() => {
+		setOpen(false);
+	}, []);
 
 	return (
 		<>
 			<Dropdown
-					title="A dropdown"
-                    onOpen={handleOpenDropdown}
+				title="A dropdown"
+				onOpen={handleOpenDropdown}
 			>
 				{['a', 'b', 'c', 'd']}
 			</Dropdown>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -244,6 +244,63 @@ WithPauseAndAutoFocusNone.parameters = {
 	}
 };
 
+export const WithDropdown = (args) => {
+	const [open, setOpen] = useState(false);
+
+    const handleOpenDropdown = useCallback(() => {
+        setTimeout(() => {
+            setOpen(true);
+        }, 1000);
+    },[]);
+
+    const handleOpen = useCallback(() => {
+        setOpen(true);
+    },[]);
+
+    const handleClose = useCallback(() => {
+        setOpen(false);
+    },[]);
+
+	return (
+		<>
+			<Dropdown
+					title="A dropdown"
+                    onOpen={handleOpenDropdown}
+			>
+				{['a', 'b', 'c', 'd']}
+			</Dropdown>
+			<Button onClick={handleOpen}>open</Button>
+			<FixedPopupPanels
+				open={open}
+				position={args['position']}
+				fullHeight={args['fullHeight']}
+				width={args['width']}
+				noAnimation={args['noAnimation']}
+				noAutoDismiss={args['noAutoDismiss']}
+				scrimType={args['scrimType']}
+				spotlightRestrict={args['spotlightRestrict']}
+			>
+				<Panel>
+					<Header>
+						<title>Fixed Popup Panel</title>
+					</Header>
+					<Button onClick={handleClose}>Close</Button>
+				</Panel>
+			</FixedPopupPanels>
+		</>
+	);
+};
+
+select('position', WithDropdown, ['left', 'right'], Config);
+boolean('fullHeight', WithDropdown, Config);
+select('width', WithDropdown, ['narrow', 'half'], Config);
+boolean('noAnimation', WithDropdown, Config);
+boolean('noAutoDismiss', WithDropdown, Config);
+select('scrimType', WithDropdown, ['none', 'translucent', 'transparent'], Config);
+select('spotlightRestrict', WithDropdown, ['self-first', 'self-only'], Config);
+
+WithDropdown.storyName = 'with Dropdown';
+
 export const WithScroller = (args) => {
 	return (
 		<FixedPopupPanels

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -135,6 +135,6 @@ export default {
 WithAutoFocusControl.storyName = 'with AutoFocus Control';
 WithAutoFocusControl.parameters = {
 	props: {
-		noPanel: true
+		noPanels: true
 	}
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When two floatinglayers are displayed, there is a bug that a popup which open later shown on down of other popup .

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a story to test two floating layers in FixedPopupPanel qa-sampler 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I fixed minor console error on Panels qa-sampler

### Links
[//]: # (Related issues, references)
WRN-18494

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
