### PR TITLE
WRO-4073: Fixed editable wrapper to set proper index of selected item when scrolled by 5way mode

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -403,7 +403,7 @@ const EditableWrapper = (props) => {
 
 		const handleMoveItemsByScroll = () => {
 			const {itemWidth, lastMouseClientX, selectedItem} = mutableRef.current;
-			if (selectedItem && Spotlight.getPointerMode()) {
+			if (selectedItem && mutableRef.current.lastInputType !== 'key') {
 				const toIndex = Math.floor((lastMouseClientX + scrollContentNode.scrollLeft) / itemWidth);
 				mutableRef.current.lastInputType = 'scroll';
 				moveItems(lastMouseClientX > scrollContentCenter ? toIndex + 1 : toIndex - 1);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -403,7 +403,7 @@ const EditableWrapper = (props) => {
 
 		const handleMoveItemsByScroll = () => {
 			const {itemWidth, lastMouseClientX, selectedItem} = mutableRef.current;
-			if (selectedItem) {
+			if (selectedItem && Spotlight.getPointerMode()) {
 				const toIndex = Math.floor((lastMouseClientX + scrollContentNode.scrollLeft) / itemWidth);
 				mutableRef.current.lastInputType = 'scroll';
 				moveItems(lastMouseClientX > scrollContentCenter ? toIndex + 1 : toIndex - 1);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed editable wrapper to set proper index of selected item when scrolled by 5way mode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check if it is pointer mode when moving items by scroll event

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4073

### Comments
