### PR TITLE
WRO-5036: Tab does not collapse when enters a menu.

### DIFF
--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
+import {range, select} from '@enact/storybook-utils/addons/controls';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Item from '@enact/sandstone/Item';
@@ -77,7 +77,6 @@ export const WithVariableNumberOfTabs = (args) => {
 		<Panel>
 			<Header title="TabLayout" subtitle="With variable number of tabs" />
 			<TabLayout
-				collapsed={args['collapsed']}
 				orientation={args['orientation']}
 			>
 				{Array.from({length: tabs}, (v, i) => (
@@ -143,7 +142,6 @@ export const WithVariableNumberOfTabs = (args) => {
 };
 
 range('Number of Tabs', WithVariableNumberOfTabs, {groupId: 'TabLayout'}, {min: 0, max: 20, step: 1}, 3);
-boolean('collapsed', WithVariableNumberOfTabs, TabLayout);
 select('orientation', WithVariableNumberOfTabs, ['vertical', 'horizontal'], TabLayout, 'vertical');
 
 WithVariableNumberOfTabs.storyName = 'With variable number of tabs';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to remove 'collapsed' prop in TabLayout sample.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Remove 'collapsed' prop in TabLayout sample.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]:# (Related issues, references)
WRO-5036

### Comments
As a result of the discussion, we decided to remove 'collapsed' prop from sampler controls. None of the TCs related to this sample used 'collapsed' prop, and there is no related history.