### PR TITLE
WRO-242: Refine 5-way control for a editable scroller

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -260,7 +260,7 @@ const EditableWrapper = (props) => {
 				ev.stopPropagation();
 			}
 		}
-	}, [editable, finalizeOrders, reset, startEditing]);
+	}, [editable, finalizeOrders, moveItemsByKeyDown, reset, startEditing]);
 
 	useEffect(() => {
 		// Calculate the item width once

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -35,7 +35,7 @@ const EditableShape = PropTypes.shape({
 	removeItemFuncRef: EnactPropTypes.ref
 });
 
-const SpotlightAccelerator = new Accelerator([5, 4]); // [3, 3, 3, 2, 2, 2, 1]
+const SpotlightAccelerator = new Accelerator([5, 4]);
 
 /**
  * A Sandstone-styled EditableWrapper.

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -8,7 +8,7 @@ import {useCallback, useEffect, useRef} from 'react';
 
 import css from './EditableWrapper.module.less';
 
-const SpotlightAccelerator = new Accelerator(); // [3, 3, 3, 2, 2, 2, 1]
+const SpotlightAccelerator = new Accelerator([5, 4]); // [3, 3, 3, 2, 2, 2, 1]
 
 /**
  * A Sandstone-styled EditableWrapper.
@@ -208,10 +208,12 @@ const EditableWrapper = (props) => {
 			left = container.scrollLeft + itemLeft;
 		}
 
-		scrollContainerHandle.current.start({
-			targetX: left,
-			targetY: 0
-		});
+		if (left != null) { /* avoid null or undefined */
+			scrollContainerHandle.current.start({
+				targetX: left,
+				targetY: 0
+			});
+		}
 
 		moveItems(toIndex);
 	}, [moveItems, scrollContainerHandle, scrollContentRef]);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Added acceleration feature for holding-down 5-way keys
- Updated to work only once when holding down `enter` key

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-242

### Comments
