### PR TITLE
WRO-591: Fixed editable wrapper to adjust sensitivity to swap the items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - node  
+    - node
 sudo: false
 cache: npm
 before_install:
     - sudo apt-get update
-    - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev  
+    - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
+    - npm cache clean --force
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - node
+    - node  
 sudo: false
 cache: npm
 before_install:
     - sudo apt-get update
-    - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+    - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev  
 install:
-    - npm cache clean --force
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` sensitivity to swap items on`editable` mode
+
 ## [2.5.0-alpha.2] - 2022-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` sensitivity to swap items on`editable` mode
+- `sandstone/Scroller` thresholds for swapping items by pointer when `editable` is given
+- `sandstone/Scroller` to support RTL locales when `editable` is given
 - `sandstone/TimePicker` to forward `onComplete` event in RTL countries that do not display meridiem
 
 ## [2.5.0-alpha.2] - 2022-05-09

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -380,9 +380,9 @@ const EditableWrapper = (props) => {
 	useEffect(() => {
 		// Calculate the item width once
 		const {rtl} = scrollContainerHandle.current;
-		const bodyWidth = document.body.getBoundingClientRect().width;
 		const item = wrapperRef.current?.children[0];
-		if (item) {
+		if (item && typeof window !== 'undefined') {
+			const bodyWidth = document.body.getBoundingClientRect().width;
 			const neighbor = item.nextElementSibling || item.previousElementSibling;
 			mutableRef.current.itemWidth = Math.abs(item.offsetLeft - neighbor?.offsetLeft);
 			mutableRef.current.centeredOffset = rtl ? bodyWidth - item.getBoundingClientRect().right : item.getBoundingClientRect().left;
@@ -416,15 +416,15 @@ const EditableWrapper = (props) => {
 	useEffect(() => {
 		// addEventListener to moveItems while scrolled
 		const scrollContentNode = scrollContentRef.current;
-		const scrollContentRect = scrollContentNode.getBoundingClientRect();
 
 		const handleMoveItemsByScroll = () => {
+			const bodyWidth = document.body.getBoundingClientRect().width;
 			const {itemWidth, lastMouseClientX, selectedItem} = mutableRef.current;
 			const {rtl} = scrollContainerHandle.current;
 			if (selectedItem && mutableRef.current.lastInputType !== 'key') {
-				const toIndex = Math.floor(((rtl ? scrollContentRect.right - lastMouseClientX : lastMouseClientX) + scrollContentNode.scrollLeft * (rtl ? -1 : 1)) / itemWidth);
+				const toIndex = Math.floor(((rtl ? bodyWidth - lastMouseClientX : lastMouseClientX) + scrollContentNode.scrollLeft * (rtl ? -1 : 1)) / itemWidth);
 				mutableRef.current.lastInputType = 'scroll';
-				moveItems(!rtl ^ !(lastMouseClientX > scrollContentRect.width / 2) ? toIndex + 1 : toIndex - 1);
+				moveItems(!rtl ^ !(lastMouseClientX > bodyWidth / 2) ? toIndex + 1 : toIndex - 1);
 			}
 		};
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -294,14 +294,14 @@ const EditableWrapper = (props) => {
 
 	const handleMouseMove = useCallback((ev) => {
 		const {centeredOffset, itemWidth, prevToIndex, selectedItem} = mutableRef.current;
+		const {rtl} = scrollContainerHandle.current;
 
 		if (selectedItem) {
+			const bodyWidth = document.body.getBoundingClientRect().width;
+			const {clientX} = ev;
+
 			// Determine toIndex with mouse client x position
 			// Coordinate calculation in RTL locales is not supported in chrome below 85
-			const {clientX} = ev;
-			const {rtl} = scrollContainerHandle.current;
-
-			const bodyWidth = document.body.getBoundingClientRect().width;
 			const scrollContentOffset = scrollContentRef.current.scrollLeft * (rtl ? -1 : 1) - centeredOffset;
 			const clientXFromContent = (rtl ? bodyWidth - clientX : clientX) + scrollContentOffset;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The UX guide specifies changing the order of items when 1/3 of the items have passed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Fix `sandstone/Scroller` sensitivity to swap items on the editable mode.
- Fix `centeredOffset` formular (Because ev.clientX value is based on root element rather than `editable` wrapper div. So I used body width) 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-591

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
