### PR TITLE
WRO-2828: Should be prop's default value 'wrap: false' in Picker QA S…

### DIFF
--- a/samples/sampler/stories/qa/Picker.js
+++ b/samples/sampler/stories/qa/Picker.js
@@ -224,7 +224,7 @@ export const WithItemAddRemoveEnyo2448 = (args) => (
 
 select('width', WithItemAddRemoveEnyo2448, prop.width, Picker, 'medium');
 select('orientation', WithItemAddRemoveEnyo2448, prop.orientation, Picker, 'horizontal');
-boolean('wrap', WithItemAddRemoveEnyo2448, Picker, true);
+boolean('wrap', WithItemAddRemoveEnyo2448, Picker);
 boolean('joined', WithItemAddRemoveEnyo2448, Picker);
 select('changedBy', WithItemAddRemoveEnyo2448, prop.changedBy, Picker, 'enter');
 boolean('noAnimation', WithItemAddRemoveEnyo2448, Picker);
@@ -246,7 +246,7 @@ export const RtlLayoutPlat28123 = (args) => (
 );
 
 select('width', RtlLayoutPlat28123, prop.width, Picker, 'medium');
-boolean('wrap', RtlLayoutPlat28123, Picker, true);
+boolean('wrap', RtlLayoutPlat28123, Picker);
 boolean('joined', RtlLayoutPlat28123, Picker);
 select('changedBy', RtlLayoutPlat28123, prop.changedBy, Picker, 'enter');
 boolean('noAnimation', RtlLayoutPlat28123, Picker);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to change default prop 'wrap:false' in Picker qa-sampler(Pciker > RTL layout).
- Need to change default prop 'wrap:false' in Picker qa-sampler(Pciker > itemAdd/Remove).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Change default prop 'wrap:false' in Picker qa-sampler(Pciker > RTL layout).
- Change default prop 'wrap:false' in Picker qa-sampler(Pciker > itemAdd/Remove).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]:# (Related issues, references)
WRO-2828

### Comments
