### PR TITLE
WRO-4544: Remove limitation of the number of horizontal tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Popup`, `sandstone/PopupTabLayout`, `sandstone/FixedPopupPanels`, and `sandstone/FlexiblePopupPanels` to add `detail` property containing `inputType` in `onClose` event payload
 
+### Changed
+
+- `sandstone/TabLayout` to eliminate the horizontal maximum number of tabs
+
 ### Fixed
 
 - `sandstone/Scroller` to focus scroll thumb initially when it is used in Panels

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -335,7 +335,7 @@ const TabLayoutBase = kind({
 		}),
 		tabOrientation: ({orientation}) => orientation === 'vertical' ? 'horizontal' : 'vertical',
 		// limit to 6 tabs for horizontal orientation
-		tabs: ({children, orientation}) => {
+		tabs: ({children}) => {
 			const tabs = mapAndFilterChildren(children, (child) => (
 				Object.keys(child.props)
 					.filter((prop) => prop !== 'children' && prop !== 'id')

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -334,7 +334,6 @@ const TabLayoutBase = kind({
 			'--tablayout-expand-collapse-diff': ((orientation === 'vertical') ? scaleToRem(dimensions.tabs.normal - dimensions.tabs.collapsed) : 0)
 		}),
 		tabOrientation: ({orientation}) => orientation === 'vertical' ? 'horizontal' : 'vertical',
-		// limit to 6 tabs for horizontal orientation
 		tabs: ({children}) => {
 			const tabs = mapAndFilterChildren(children, (child) => (
 				Object.keys(child.props)

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -189,8 +189,6 @@ const TabLayoutBase = kind({
 		/**
 		 * Orientation of the tabs.
 		 *
-		 * Horizontal tabs support a maximum of six tabs.
-		 *
 		 * @type {('horizontal'|'vertical')}
 		 * @default 'vertical'
 		 * @public
@@ -343,7 +341,7 @@ const TabLayoutBase = kind({
 					.filter((prop) => prop !== 'children' && prop !== 'id')
 					.reduce((obj, key) => ({...obj, [key]: child.props[key]}), {})
 			));
-			return orientation === 'horizontal' && tabs.length > 6 ? tabs.slice(0, 6) : tabs;
+			return tabs;
 		}
 	},
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [X] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
2023 UX requirements have changed to the number of horizontal tabs 6->8

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove limitation of the number of horizontal tabs. 
Enact tab width automatically stretches on horizontal tabs and the number 8 can be changed to any number in the future. Rather than changing the limited number, I’d delegate the choice of horizontal tab numbers to apps with proper tab title length or only with icon.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I just removed check logic from the computed but I also thought the other option which is that
using the const variable like `MAX_HORIZONTAL_TABS = 8` or `MAC_HORIZONTAL_TABS = Number.MAX_SAFE_INTEGER` to make unlimited.  

### Links
[//]: # (Related issues, references)
WRO-4544

### Comments


Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>