### PR TITLE
WRO-4786: Fix editable scroller to scroll properly by wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
     - lts/*
     - node
 sudo: false
-cache: npm
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
-    - npm config set prefer-offline true
+    - npm config set prefer-offline false
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -292,28 +292,32 @@ const EditableWrapper = (props) => {
 		}
 	}, [editable, finalizeOrders, reset]);
 
-	const handleMouseMove = useCallback((ev) => {
-		const {centeredOffset, itemWidth, prevToIndex, selectedItem} = mutableRef.current;
+	const getNextIndexFromPosition = useCallback((x, tolerance) => {
+		const {centeredOffset, itemWidth, prevToIndex} = mutableRef.current;
 		const {rtl} = scrollContainerHandle.current;
+		const bodyWidth = document.body.getBoundingClientRect().width;
 
-		if (selectedItem) {
-			const bodyWidth = document.body.getBoundingClientRect().width;
+		// Determine toIndex with mouse client x position
+		// Coordinate calculation in RTL locales is not supported in chrome below 85
+		const scrollContentOffset = scrollContentRef.current.scrollLeft * (rtl ? -1 : 1) - centeredOffset;
+		const clientXFromContent = (rtl ? bodyWidth - x : x) + scrollContentOffset;
+		const moveDirection = (itemWidth * (prevToIndex + 0.5) < clientXFromContent) ? 1 : -1; // 1: To next index , -1: To prev index
+		const moveTolerance = itemWidth * tolerance * moveDirection;
+
+		return Math.floor((clientXFromContent - moveTolerance) / itemWidth);
+	}, [scrollContainerHandle, scrollContentRef]);
+
+	const handleMouseMove = useCallback((ev) => {
+		if (mutableRef.current.selectedItem) {
 			const {clientX} = ev;
 
-			// Determine toIndex with mouse client x position
-			// Coordinate calculation in RTL locales is not supported in chrome below 85
-			const scrollContentOffset = scrollContentRef.current.scrollLeft * (rtl ? -1 : 1) - centeredOffset;
-			const clientXFromContent = (rtl ? bodyWidth - clientX : clientX) + scrollContentOffset;
-
-			const moveDirection = (itemWidth * (prevToIndex + 0.5) < clientXFromContent) ? 1 : -1; // 1: To next index , -1: To prev index
-			const moveTolerance = itemWidth * 0.33 * moveDirection;
-			const toIndex = Math.floor((clientXFromContent - moveTolerance) / itemWidth);
+			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
 			mutableRef.current.lastMouseClientX = clientX;
 			mutableRef.current.lastInputType = 'mouse';
 			moveItems(toIndex);
 		}
-	}, [moveItems, scrollContainerHandle, scrollContentRef]);
+	}, [getNextIndexFromPosition, moveItems]);
 
 	const handleMouseLeave = useCallback(() => {
 		const {itemWidth, lastInputType, lastMouseClientX, selectedItem} = mutableRef.current;
@@ -419,15 +423,15 @@ const EditableWrapper = (props) => {
 
 		const handleMoveItemsByScroll = () => {
 			const bodyWidth = document.body.getBoundingClientRect().width;
-			const {itemWidth, lastMouseClientX, selectedItem} = mutableRef.current;
+			const {lastMouseClientX, selectedItem} = mutableRef.current;
 			const {isHoveringToScroll, rtl} = scrollContainerHandle.current;
 			if (selectedItem && mutableRef.current.lastInputType !== 'key') {
-				const toIndex = Math.floor(((rtl ? bodyWidth - lastMouseClientX : lastMouseClientX) + scrollContentNode.scrollLeft * (rtl ? -1 : 1)) / itemWidth);
 				mutableRef.current.lastInputType = 'scroll';
 				if (isHoveringToScroll) {
+					const toIndex = getNextIndexFromPosition(lastMouseClientX, 0);
 					moveItems(!rtl ^ !(lastMouseClientX > bodyWidth / 2) ? toIndex + 1 : toIndex - 1);
 				} else {
-					moveItems(toIndex);
+					moveItems(getNextIndexFromPosition(lastMouseClientX, 0.33));
 				}
 			}
 		};
@@ -438,7 +442,7 @@ const EditableWrapper = (props) => {
 			scrollContentNode.removeEventListener('scroll', handleMoveItemsByScroll);
 		};
 
-	}, [moveItems, scrollContainerHandle, scrollContentRef]);
+	}, [getNextIndexFromPosition, moveItems, scrollContainerHandle, scrollContentRef]);
 
 	return (
 		<div

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -413,11 +413,15 @@ const EditableWrapper = (props) => {
 
 		const handleMoveItemsByScroll = () => {
 			const {itemWidth, lastMouseClientX, selectedItem} = mutableRef.current;
-			const {rtl} = scrollContainerHandle.current;
+			const {isHoveringToScroll, rtl} = scrollContainerHandle.current;
 			if (selectedItem && mutableRef.current.lastInputType !== 'key') {
 				const toIndex = Math.floor(((rtl ? scrollContentRect.right - lastMouseClientX : lastMouseClientX) + scrollContentNode.scrollLeft * (rtl ? -1 : 1)) / itemWidth);
 				mutableRef.current.lastInputType = 'scroll';
-				moveItems(!rtl ^ !(lastMouseClientX > scrollContentRect.width / 2) ? toIndex + 1 : toIndex - 1);
+				if (isHoveringToScroll) {
+					moveItems(!rtl ^ !(lastMouseClientX > scrollContentRect.width / 2) ? toIndex + 1 : toIndex - 1);
+				} else {
+					moveItems(toIndex);
+				}
 			}
 		};
 

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -84,15 +84,17 @@ const HoverToScrollBase = (props) => {
 	}, [direction, scrollContainerHandleRef]);
 
 	const startRaf = useCallback((job) => {
+		scrollContainerHandleRef.isHoveringToScroll = true;
 		if (typeof window === 'object') {
 			mutableRef.current.hoverToScrollRafId = window.requestAnimationFrame(job);
 			if (typeof document === 'object') {
 				document.addEventListener('keydown', handleGlobalKeyDown, {capture: true});
 			}
 		}
-	}, [handleGlobalKeyDown]);
+	}, [handleGlobalKeyDown, scrollContainerHandleRef]);
 
 	const stopRaf = useCallback(() => {
+		scrollContainerHandleRef.isHoveringToScroll = false;
 		if (typeof window === 'object' && mutableRef.current.hoverToScrollRafId !== null) {
 			window.cancelAnimationFrame(mutableRef.current.hoverToScrollRafId);
 			mutableRef.current.hoverToScrollRafId = null;
@@ -100,7 +102,7 @@ const HoverToScrollBase = (props) => {
 				document.removeEventListener('keydown', handleGlobalKeyDown, {capture: true});
 			}
 		}
-	}, [handleGlobalKeyDown]);
+	}, [handleGlobalKeyDown, scrollContainerHandleRef]);
 
 	const getPointerEnterHandler = useCallback((position) => {
 		if (typeof window === 'object') {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller does not scroll properly by wheel when `editable` is given and one item is selected.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update calculation for a position of the selected item to compensate the position only for hovering on edge not for a wheel input.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4786

### Comments
