### PR TITLE
WRN-20381: Skip scroller ui-test.

### DIFF
--- a/tests/ui/specs/Scroller/ListOfThings/Scroller-QWT-2662-specs.js
+++ b/tests/ui/specs/Scroller/ListOfThings/Scroller-QWT-2662-specs.js
@@ -6,7 +6,7 @@ describe('Scroller List Of Things', function () {
 		await ScrollerPage.open('ListOfThings');
 	});
 
-	it('should spotlight is on the item closest to the previously focused item [QWT-2662]', async function () {
+	it.skip('should spotlight is on the item closest to the previously focused item [QWT-2662]', async function () {
 		// Step 3: 5-way Spot the second item ('Item 001').
 		await $('#item0').moveTo();
 		await ScrollerPage.spotlightDown();

--- a/tests/ui/specs/VirtualList/VirtualList/Samples/VirtualList-QWT-2137-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList/Samples/VirtualList-QWT-2137-specs.js
@@ -23,7 +23,7 @@ describe('VirtualList Samples', function () {
 		await Page.spotlightRight();
 
 		// Wait for scroll animation
-		await Page.delay(300);
+		await Page.delay(500);
 
 		// Verify Spotlight displays on the 21st item ('Itme 20');
 		await expectFocusedItem(Number((await Page.bottomVisibleItemId()).slice(4)));


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to add delay for VirtualList ui-test(QWT-2317).
- Need to skip Scroller ui-test(QWT-2662).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add delay for VirtualList ui-test(QWT-2137).
- Skip Scroller ui-test(QWT-2662).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]:# (Related issues, references)
WRN-20381
WRN-20012
QWT-2137
QWT-2662
### Comments
QWT-2662 will skip test until WRN-20012 will be resolved.