### PR TITLE
WRO-6793: Add delay before long Press in ui-test(QWT-2389).

### DIFF
--- a/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
+++ b/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
@@ -37,7 +37,7 @@ describe('VideoPlayer', function () {
 			await Page.delay(5000);
 
 			const sliderWidth = await videoPlayerDefault.slider.getCSSProperty('width');
-			
+
 			expect(await sliderWidth.value).to.not.equal('0px');
 		});
 

--- a/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
+++ b/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
@@ -34,10 +34,10 @@ describe('VideoPlayer', function () {
 			expect(await initialSliderWidth.value).to.equal('0px');
 
 			await videoPlayerDefault.playButton.click();
-			await Page.delay(2000);
+			await Page.delay(5000);
 
 			const sliderWidth = await videoPlayerDefault.slider.getCSSProperty('width');
-
+			
 			expect(await sliderWidth.value).to.not.equal('0px');
 		});
 

--- a/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWT-2389-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWT-2389-specs.js
@@ -14,6 +14,7 @@ describe('VirtualList with multiple spottables in an item', function () {
 		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
 		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(0);
 		// 5-way Down hold for 1 second.
+		await Page.delay(500);
 		await browser.keys('Down Arrow');
 		// Spotlight still on any item's starIcon.
 		// '5-way down' long pressure is too fast to catch focus element in Jenkins. Therefore, test to catch focus properly with 5-way down.


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to add delay before long press in ui-test.
- Need to add delay wait for loading video in ui-test(VideoPlayer).
### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add delay before long press in ui-test.
- Add delay wait for loading video in ui-test(VideoPlayer).
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]:# (Related issues, references)
WRO-6793

### Comments
It only reproduced in jenkins.