### PR TITLE
WRO-4784: Added A11y feature for editable scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/Scroller` to support read out feature for A11y when `editable` is given
+
 ### Fixed
+
 - `sandstone/Scroller` to position the focused item into scroller view
 
 ## [2.5.0-beta.1] - 2022-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Scroller` to support read out feature for A11y when `editable` is given
+- `sandstone/Scroller` read out feature to support A11y when `editable` is given
 
 ### Changed
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -4,9 +4,13 @@ import {is} from '@enact/core/keymap';
 import {mergeClassNameMaps} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
 import Accelerator from '@enact/spotlight/Accelerator';
+import {Announce} from '@enact/ui/AnnounceDecorator';
 import classNames from 'classnames';
+import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
 import {useCallback, useEffect, useRef} from 'react';
+
+import $L from '../internal/$L';
 
 import componentCss from './EditableWrapper.module.less';
 
@@ -65,6 +69,7 @@ const EditableWrapper = (props) => {
 
 		// DOM elements
 		selectedItem: null,
+		selectedItemLabel: '',
 		rearrangedItems: [],
 
 		// Indices
@@ -81,8 +86,11 @@ const EditableWrapper = (props) => {
 		lastMouseClientX: null,
 
 		// Last InputType which moves Items
-		lastInputType: null
+		lastInputType: null,
+		lastInputDirection: null
 	});
+
+	const announceRef = useRef({});
 
 	// Functions
 
@@ -93,6 +101,7 @@ const EditableWrapper = (props) => {
 		selectedItem?.classList.remove(componentCss.selected, customCss.selected, componentCss.rearranged);
 
 		mutableRef.current.selectedItem = null;
+		mutableRef.current.selectedItemLabel = '';
 		mutableRef.current.lastMoveDirection = null;
 		mutableRef.current.prevToIndex = null;
 		wrapperRef.current.style.setProperty('--selected-item-offset', '0px');
@@ -145,9 +154,14 @@ const EditableWrapper = (props) => {
 
 			item.classList.add(componentCss.selected, customCss.selected);
 			mutableRef.current.selectedItem = item;
+			mutableRef.current.selectedItemLabel = (item.getAttribute('data-item-label') || item.textContent) + ' ';
 
 			mutableRef.current.fromIndex = Number(item.style.order) - 1;
 			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
+
+			announceRef.current.announce(
+				mutableRef.current.selectedItemLabel + $L('Move left and right or press up key to delete')
+			);
 		}
 	}, [customCss.selected]);
 
@@ -177,6 +191,23 @@ const EditableWrapper = (props) => {
 		ev.stopPropagation();
 	}, [editable, finalizeOrders, findItemNode, reset, startEditing]);
 
