### PR TITLE
WRO-2688: Prevent to webfont loading when the webos font is installed

### DIFF
--- a/styles/internal/fonts.less
+++ b/styles/internal/fonts.less
@@ -27,16 +27,15 @@
 @font-system-src-sandstone-number-600:  local("LG Smart UI NUMBER SemiBold"), local("LGSmartUINUMBER-SemiBold");
 @font-system-src-sandstone-number-700:  local("LG Smart UI NUMBER Bold"), local("LGSmartUINUMBER-Bold");
 
-@font-system-src-non-latin-300:  local("LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular");
-@font-system-src-non-latin-400:  local("LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular");
-@font-system-src-non-latin-600:  local("LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold");
-@font-system-src-non-latin-700:  local("LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold");
+@font-web-src-th-locale: url(https://fonts.gstatic.com/s/notosansthai/v13/iJWQBXeUZi_OHPqn4wq6hQ2_hbJ1xyN9wd43SofNWcdfKI2h.woff2) format('woff2');
+
+@font-system-src-non-latin-300:  local("LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular"), @font-web-src-th-locale;
+@font-system-src-non-latin-400:  local("LG Smart UI AR HE TH Regular"), local("LGSmartUIARHETH-Regular"), @font-web-src-th-locale;
+@font-system-src-non-latin-600:  local("LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold"), @font-web-src-th-locale;
+@font-system-src-non-latin-700:  local("LG Smart UI AR HE TH SemiBold"), local("LGSmartUIARHETH-SemiBold"), @font-web-src-th-locale;
 
 @font-system-src-sandstone-icons:  local("Sandstone Icons"), local("SandstoneIcons"), url("../../fonts/Sandstone_Icons.ttf") format("truetype");
 @font-system-src-lg-icons:         @font-system-src-sandstone-400, local("LG Smart UI Dingbat"), local("LGSmartUIDingbat");
-
-// ----- WEB FONT NAMES ------
-@font-web-src-th-locale-normal: url(https://fonts.gstatic.com/s/notosansthai/v13/iJWQBXeUZi_OHPqn4wq6hQ2_hbJ1xyN9wd43SofNWcdfKI2h.woff2) format('woff2');
 
 // Localized fonts
 // Order correlates with load and priority order. Later fonts are stacked on top of earlier fonts.
@@ -116,9 +115,6 @@
 .buildFontFamily("@{font-family-base-name} Number"; @font-system-src-sandstone-number-300; @font-system-src-sandstone-condensed-300; 300);
 .buildFontFamily("@{font-family-base-name} Number"; @font-system-src-sandstone-number-600; @font-system-src-sandstone-condensed-600; 600);
 .buildFontFamily("@{font-family-base-name} Number"; @font-system-src-sandstone-number-700; @font-system-src-sandstone-condensed-700; 700);
-
-/* ----- Manual Sandstone Locale Fonts (Stacking onto "Sandstone") ------ */
-.buildFontFace(@font-family-base-name; @font-web-src-th-locale-normal; 300 400 600 700);
 
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-400);
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-300; 300);

--- a/styles/internal/fonts.less
+++ b/styles/internal/fonts.less
@@ -116,6 +116,7 @@
 .buildFontFamily("@{font-family-base-name} Number"; @font-system-src-sandstone-number-600; @font-system-src-sandstone-condensed-600; 600);
 .buildFontFamily("@{font-family-base-name} Number"; @font-system-src-sandstone-number-700; @font-system-src-sandstone-condensed-700; 700);
 
+/* ----- Manual Sandstone Locale Fonts (Stacking onto "Sandstone") ------ */
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-400);
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-300; 300);
 .buildFontFace(@font-family-base-name; @font-system-src-non-latin-600; 600);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
TH Webfont always loads and it occur cause flicker.
The flicker cause screenshot test fail on Khmer TC.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Prevent to webfont loading when the webos font is installed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-2688
https://github.com/enactjs/sandstone/pull/1138

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)