### PR TITLE
Fixed scroller to position focused item into view when the window is resized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+- `sandstone/Scroller` to position the focused item into scroller view
+
 ## [2.5.0-alpha.2] - 2022-05-09
 
 ### Added

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -903,17 +903,17 @@ export const WithInputFields = (args) => (
 			<Item>2</Item>
 			<Item>3</Item>
 			<Item>4</Item>
-			<Input defaultValue="Input 1"/>
+			<Input defaultValue="Input 1" />
 			<Item>5</Item>
 			<Item>6</Item>
 			<Item>7</Item>
 			<Item>8</Item>
-			<Input defaultValue="Input 2"/>
+			<Input defaultValue="Input 2" />
 			<Item>9</Item>
 			<Item>10</Item>
 			<Item>11</Item>
 			<Item>12</Item>
-			<Input defaultValue="Input 3"/>
+			<Input defaultValue="Input 3" />
 			<Item>13</Item>
 			<Item>14</Item>
 			<Item>15</Item>

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -4,6 +4,7 @@ import {boolean, number, range, select} from '@enact/storybook-utils/addons/cont
 import Button from '@enact/sandstone/Button';
 import BodyText from '@enact/sandstone/BodyText';
 import ImageItem from '@enact/sandstone/ImageItem';
+import {InputField as Input} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import {Header} from '@enact/sandstone/Panels';
@@ -881,3 +882,48 @@ select('focusableScrollbar', WithLongContents, prop.focusableScrollbarOption, Co
 select('scrollMode', WithLongContents, prop.scrollModeOption, Config);
 
 WithLongContents.storyName = 'With Long Contents';
+
+export const WithInputFields = (args) => (
+	<Scroller
+		focusableScrollbar={args['focusableScrollbar']}
+		key={args['scrollMode']}
+		onKeyDown={action('onKeyDown')}
+		onScrollStart={action('onScrollStart')}
+		onScrollStop={action('onScrollStop')}
+		scrollMode={args['scrollMode']}
+		spotlightDisabled={args['spotlightDisabled']}
+	>
+		<div
+				style={{
+					height: ri.scaleToRem(2004),
+					width: ri.scaleToRem(4002)
+				}}
+			>
+				<Item>1</Item>
+				<Item>2</Item>
+				<Item>3</Item>
+				<Item>4</Item>
+				<Input defaultValue="Input 1"/>
+				<Item>5</Item>
+				<Item>6</Item>
+				<Item>7</Item>
+				<Item>8</Item>
+				<Input defaultValue="Input 2"/>
+				<Item>9</Item>
+				<Item>10</Item>
+				<Item>11</Item>
+				<Item>12</Item>
+				<Input defaultValue="Input 3"/>
+				<Item>13</Item>
+				<Item>14</Item>
+				<Item>15</Item>
+				<Item>16</Item>
+			</div>
+	</Scroller>
+);
+
+select('focusableScrollbar', WithInputFields, prop.focusableScrollbarOption, Config);
+select('scrollMode', WithInputFields, prop.scrollModeOption, Config);
+boolean('spotlightDisabled', WithInputFields, Config, false);
+
+WithInputFields.storyName = 'With InputFields';

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -894,31 +894,31 @@ export const WithInputFields = (args) => (
 		spotlightDisabled={args['spotlightDisabled']}
 	>
 		<div
-				style={{
-					height: ri.scaleToRem(2004),
-					width: ri.scaleToRem(4002)
-				}}
-			>
-				<Item>1</Item>
-				<Item>2</Item>
-				<Item>3</Item>
-				<Item>4</Item>
-				<Input defaultValue="Input 1"/>
-				<Item>5</Item>
-				<Item>6</Item>
-				<Item>7</Item>
-				<Item>8</Item>
-				<Input defaultValue="Input 2"/>
-				<Item>9</Item>
-				<Item>10</Item>
-				<Item>11</Item>
-				<Item>12</Item>
-				<Input defaultValue="Input 3"/>
-				<Item>13</Item>
-				<Item>14</Item>
-				<Item>15</Item>
-				<Item>16</Item>
-			</div>
+			style={{
+				height: ri.scaleToRem(2004),
+				width: ri.scaleToRem(4002)
+			}}
+		>
+			<Item>1</Item>
+			<Item>2</Item>
+			<Item>3</Item>
+			<Item>4</Item>
+			<Input defaultValue="Input 1"/>
+			<Item>5</Item>
+			<Item>6</Item>
+			<Item>7</Item>
+			<Item>8</Item>
+			<Input defaultValue="Input 2"/>
+			<Item>9</Item>
+			<Item>10</Item>
+			<Item>11</Item>
+			<Item>12</Item>
+			<Input defaultValue="Input 3"/>
+			<Item>13</Item>
+			<Item>14</Item>
+			<Item>15</Item>
+			<Item>16</Item>
+		</div>
 	</Scroller>
 );
 

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -4,7 +4,7 @@ import {boolean, number, range, select} from '@enact/storybook-utils/addons/cont
 import Button from '@enact/sandstone/Button';
 import BodyText from '@enact/sandstone/BodyText';
 import ImageItem from '@enact/sandstone/ImageItem';
-import {InputField as Input} from '@enact/sandstone/Input';
+import {InputField} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import {Header} from '@enact/sandstone/Panels';
@@ -903,17 +903,17 @@ export const WithInputFields = (args) => (
 			<Item>2</Item>
 			<Item>3</Item>
 			<Item>4</Item>
-			<Input defaultValue="Input 1" />
+			<InputField defaultValue="Input 1" />
 			<Item>5</Item>
 			<Item>6</Item>
 			<Item>7</Item>
 			<Item>8</Item>
-			<Input defaultValue="Input 2" />
+			<InputField defaultValue="Input 2" />
 			<Item>9</Item>
 			<Item>10</Item>
 			<Item>11</Item>
 			<Item>12</Item>
-			<Input defaultValue="Input 3" />
+			<InputField defaultValue="Input 3" />
 			<Item>13</Item>
 			<Item>14</Item>
 			<Item>15</Item>

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -246,9 +246,9 @@ const useThemeScroll = (props, instances) => {
 
 		if (focusedItem) {
 			focusedItem.scrollIntoView(false);
-			return true;
+			return false;
 		}
-		return false;
+		return true;
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -245,7 +245,7 @@ const useThemeScroll = (props, instances) => {
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
-			focusedItem.scrollIntoView(false);
+			focusedItem.scrollIntoView(true);
 			return false;
 		}
 		return true;

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -245,8 +245,10 @@ const useThemeScroll = (props, instances) => {
 		const focusedItem = Spotlight.getCurrent();
 
 		if (focusedItem) {
-			focusedItem.blur();
+			focusedItem.scrollIntoView(false);
+			return true;
 		}
+		return false;
 	}
 
 	// FIXME setting event handlers directly to work on the V8 snapshot.


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Current scroller scroll to the top when resizing event regardless of current focused item and position.
Fixed scroller to allow input via VKB into inputfields within the scroller even when the window is resized.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When handling resize window, element.scrollIntoView when focused item exist.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-398

### Comments
