### PR TITLE
WRO-7201: Fixed FixedPopupPanels, PopupTabLayout, and TabLayout onKeyDown handlers to check whether event target is INPUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/FixedPopupPanels`, `sandstone/PopupTabLayout`, and `sandstone/TabLayout` to move caret with left and right keys in InputField
+
 ## [2.5.0-rc.1] - 2022-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/FixedPopupPanels`, `sandstone/PopupTabLayout`, and `sandstone/TabLayout` to move caret with left and right keys in InputField
+- `sandstone/FixedPopupPanels`, `sandstone/PopupTabLayout`, and `sandstone/TabLayout` to move caret in InputField with left and right keys
 
 ## [2.5.0-rc.1] - 2022-06-23
 

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -46,6 +46,13 @@ const fixedPopupPanelsHandlers = {
 		forProp('rtl', false),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
+		(ev) => {
+			if (ev.target.tagName === 'INPUT') {
+				ev.stopPropagation();
+				return false;
+			}
+			return true;
+		},
 		({target}) => (document.querySelector(`section.${css.body}`).contains(target)),
 		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forwardCustom('onBack'),

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -43,16 +43,10 @@ const FixedPopupPanelsDecorator = compose(
 const fixedPopupPanelsHandlers = {
 	onKeyDown: handle(
 		forward('onKeyDown'),
+		({target}) => (target.tagName !== 'INPUT'),
 		forProp('rtl', false),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
-		(ev) => {
-			if (ev.target.tagName === 'INPUT') {
-				ev.stopPropagation();
-				return false;
-			}
-			return true;
-		},
 		({target}) => (document.querySelector(`section.${css.body}`).contains(target)),
 		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forwardCustom('onBack'),

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -367,6 +367,7 @@ const tabPanelsHandlers = {
 	),
 	onKeyDown: handle(
 		forward('onKeyDown'),
+		({target}) => (target.tagName !== 'INPUT'),
 		forProp('rtl', false),
 		forKey('left'),
 		(ev, {index}) => (index > 0),
@@ -379,9 +380,6 @@ const tabPanelsHandlers = {
 		},
 		(ev) => {
 			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
-				ev.stopPropagation();
-				return false;
-			} else if (ev.target.tagName === 'INPUT') {
 				ev.stopPropagation();
 				return false;
 			}

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -381,6 +381,9 @@ const tabPanelsHandlers = {
 			if (getContainerNode(getContainersForNode(ev.target).pop()).tagName === 'HEADER') {
 				ev.stopPropagation();
 				return false;
+			} else if (ev.target.tagName === 'INPUT') {
+				ev.stopPropagation();
+				return false;
 			}
 			return document.querySelector(`section.${componentCss.body}`).contains(ev.target);
 		},

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -250,7 +250,7 @@ const TabLayoutBase = kind({
 			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
 			const direction = getDirection(keyCode);
 
-			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target)) {
+			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target) && target.tagName !== 'INPUT') {
 				Spotlight.setPointerMode(false);
 				ev.preventDefault();
 

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -552,7 +552,7 @@ const WithVariousItemsSamplesBase = ({args, rtl}) => {
 							<br />
 							<Input size="small" value="Input" noBackButton />
 							<Button onClick={handleOpenPopup} size="small">Open</Button>
-							<InputField/>
+							<InputField />
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
 								<Button onClick={handleClosePopup}>Close</Button>
 								<Button>Dummy</Button>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -10,7 +10,7 @@ import Button from '@enact/sandstone/Button';
 import {FixedPopupPanels, Panel, Header} from '@enact/sandstone/FixedPopupPanels';
 import Dropdown from '@enact/sandstone/Dropdown';
 import Icon from '@enact/sandstone/Icon';
-import Input from '@enact/sandstone/Input';
+import Input, {InputField} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import Popup from '@enact/sandstone/Popup';
 import Scroller from '@enact/sandstone/Scroller';
@@ -552,6 +552,7 @@ const WithVariousItemsSamplesBase = ({args, rtl}) => {
 							<br />
 							<Input size="small" value="Input" noBackButton />
 							<Button onClick={handleOpenPopup} size="small">Open</Button>
+							<InputField/>
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
 								<Button onClick={handleClosePopup}>Close</Button>
 								<Button>Dummy</Button>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -552,7 +552,7 @@ const WithVariousItemsSamplesBase = ({args, rtl}) => {
 							<br />
 							<Input size="small" value="Input" noBackButton />
 							<Button onClick={handleOpenPopup} size="small">Open</Button>
-							<InputField />
+							<InputField defaultValue="value" />
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>
 								<Button onClick={handleClosePopup}>Close</Button>
 								<Button>Dummy</Button>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -5,7 +5,7 @@ import Button from '@enact/sandstone/Button';
 import Dropdown from '@enact/sandstone/Dropdown';
 import Heading from '@enact/sandstone/Heading';
 import Icon from '@enact/sandstone/Icon';
-import Input from '@enact/sandstone/Input';
+import Input, {InputField} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import {Panel, Header} from '@enact/sandstone/Panels';
 import Popup from '@enact/sandstone/Popup';
@@ -275,6 +275,7 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 						<TabPanel>
 							<Header title="Advanced Audio" type="compact" />
 							<Item>Balance</Item>
+							<InputField/>
 							<Input size="small" value="Input" noBackButton />
 							<Button onClick={handleOpenPopup} size="small" >Open</Button>
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -275,7 +275,7 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 						<TabPanel>
 							<Header title="Advanced Audio" type="compact" />
 							<Item>Balance</Item>
-							<InputField />
+							<InputField defaultValue="value" />
 							<Input size="small" value="Input" noBackButton />
 							<Button onClick={handleOpenPopup} size="small" >Open</Button>
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -275,7 +275,7 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 						<TabPanel>
 							<Header title="Advanced Audio" type="compact" />
 							<Item>Balance</Item>
-							<InputField/>
+							<InputField />
 							<Input size="small" value="Input" noBackButton />
 							<Button onClick={handleOpenPopup} size="small" >Open</Button>
 							<Popup open={popupOpen} onKeyUp={handleKeyUpOnPopup}>

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -464,7 +464,7 @@ export const WithInputField = () => {
 			<Header title="TabLayout" subtitle="With InputField" />
 			<TabLayout>
 				<Tab title="Tab 0">
-					<InputField/>
+					<InputField />
 				</Tab>
 			</TabLayout>
 		</Panel>

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -464,7 +464,9 @@ export const WithInputField = () => {
 			<Header title="TabLayout" subtitle="With InputField" />
 			<TabLayout>
 				<Tab title="Tab 0">
-					<InputField defaultValue="value" />
+					<InputField defaultValue="Value 0" /><br /><br />
+					<InputField defaultValue="Value 1" /><br /><br />
+					<InputField defaultValue="Value 2" /><br /><br />
 				</Tab>
 			</TabLayout>
 		</Panel>

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -464,7 +464,7 @@ export const WithInputField = () => {
 			<Header title="TabLayout" subtitle="With InputField" />
 			<TabLayout>
 				<Tab title="Tab 0">
-					<InputField />
+					<InputField defaultValue="value" />
 				</Tab>
 			</TabLayout>
 		</Panel>

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -3,6 +3,7 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {range, select} from '@enact/storybook-utils/addons/controls';
 import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
+import {InputField} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
 import {Panel, Header} from '@enact/sandstone/Panels';
 import {Scroller} from '@enact/sandstone/Scroller';
@@ -456,3 +457,18 @@ WithControlledIndex.parameters = {
 		noPanel: true
 	}
 };
+
+export const WithInputField = () => {
+	return (
+		<Panel>
+			<Header title="TabLayout" subtitle="With InputField" />
+			<TabLayout>
+				<Tab title="Tab 0">
+					<InputField/>
+				</Tab>
+			</TabLayout>
+		</Panel>
+	);
+};
+
+WithInputField.storyName = 'With InputField';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unable to move caret using left and right keys in the InputField, when InputField is located in FixedPopupPanels, PopupTabLayout and TabLayout. When left or right keys pressed, focus moved to other spottable. 

In this change, I fixed to move the caret when left or right keys are pressed in InputField.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added condition in FixedPopupPanels, PopupTabLayout, and TabLayout handlers to check whether event target is INPUT.
Fixed not to follow the onKeyDownHandler logic associated with the left and right keys if event target is INPUT.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7201

### Comments
