### PR TITLE
WRO-6848: Provide `stopPropagation` method in `onBack` event payload of `WizardPanels`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - npm config set prefer-offline false
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRO-6848 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - npm config set prefer-offline false
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=feature/WRO-6848 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/WizardPanels` to provide `stopPropagation` method in `onBack` event payload
+
 ## [2.5.0-rc.1] - 2022-06-23
 
 ### Added
@@ -18,7 +24,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` to position the focused item into scroller view
-- `sandstone/WizardPanels` to provide `stopPropagation` method in `onBack` event payload
 
 ## [2.5.0-beta.1] - 2022-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` to position the focused item into scroller view
+- `sandstone/WizardPanels` to provide `stopPropagation` method in `onBack` event payload
 
 ## [2.5.0-beta.1] - 2022-05-31
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -1,4 +1,4 @@
-import handle, {adaptEvent, forProp, forwardWithPrevent, not} from '@enact/core/handle';
+import handle, {adaptEvent, forProp, forwardCustomWithPrevent, forwardWithPrevent, not} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import useChainRefs from '@enact/core/useChainRefs';
@@ -649,7 +649,7 @@ const WizardPanelsDecorator = compose(
 	CancelDecorator({
 		cancel: 'onChange',
 		shouldCancel: handle(
-			adaptEvent(() => ({type: 'onBack'}), forwardWithPrevent('onBack')),
+			forwardCustomWithPrevent('onBack'),
 			not(forProp('noPrevButton', true))
 		)
 	}),

--- a/WizardPanels/tests/WizardPanels-specs.js
+++ b/WizardPanels/tests/WizardPanels-specs.js
@@ -638,10 +638,9 @@ describe('WizardPanel Specs', () => {
 				expect(actual).toHaveClass('current');
 			});
 			await waitFor(() => {
-				const expectedEvent = {type: 'onBack'};
-				const actualEvent = spy.mock.calls.length && spy.mock.calls[0][0];
+				const expected = {type: 'onBack', stopPropagation: expect.any(Function)};
 
-				expect(actualEvent).toMatchObject(expectedEvent);
+				expect(spy).toBeCalledWith(expect.objectContaining(expected));
 			});
 		}
 	);
@@ -666,10 +665,9 @@ describe('WizardPanel Specs', () => {
 				expect(actual).toHaveClass('current');
 			});
 			await waitFor(() => {
-				const expectedEvent = {type: 'onBack'};
-				const actualEvent = spy.mock.calls.length && spy.mock.calls[0][0];
+				const expected = {type: 'onBack', stopPropagation: expect.any(Function)};
 
-				expect(actualEvent).toMatchObject(expectedEvent);
+				expect(spy).toBeCalledWith(expect.objectContaining(expected));
 			});
 		}
 	);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The event payload of `onBack` event of `WizardPanels` does not have `stopPropagation` method.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This PR changes `WizardPanels` to provide `stopPropagation` method in `onBack` event payload.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This PR relies on enactjs/enact#3067.

### Links
[//]: # (Related issues, references)
WRO-6848
enactjs/enact#2982
enactjs/sandstone#1120
enactjs/sandstone#1136

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
