### PR TITLE
WRO-3415: Provides event payload info for input type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=feature/WRO-3415 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRO-3415 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ node_js:
     - lts/*
     - node  
 sudo: false
-cache: npm
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev  
 install:
-    - npm config set prefer-offline true
+    - npm config set prefer-offline false
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/Popup`, `sandstone/PopupTabLayout`, `sandstone/FixedPopupPanels`, and `sandstone/FlexiblePopupPanels` to add `detail` property containing `inputType` in `onClose` event payload
+
 ### Fixed
 
 - `sandstone/TimePicker` to forward `onComplete` event in RTL countries that do not display meridiem

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -281,15 +281,6 @@ class Popup extends Component {
 
 	static propTypes = /** @lends sandstone/Popup.Popup.prototype */ {
 		/**
-		 * Hint string read when focusing the popup close button.
-		 *
-		 * @type {String}
-		 * @default 'Close'
-		 * @public
-		 */
-		closeButtonAriaLabel: PropTypes.string,
-
-		/**
 		 * Prevents closing the popup via 5-way navigation out of the content.
 		 *
 		 * @type {Boolean}
@@ -320,9 +311,15 @@ class Popup extends Component {
 		 * Called on:
 		 *
 		 * * pressing `ESC` key,
-		 * * clicking on the close button, or
+		 * * clicking on outside the boundary of the popup, or
 		 * * moving spotlight focus outside the boundary of the popup when `spotlightRestrict` is
 		 *   `'self-first'`.
+		 *
+		 * Event payload:
+		 *
+		 * * pressing `ESC` key, carries `detail` property containing `inputType` value of `'key'`.
+		 * * clicking outside the boundary of the popup, carries `detail` property containing
+		 *   `inputType` value of `'click'`.
 		 *
 		 * It is the responsibility of the callback to set the `open` property to `false`.
 		 *
@@ -566,8 +563,8 @@ class Popup extends Component {
 		}
 	};
 
-	handleDismiss = () => {
-		forwardCustom('onClose')({}, this.props);
+	handleDismiss = (ev) => {
+		forwardCustom('onClose', () => ({detail: ev?.detail}))({}, this.props);
 	};
 
 	handlePopupHide = (ev) => {

--- a/Popup/tests/Popup-specs.js
+++ b/Popup/tests/Popup-specs.js
@@ -1,6 +1,6 @@
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
 import {Popup} from '../Popup';
 
@@ -77,6 +77,23 @@ describe('Popup specs', () => {
 		const popup = screen.getByRole('alert');
 
 		expect(popup).toHaveAttribute('data-webos-voice-disabled');
+	});
+
+	test('should fire onClose event with type and detail info when Popup is closed', () => {
+		const handleClose = jest.fn();
+
+		render(
+			<FloatingLayerController>
+				<Popup onClose={handleClose} open><div>popup</div></Popup>
+			</FloatingLayerController>
+		);
+
+		fireEvent.keyUp(screen.getByText('popup'), {keyCode: 27});
+
+		const expectedType = {type: 'onClose', detail: {inputType: 'key'}};
+		const actual = handleClose.mock.calls.length && handleClose.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expectedType);
 	});
 
 	describe('with position bottom', function () {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
App developers want to know which user input invokes `onClose` event from `Popup`, `PopupTabLayout`, `FixedPopupPanels`, and `FlexiblePopupPanels` to provide different actions based on the input type.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `detail` property that contains `inputType` value: its value is `'key'` for `ESC` key, and `'click'` for clicking outside a popup.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3415
enactjs/enact/pull/3060

### Comments

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)