### PR TITLE
WRO-5477: Fixed fixedPopupPanels.panel to place the last children component as intended.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/TabLayout` to eliminate the horizontal maximum number of tabs
 
 ### Fixed
-- `sandstone/FixedPopupPanels.Panel` to place children as intended
+
+- `sandstone/FixedPopupPanels.Panel` body to be filled vertically to place the last children as intended
 - `sandstone/Scroller` to focus scroll thumb initially when it is used in Panels
 - `sandstone/Scroller` thresholds for swapping items by pointer when `editable` is given
 - `sandstone/Scroller` to support RTL locales when `editable` is given

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/TabLayout` to eliminate the horizontal maximum number of tabs
 
 ### Fixed
-
+- `sandstone/FixedPopupPanels.Panel` to place children as intended
 - `sandstone/Scroller` to focus scroll thumb initially when it is used in Panels
 - `sandstone/Scroller` thresholds for swapping items by pointer when `editable` is given
 - `sandstone/Scroller` to support RTL locales when `editable` is given

--- a/FixedPopupPanels/FixedPopupPanels.module.less
+++ b/FixedPopupPanels/FixedPopupPanels.module.less
@@ -76,6 +76,6 @@
 		display: flex;
 		flex-direction: column;
 		padding: @sand-fixedpopuppanels-panel-body-padding;
-		flex: 0 1 auto;
+		flex: 1 1 auto;
 	}
 }

--- a/samples/sampler/stories/default/FixedPopupPanels.js
+++ b/samples/sampler/stories/default/FixedPopupPanels.js
@@ -58,15 +58,15 @@ export const _FixedPopupPanels = (args) => (
 			</Panel>
 			<Panel>
 				<Header>
-					<title>Another Panel</title>
-					<subtitle>This is the second page</subtitle>
+					<title>FixedPopupPanels Panel</title>
+					<subtitle>This is the third page</subtitle>
 				</Header>
-				<Item>Example Item 1 on Panel 2</Item>
-				<Item>Example Item 2 on Panel 2</Item>
+				<Item>Example Item 1 on Panel 3</Item>
+				<Item>Example Item 2 on Panel 3</Item>
 				<footer className={css.footer}>
-                        <Button>Button1</Button>
-                        <Button>Button2</Button>
-                </footer>
+					<Button>Button 1</Button>
+					<Button>Button 2</Button>
+				</footer>
 			</Panel>
 		</FixedPopupPanels>
 		<BodyText centered>Use CONTROLS to interact with FixedPopupPanels.</BodyText>

--- a/samples/sampler/stories/default/FixedPopupPanels.js
+++ b/samples/sampler/stories/default/FixedPopupPanels.js
@@ -1,9 +1,12 @@
-import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {action} from '@enact/storybook-utils/addons/actions';
-import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
+import Button from '@enact/sandstone/Button';
 import BodyText from '@enact/sandstone/BodyText';
 import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels';
 import Item from '@enact/sandstone/Item';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
+import {action} from '@enact/storybook-utils/addons/actions';
+import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
+
+import css from './FixedPopupPanels.module.less';
 
 const Config = mergeComponentMetadata('FixedPopupPanels', FixedPopupPanels);
 Config.defaultProps.position = 'right';
@@ -53,12 +56,24 @@ export const _FixedPopupPanels = (args) => (
 				<Item>Example Item 2 on Panel 2</Item>
 				<Item>Example Item 3 on Panel 2</Item>
 			</Panel>
+			<Panel>
+				<Header>
+					<title>Another Panel</title>
+					<subtitle>This is the second page</subtitle>
+				</Header>
+				<Item>Example Item 1 on Panel 2</Item>
+				<Item>Example Item 2 on Panel 2</Item>
+				<footer className={css.footer}>
+                        <Button>Button1</Button>
+                        <Button>Button2</Button>
+                </footer>
+			</Panel>
 		</FixedPopupPanels>
 		<BodyText centered>Use CONTROLS to interact with FixedPopupPanels.</BodyText>
 	</div>
 );
 
-range('index', _FixedPopupPanels, Config, {min: 0, max: 1}, 0);
+range('index', _FixedPopupPanels, Config, {min: 0, max: 2}, 0);
 boolean('open', _FixedPopupPanels, Config);
 select('position', _FixedPopupPanels, ['left', 'right'], Config);
 boolean('fullHeight', _FixedPopupPanels, Config);

--- a/samples/sampler/stories/default/FixedPopupPanels.module.less
+++ b/samples/sampler/stories/default/FixedPopupPanels.module.less
@@ -1,0 +1,5 @@
+.footer {
+    margin-top: auto;
+    padding-bottom: 30px;
+    text-align: center;
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Using fixedPopupPanels.panel with fullHeight option, footer cannot be placed as intended with padding or margin.
Since the flex-grow value of the panel body is set to 0, so the height of the body cannot be 100%. When setting padding value for the footer, the footer component overlaps with the component above it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed flex-grow value of fixedPopupPanels.panel body from 0 to 1 to place the last children component of the panel body as intended, not collapsed with other components.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-5477

### Comments