+	const readOutCurrentPosition = useCallback((neighborItem) => {
+		const {lastInputDirection, lastInputType, selectedItemLabel} = mutableRef.current;
+		if (lastInputType === 'key') {
+			if (lastInputDirection === 'left') {
+				announceRef.current.announce(
+					new IString($L('{selectedItem} moved to the left of {neighborItem}')).format({selectedItem: selectedItemLabel, neighborItem}),
+					true
+				);
+			} else {
+				announceRef.current.announce(
+					new IString($L('{selectedItem} moved to the right of {neighborItem}')).format({selectedItem: selectedItemLabel, neighborItem}),
+					true
+				);
+			}
+		}
+	}, [scrollContainerHandle]);
+
 	// Add rearranged items
 	const addRearrangedItems = useCallback(({moveDirection, toIndex}) => {
 		// Set the moveDirection to css variable
@@ -186,6 +217,7 @@ const EditableWrapper = (props) => {
 		const {fromIndex, rearrangedItems, selectedItem} = mutableRef.current;
 		const getNextElement = (item) => moveDirection > 0 ? item.nextElementSibling : item.previousElementSibling;
 		let sibling = getNextElement(selectedItem);
+		let lastRearrangedItem;
 		let start = moveDirection > 0 ? toIndex : fromIndex;
 		let end = moveDirection > 0 ? fromIndex : toIndex;
 
@@ -196,23 +228,33 @@ const EditableWrapper = (props) => {
 				rearrangedItems.push(sibling);
 			}
 
+			lastRearrangedItem = sibling;
 			sibling = getNextElement(sibling);
 			start--;
 		}
 
+		if (lastRearrangedItem) {
+			readOutCurrentPosition(lastRearrangedItem.getAttribute('data-item-label') || lastRearrangedItem.textContent);
+		}
+
 		mutableRef.current.lastMoveDirection = moveDirection;
 
-	}, [scrollContainerHandle]);
+	}, [readOutCurrentPosition]);
 
 	const removeRearrangedItems = useCallback((numToRemove) => {
 		const {rearrangedItems} = mutableRef.current;
+		let toItem = null;
 		if (rearrangedItems.length > 0) {
 			for (let i = 0; i < numToRemove; i++) {
-				const toItem = rearrangedItems.pop();
+				toItem = rearrangedItems.pop();
 				toItem?.classList.remove(componentCss.rearrangedTransform);
 			}
 		}
-	}, []);
+
+		if (toItem) {
+			readOutCurrentPosition(toItem.getAttribute('data-item-label') || toItem.textContent);
+		}
+	}, [readOutCurrentPosition]);
 
 	// Move items
 	const moveItems = useCallback((toIndex) => {
@@ -276,8 +318,21 @@ const EditableWrapper = (props) => {
 		}
 
 		mutableRef.current.lastInputType = 'key';
+		mutableRef.current.lastInputDirection = is('left', keyCode) ? 'left' : 'right';
 		moveItems(toIndex);
-	}, [moveItems, scrollContainerHandle, scrollContentRef]);
+
+		if (toIndex <= 0) {
+			announceRef.current.announce(
+				(is('left', keyCode) && !rtl && $L('LEFTMOST')) ||
+				(is('right', keyCode) && rtl && $L('RIGHTMOST'))
+			);
+		} else if (toIndex >= dataSize - 1) {
+			announceRef.current.announce(
+				(is('right', keyCode) && !rtl &&  $L('RIGHTMOST')) ||
+				(is('left', keyCode) && rtl && $L('LEFTMOST'))
+			);
+		}
+	}, [dataSize, moveItems, scrollContainerHandle, scrollContentRef]);
 
 	// Remove an item
 	const removeItem = useCallback(() => {
@@ -342,7 +397,7 @@ const EditableWrapper = (props) => {
 
 	const handleKeyDown = useCallback((ev) => {
 		const {keyCode, repeat, target} = ev;
-		const {selectedItem} = mutableRef.current;
+		const {selectedItem, selectedItemLabel} = mutableRef.current;
 		const targetItemNode = findItemNode(target);
 
 		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
@@ -351,6 +406,13 @@ const EditableWrapper = (props) => {
 					const orders = finalizeOrders();
 					forwardCustom('onComplete', () => ({orders}))({}, editable);
 					reset();
+
+					setTimeout(() => {
+						announceRef.current.announce(
+							selectedItemLabel + $L('move complete'),
+							true
+						);
+					}, 300); // An arbitrary delay at a level that is not ignored by the new focus element
 				} else if (targetItemNode) {
 					startEditing(targetItemNode);
 				}
@@ -453,6 +515,7 @@ const EditableWrapper = (props) => {
 			ref={wrapperRef}
 		>
 			{children}
+			<Announce key="editable-wrapper-announce" ref={announceRef} />
 		</div>
 	);
 };

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -14,6 +14,8 @@ import $L from '../internal/$L';
 
 import componentCss from './EditableWrapper.module.less';
 
+const completeAnnounceDelay = 300; // An arbitrary delay at a level that is not ignored by the new focus element
+
 /**
  * The shape for editable of [Scroller]{@link sandstone/Scroller}.
  *
@@ -412,7 +414,7 @@ const EditableWrapper = (props) => {
 							selectedItemLabel + $L('move complete'),
 							true
 						);
-					}, 300); // An arbitrary delay at a level that is not ignored by the new focus element
+					}, completeAnnounceDelay);
 				} else if (targetItemNode) {
 					startEditing(targetItemNode);
 				}

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -154,7 +154,7 @@ const EditableWrapper = (props) => {
 
 			item.classList.add(componentCss.selected, customCss.selected);
 			mutableRef.current.selectedItem = item;
-			mutableRef.current.selectedItemLabel = (item.getAttribute('data-item-label') || item.textContent) + ' ';
+			mutableRef.current.selectedItemLabel = (item.ariaLabel || item.textContent) + ' ';
 
 			mutableRef.current.fromIndex = Number(item.style.order) - 1;
 			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
@@ -234,7 +234,7 @@ const EditableWrapper = (props) => {
 		}
 
 		if (lastRearrangedItem) {
-			readOutCurrentPosition(lastRearrangedItem.getAttribute('data-item-label') || lastRearrangedItem.textContent);
+			readOutCurrentPosition(lastRearrangedItem.ariaLabel || lastRearrangedItem.textContent);
 		}
 
 		mutableRef.current.lastMoveDirection = moveDirection;
@@ -252,7 +252,7 @@ const EditableWrapper = (props) => {
 		}
 
 		if (toItem) {
-			readOutCurrentPosition(toItem.getAttribute('data-item-label') || toItem.textContent);
+			readOutCurrentPosition(toItem.ariaLabel || toItem.textContent);
 		}
 	}, [readOutCurrentPosition]);
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -206,7 +206,7 @@ const EditableWrapper = (props) => {
 				);
 			}
 		}
-	}, [scrollContainerHandle]);
+	}, []);
 
 	// Add rearranged items
 	const addRearrangedItems = useCallback(({moveDirection, toIndex}) => {
@@ -239,7 +239,7 @@ const EditableWrapper = (props) => {
 
 		mutableRef.current.lastMoveDirection = moveDirection;
 
-	}, [readOutCurrentPosition]);
+	}, [readOutCurrentPosition, scrollContainerHandle]);
 
 	const removeRearrangedItems = useCallback((numToRemove) => {
 		const {rearrangedItems} = mutableRef.current;

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -272,11 +272,12 @@ export const EditableList = (args) => {
 			{
 				items.map((item, index) => {
 					return (
-						<div key={item.index} className={css.itemWrapper} data-index={item.index} style={{order: index + 1}}>
+						<div key={item.index} className={css.itemWrapper} data-item-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 							<div className={css.removeButtonContainer}>
 								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
 							</div>
 							<ImageItem
+								aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
 								src={item.src}
 								className={css.imageItem}
 							>

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -274,7 +274,7 @@ export const EditableList = (args) => {
 					return (
 						<div key={item.index} className={css.itemWrapper} data-index={item.index} style={{order: index + 1}}>
 							<div className={css.removeButtonContainer}>
-								<Button className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
+								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
 							</div>
 							<ImageItem
 								src={item.src}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -272,7 +272,7 @@ export const EditableList = (args) => {
 			{
 				items.map((item, index) => {
 					return (
-						<div key={item.index} className={css.itemWrapper} data-item-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+						<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 							<div className={css.removeButtonContainer}>
 								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
 							</div>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Need to support A11y feature on for editable scroller

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Specs : 
* When focus item in Scroller (I fixed sampler. It should be implemented on App)
<item label> + <"Edit mode to press and hold OK key")
* When entering edit mode and focusing for the first time
<item label> + <"Move left and right or press up key to delete")
*  press left / right
<item label> + <"moved to the left of"> + <item label.position+1>
<item label> + <"moved to the right of"> + <item label.position-1>
App should add `data-item-label` on the each item's container
* press left/right when focus on leftmost/rightmost
<"Leftmost">
<"Rightmost">
* (edit mode) press up  (I fixed sampler. It should be implemented on App)
<"Delete"> + <"button">
* done (OK key in edit mode)
<item label> + <"move complete">
=> Since the focus element is read again after re-rendering, it is implemented to call `annouce` after a arbitrary 300ms.
There is other way to modify the label twice in the app, But I thought this was not good way to guide.  So I just used setTimout.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4784

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
