### PR TITLE
WRO-4785: Update A11y UX (Picker / ScrollbarTrack)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/Scroller` scrollbar thumb to read out "Press ok button button to read text" additionally when `focusableScrollbar` prop is `byEnter`
+- `sandstone/Scroller` scrollbar thumb to read out 'leftmost', 'rightmost', 'topmost', or 'downmost' when reaching the end of the scroll
+- `sandstone/Picker` and `sandstone/RangePicker` to read out `title`
+
 ## [2.5.0-beta.1] - 2022-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Changed
 
-- `sandstone/Scroller` scrollbar thumb to read out "Press ok button button to read text" additionally when `focusableScrollbar` prop is `byEnter`
+- `sandstone/Scroller` scrollbar thumb to read out "press ok button to read text" additionally when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` scrollbar thumb to read out 'leftmost', 'rightmost', 'topmost', or 'downmost' when reaching the end of the scroll
 - `sandstone/Picker` and `sandstone/RangePicker` to read out `title`
 

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -211,6 +211,8 @@ const PickerBase = kind({
 		/**
 		 * The primary text of the `Picker`.
 		 *
+		 * The screen readers read out the title text when the `joined` prop is false
+		 *
 		 * @type {String}
 		 * @public
 		 */
@@ -326,7 +328,7 @@ const PickerBase = kind({
 		return (
 			<>
 				{title ? <Heading className={classnames(css.title, {[css.inlineTitle]: inlineTitle})} marqueeOn="hover" size="tiny">{title}</Heading> : null}
-				<PickerCore {...rest} data-webos-voice-labels-ext={voiceLabel} min={0} max={max} index={value} step={1} value={value}>
+				<PickerCore {...rest} data-webos-voice-labels-ext={voiceLabel} min={0} max={max} index={value} step={1} title={title} value={value}>
 					{children}
 				</PickerCore>
 			</>

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -378,6 +378,16 @@ const PickerBase = class extends ReactComponent {
 		step: PropTypes.number,
 
 		/**
+		 * The primary text of the `Picker`.
+		 *
+		 * The screen readers read out the title text when the `joined` prop is false
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		title: PropTypes.string,
+
+		/**
 		 * The type of picker. It determines the aria-label for the next and previous buttons.
 		 *
 		 * Depending on the `type`, `joined`, `decrementAriaLabel`, and `incrementAriaLabel`,
@@ -819,6 +829,7 @@ const PickerBase = class extends ReactComponent {
 
 	calcButtonLabel (next, valueText) {
 		const {decrementAriaLabel, incrementAriaLabel, orientation} = this.props;
+		const titleText = this.props.title ? this.props.title + ' ' : '';
 		let label;
 		if (orientation === 'vertical') {
 			label = next ? decrementAriaLabel : incrementAriaLabel;
@@ -827,13 +838,13 @@ const PickerBase = class extends ReactComponent {
 		}
 
 		if (label != null) {
-			return label;
+			return titleText + label;
 		}
 
 		if (this.props.type === 'number') {
-			return `${valueText} ${next ? $L('press ok button to increase the value') : $L('press ok button to decrease the value')}`;
+			return `${titleText}${valueText} ${next ? $L('press ok button to increase the value') : $L('press ok button to decrease the value')}`;
 		} else {
-			return `${valueText} ${next ? $L('next item') : $L('previous item')}`;
+			return `${titleText}${valueText} ${next ? $L('next item') : $L('previous item')}`;
 		}
 	}
 
@@ -918,6 +929,7 @@ const PickerBase = class extends ReactComponent {
 		delete rest.onSpotlightLeft;
 		delete rest.onSpotlightRight;
 		delete rest.onSpotlightUp;
+		delete rest.title;
 		delete rest.wrap;
 
 		const incrementIcon = selectIncIcon(this.props);

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -842,9 +842,9 @@ const PickerBase = class extends ReactComponent {
 		}
 
 		if (this.props.type === 'number') {
-			return `${titleText}${valueText} ${next ? $L('press ok button to increase the value') : $L('press ok button to decrease the value')}`;
+			return titleText + `${valueText} ${next ? $L('press ok button to increase the value') : $L('press ok button to decrease the value')}`;
 		} else {
-			return `${titleText}${valueText} ${next ? $L('next item') : $L('previous item')}`;
+			return titleText + `${valueText} ${next ? $L('next item') : $L('previous item')}`;
 		}
 	}
 

--- a/internal/Picker/tests/Picker-specs.js
+++ b/internal/Picker/tests/Picker-specs.js
@@ -518,6 +518,42 @@ describe('Picker Specs', () => {
 			expect(decrementButton).toHaveAttribute(expectedAttribute, expectedValue);
 		});
 
+		test('should set the aria-label attribute properly in the next icon button with title', () => {
+			const titleText = 'title text';
+			render(
+				<Picker index={1} max={3} min={0} title={titleText} value={1}>
+					<PickerItem>1</PickerItem>
+					<PickerItem>2</PickerItem>
+					<PickerItem>3</PickerItem>
+					<PickerItem>4</PickerItem>
+				</Picker>
+			);
+			const incrementButton = screen.getAllByRole('button')[0];
+
+			const expectedAttribute = 'aria-label';
+			const expectedValue = titleText + ' ' + '2 next item';
+
+			expect(incrementButton).toHaveAttribute(expectedAttribute, expectedValue);
+		});
+
+		test('should set the aria-label attribute properly in the previous icon button with title', () => {
+			const titleText = 'title text';
+			render(
+				<Picker index={1} max={3} min={0} title={titleText} value={1}>
+					<PickerItem>1</PickerItem>
+					<PickerItem>2</PickerItem>
+					<PickerItem>3</PickerItem>
+					<PickerItem>4</PickerItem>
+				</Picker>
+			);
+			const decrementButton = screen.getAllByRole('button')[1];
+
+			const expectedAttribute = 'aria-label';
+			const expectedValue = titleText + ' ' + '2 previous item';
+
+			expect(decrementButton).toHaveAttribute(expectedAttribute, expectedValue);
+		});
+
 		test('should set the aria-valuetext attribute properly to read it when changing the value', () => {
 			render(
 				<Picker index={1} max={3} min={0} value={1}>
@@ -606,6 +642,42 @@ describe('Picker Specs', () => {
 			const expectedAttribute = 'aria-label';
 
 			expect(picker).toHaveAttribute(expectedAttribute, customLabel);
+		});
+
+		test('should set picker `decrementAriaLabel` to decrement button with title', () => {
+			const titleText = 'title text';
+			const customLabel = 'custom decrement aria-label';
+			render(
+				<Picker decrementAriaLabel={customLabel} index={1} max={3} min={0} title={titleText} value={1}>
+					<PickerItem>1</PickerItem>
+					<PickerItem>2</PickerItem>
+					<PickerItem>3</PickerItem>
+					<PickerItem>4</PickerItem>
+				</Picker>
+			);
+			const picker = screen.getAllByRole('button')[1];
+
+			const expectedAttribute = 'aria-label';
+
+			expect(picker).toHaveAttribute(expectedAttribute, titleText + ' ' + customLabel);
+		});
+
+		test('should set picker `incrementAriaLabel` to decrement button with title', () => {
+			const titleText = 'title text';
+			const customLabel = 'custom increment aria-label';
+			render(
+				<Picker incrementAriaLabel={customLabel} index={1} max={3} min={0} title={titleText} value={1}>
+					<PickerItem>1</PickerItem>
+					<PickerItem>2</PickerItem>
+					<PickerItem>3</PickerItem>
+					<PickerItem>4</PickerItem>
+				</Picker>
+			);
+			const picker = screen.getAllByRole('button')[0];
+
+			const expectedAttribute = 'aria-label';
+
+			expect(picker).toHaveAttribute(expectedAttribute, titleText + ' ' + customLabel);
 		});
 
 		test('should set `aria-label` to joined picker', () => {

--- a/samples/qa-a11y/src/views/Picker.js
+++ b/samples/qa-a11y/src/views/Picker.js
@@ -53,6 +53,16 @@ const PickerView = () => (
 			>
 				{airports}
 			</Picker>
+
+			<Picker
+				alt="Horizontal with Title"
+				title='Title text'
+				inlineTitle
+				orientation="horizontal"
+				width="large"
+			>
+				{airports}
+			</Picker>
 		</Section>
 
 		<Section className={appCss.marginTop} title="Horizontal and Joined">

--- a/samples/qa-a11y/src/views/Picker.js
+++ b/samples/qa-a11y/src/views/Picker.js
@@ -56,9 +56,9 @@ const PickerView = () => (
 
 			<Picker
 				alt="Horizontal with Title"
-				title='Title text'
 				inlineTitle
 				orientation="horizontal"
+				title="Title text"
 				width="large"
 			>
 				{airports}

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
+import {range, select} from '@enact/storybook-utils/addons/controls';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Item from '@enact/sandstone/Item';
@@ -77,7 +77,6 @@ export const WithVariableNumberOfTabs = (args) => {
 		<Panel>
 			<Header title="TabLayout" subtitle="With variable number of tabs" />
 			<TabLayout
-				collapsed={args['collapsed']}
 				orientation={args['orientation']}
 			>
 				{Array.from({length: tabs}, (v, i) => (
@@ -143,7 +142,6 @@ export const WithVariableNumberOfTabs = (args) => {
 };
 
 range('Number of Tabs', WithVariableNumberOfTabs, {groupId: 'TabLayout'}, {min: 0, max: 20, step: 1}, 3);
-boolean('collapsed', WithVariableNumberOfTabs, TabLayout);
 select('orientation', WithVariableNumberOfTabs, ['vertical', 'horizontal'], TabLayout, 'vertical');
 
 WithVariableNumberOfTabs.storyName = 'With variable number of tabs';

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -74,17 +74,23 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 			if ((vertical && (isUpDown || isPageKey)) || (!vertical && (isLeftRight))) {
 				// Do nothing when (!vertical && pageKey)
 
-				if (!ev.repeat && announceRef.current.announce) {
-					announceRef.current.announce(
-						(isDown(keyCode) || isPageDown(keyCode)) && $L('DOWN') ||
-						(isUp(keyCode) || isPageUp(keyCode)) && $L('UP') ||
-						isLeft(keyCode) && $L('LEFT') ||
-						$L('RIGHT') // the case that isRight(keyCode) is true
-					);
-				}
-
 				if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
 					consumeEventWithScroll(scrollParam, ev);
+
+					setTimeout(()=>{
+						const updatedScrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
+						const horizontalReachLeftMost = rtl ? updatedScrollProgress === 1 : updatedScrollProgress === 0;
+						const horizontalReachRightMost = rtl ? updatedScrollProgress === 0 : updatedScrollProgress === 1;
+
+						if (!ev.repeat && announceRef.current.announce) {
+							announceRef.current.announce(
+								(isDown(keyCode) || isPageDown(keyCode)) && ((updatedScrollProgress === 1 && $L('DOWNMOST')) || $L('DOWN')) ||
+								(isUp(keyCode) || isPageUp(keyCode)) && ((updatedScrollProgress === 0 && $L('UPMOST')) || $L('UP')) ||
+								isLeft(keyCode) && ((horizontalReachLeftMost && $L('LEFTMOST')) || $L('LEFT')) ||
+								((horizontalReachRightMost && $L('RIGHTMOST')) || $L('RIGHT')) // the case that isRight(keyCode) is true
+							);
+						}
+					}, 500); // Wait for finishing scroll animation
 				}
 			}
 

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -71,28 +71,38 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 				},
 				scrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
 
-			if ((vertical && (isUpDown || isPageKey)) || (!vertical && (isLeftRight))) {
-				// Do nothing when (!vertical && pageKey)
+				if ((vertical && (isUpDown || isPageKey)) || (!vertical && (isLeftRight))) {
+					// Do nothing when (!vertical && pageKey)
 
-				if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
-					consumeEventWithScroll(scrollParam, ev);
+					if (!ev.repeat && announceRef.current.announce) {
+						announceRef.current.announce(
+							(isDown(keyCode) || isPageDown(keyCode)) && $L('DOWN') ||
+							(isUp(keyCode) || isPageUp(keyCode)) && $L('UP') ||
+							isLeft(keyCode) && $L('LEFT') ||
+							$L('RIGHT') // the case that isRight(keyCode) is true
+						);
+					}
 
-					setTimeout(() => {
-						const updatedScrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
-						const horizontalReachLeftMost = rtl ? updatedScrollProgress === 1 : updatedScrollProgress === 0;
-						const horizontalReachRightMost = rtl ? updatedScrollProgress === 0 : updatedScrollProgress === 1;
+					if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
+						consumeEventWithScroll(scrollParam, ev);
 
-						if (!ev.repeat && announceRef.current.announce) {
-							announceRef.current.announce(
-								(isDown(keyCode) || isPageDown(keyCode)) && ((updatedScrollProgress === 1 && $L('DOWNMOST')) || $L('DOWN')) ||
-								(isUp(keyCode) || isPageUp(keyCode)) && ((updatedScrollProgress === 0 && $L('UPMOST')) || $L('UP')) ||
-								isLeft(keyCode) && ((horizontalReachLeftMost && $L('LEFTMOST')) || $L('LEFT')) ||
-								((horizontalReachRightMost && $L('RIGHTMOST')) || $L('RIGHT')) // the case that isRight(keyCode) is true
-							);
-						}
-					}, 500); // Wait for finishing scroll animation
+						setTimeout(() => {
+							const updatedScrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
+							const horizontalReachLeftMost = rtl ? updatedScrollProgress === 1 : updatedScrollProgress === 0;
+							const horizontalReachRightMost = rtl ? updatedScrollProgress === 0 : updatedScrollProgress === 1;
+
+							// Current UX announce only after Scroll via Scrollthumb.
+							if (announceRef.current.announce && (updatedScrollProgress === 0 || updatedScrollProgress === 1)) {
+								announceRef.current.announce(
+									(isDown(keyCode) || isPageDown(keyCode)) && updatedScrollProgress === 1 && $L('DOWNMOST') ||
+									(isUp(keyCode) || isPageUp(keyCode)) && updatedScrollProgress === 0 && $L('UPMOST') ||
+									(isLeft(keyCode) && horizontalReachLeftMost && $L('LEFTMOST')) ||
+									(isRight(keyCode) && horizontalReachRightMost && $L('RIGHTMOST')) // the case that isRight(keyCode) is true
+								);
+							}
+						}, 500); // Wait for finishing scroll animation.
+					}
 				}
-			}
 
 			if (!ev.repeat) {
 				SpotlightAccelerator.reset();

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -19,6 +19,8 @@ const
 	isRight = is('right'),
 	isUp = is('up');
 
+const scrollStopWaiting = 500; // Wait for finishing scroll animation.
+
 const SpotlightAccelerator = new Accelerator();
 const SpottableDiv = Spottable('div');
 
@@ -100,7 +102,7 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 								(isRight(keyCode) && horizontalReachRightMost && $L('RIGHTMOST')) // the case that isRight(keyCode) is true
 							);
 						}
-					}, 500); // Wait for finishing scroll animation.
+					}, scrollStopWaiting);
 				}
 			}
 

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -71,38 +71,38 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 				},
 				scrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
 
-				if ((vertical && (isUpDown || isPageKey)) || (!vertical && (isLeftRight))) {
-					// Do nothing when (!vertical && pageKey)
+			if ((vertical && (isUpDown || isPageKey)) || (!vertical && (isLeftRight))) {
+				// Do nothing when (!vertical && pageKey)
 
-					if (!ev.repeat && announceRef.current.announce) {
-						announceRef.current.announce(
-							(isDown(keyCode) || isPageDown(keyCode)) && $L('DOWN') ||
-							(isUp(keyCode) || isPageUp(keyCode)) && $L('UP') ||
-							isLeft(keyCode) && $L('LEFT') ||
-							$L('RIGHT') // the case that isRight(keyCode) is true
-						);
-					}
-
-					if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
-						consumeEventWithScroll(scrollParam, ev);
-
-						setTimeout(() => {
-							const updatedScrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
-							const horizontalReachLeftMost = rtl ? updatedScrollProgress === 1 : updatedScrollProgress === 0;
-							const horizontalReachRightMost = rtl ? updatedScrollProgress === 0 : updatedScrollProgress === 1;
-
-							// Current UX announce only after Scroll via Scrollthumb.
-							if (announceRef.current.announce && (updatedScrollProgress === 0 || updatedScrollProgress === 1)) {
-								announceRef.current.announce(
-									(isDown(keyCode) || isPageDown(keyCode)) && updatedScrollProgress === 1 && $L('DOWNMOST') ||
-									(isUp(keyCode) || isPageUp(keyCode)) && updatedScrollProgress === 0 && $L('UPMOST') ||
-									(isLeft(keyCode) && horizontalReachLeftMost && $L('LEFTMOST')) ||
-									(isRight(keyCode) && horizontalReachRightMost && $L('RIGHTMOST')) // the case that isRight(keyCode) is true
-								);
-							}
-						}, 500); // Wait for finishing scroll animation.
-					}
+				if (!ev.repeat && announceRef.current.announce) {
+					announceRef.current.announce(
+						(isDown(keyCode) || isPageDown(keyCode)) && $L('DOWN') ||
+						(isUp(keyCode) || isPageUp(keyCode)) && $L('UP') ||
+						isLeft(keyCode) && $L('LEFT') ||
+						$L('RIGHT') // the case that isRight(keyCode) is true
+					);
 				}
+
+				if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
+					consumeEventWithScroll(scrollParam, ev);
+
+					setTimeout(() => {
+						const updatedScrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
+						const horizontalReachLeftMost = rtl ? updatedScrollProgress === 1 : updatedScrollProgress === 0;
+						const horizontalReachRightMost = rtl ? updatedScrollProgress === 0 : updatedScrollProgress === 1;
+
+						// Current UX announce only after Scroll via Scrollthumb.
+						if (announceRef.current.announce && (updatedScrollProgress === 0 || updatedScrollProgress === 1)) {
+							announceRef.current.announce(
+								(isDown(keyCode) || isPageDown(keyCode)) && updatedScrollProgress === 1 && $L('DOWNMOST') ||
+								(isUp(keyCode) || isPageUp(keyCode)) && updatedScrollProgress === 0 && $L('UPMOST') ||
+								(isLeft(keyCode) && horizontalReachLeftMost && $L('LEFTMOST')) ||
+								(isRight(keyCode) && horizontalReachRightMost && $L('RIGHTMOST')) // the case that isRight(keyCode) is true
+							);
+						}
+					}, 500); // Wait for finishing scroll animation.
+				}
+			}
 
 			if (!ev.repeat) {
 				SpotlightAccelerator.reset();

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -77,7 +77,7 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 				if (ev.repeat || !isNaN(scrollProgress) && ((scrollParam.isForward && scrollProgress !== 1) || (!scrollParam.isForward && scrollProgress !== 0))) {
 					consumeEventWithScroll(scrollParam, ev);
 
-					setTimeout(()=>{
+					setTimeout(() => {
 						const updatedScrollProgress = Number(ref.current && ref.current.style.getPropertyValue('--scrollbar-thumb-progress-ratio'));
 						const horizontalReachLeftMost = rtl ? updatedScrollProgress === 1 : updatedScrollProgress === 0;
 						const horizontalReachRightMost = rtl ? updatedScrollProgress === 0 : updatedScrollProgress === 1;

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -488,9 +488,11 @@ const useScroll = (props) => {
 		scrollContentRef
 	});
 
+	const scrollThumbAriaLabelForByEnter = focusableScrollbar === 'byEnter' ? $L('press ok button to read text') : '';
+
 	assignProperties('horizontalScrollbarProps', {
 		...scrollbarProps,
-		'aria-label': horizontalScrollThumbAriaLabel == null ? $L('scroll left or right with left right button') : horizontalScrollThumbAriaLabel,
+		'aria-label': horizontalScrollThumbAriaLabel == null ? $L('scroll left or right with left right button') + scrollThumbAriaLabelForByEnter : horizontalScrollThumbAriaLabel,
 		className: [css.horizontalScrollbar],
 		focusableScrollbar,
 		scrollbarHandle: horizontalScrollbarHandle
@@ -498,7 +500,7 @@ const useScroll = (props) => {
 
 	assignProperties('verticalScrollbarProps', {
 		...scrollbarProps,
-		'aria-label': verticalScrollThumbAriaLabel == null ? $L('scroll up or down with up down button') : verticalScrollThumbAriaLabel,
+		'aria-label': verticalScrollThumbAriaLabel == null ? $L('scroll up or down with up down button') + scrollThumbAriaLabelForByEnter : verticalScrollThumbAriaLabel,
 		className: [css.verticalScrollbar],
 		focusableScrollbar,
 		scrollbarHandle: verticalScrollbarHandle

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -488,7 +488,7 @@ const useScroll = (props) => {
 		scrollContentRef
 	});
 
-	const scrollThumbAriaLabelForByEnter = focusableScrollbar === 'byEnter' ? $L('press ok button to read text') : '';
+	const scrollThumbAriaLabelForByEnter = focusableScrollbar === 'byEnter' ? ' ' + $L('press ok button to read text') : '';
 
 	assignProperties('horizontalScrollbarProps', {
 		...scrollbarProps,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was A11y UX update for Picker / ScrollbarTrack.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I changed `sandstone/Scroller` scrollbar thumb to read out "Press ok button button to read text" additionally when `focusableScrollbar` prop is `byEnter`
I changed `sandstone/Scroller` scrollbar thumb to read out 'leftmost', 'rightmost', 'topmost', or 'downmost' when reaching the end of the scroll
I changed `sandstone/Picker` and `sandstone/RangePicker` to read out `title`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4785

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)