### PR TITLE
WRO-7722: Fix Alert override color to show Progressbar properly 

### DIFF
--- a/Alert/Alert.module.less
+++ b/Alert/Alert.module.less
@@ -146,7 +146,7 @@
 			--sand-disabled-selected-focus-color: @sand-alert-overlay-disabled-selected-focus-color;
 			--sand-disabled-selected-focus-bg-color: @sand-alert-overlay-disabled-selected-focus-bg-color;
 			--sand-progress-color-rgb: @sand-alert-overlay-progress-color-rgb;
-			--sand-progress-bg-color: @sand-alert-overlay-progress-bg-color;
+			--sand-progress-bg-color-rgb: @sand-alert-overlay-progress-bg-color-rgb;
 			--sand-checkbox-color: @sand-alert-overlay-checkbox-color;
 			--sand-checkbox-disabled-selected-color: @sand-alert-overlay-checkbox-disabled-selected-color;
 			--sand-formcheckboxitem-focus-text-color: @sand-alert-overlay-formcheckboxitem-focus-text-color;

--- a/Alert/Alert.module.less
+++ b/Alert/Alert.module.less
@@ -147,6 +147,7 @@
 			--sand-disabled-selected-focus-bg-color: @sand-alert-overlay-disabled-selected-focus-bg-color;
 			--sand-progress-color-rgb: @sand-alert-overlay-progress-color-rgb;
 			--sand-progress-bg-color-rgb: @sand-alert-overlay-progress-bg-color-rgb;
+			--sand-progress-bg-color-alpha: @sand-alert-overlay-progress-bg-color-alpha;
 			--sand-checkbox-color: @sand-alert-overlay-checkbox-color;
 			--sand-checkbox-disabled-selected-color: @sand-alert-overlay-checkbox-disabled-selected-color;
 			--sand-formcheckboxitem-focus-text-color: @sand-alert-overlay-formcheckboxitem-focus-text-color;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Alert` to show `sandstone/ProgressBar` color properly
 - `sandstone/FixedPopupPanels`, `sandstone/PopupTabLayout`, and `sandstone/TabLayout` to move caret in InputField with left and right keys
 - `sandstone/WizardPanels` to provide `stopPropagation` method in `onBack` event payload
 

--- a/samples/sampler/stories/qa/Alert.js
+++ b/samples/sampler/stories/qa/Alert.js
@@ -5,6 +5,8 @@ import Alert, {AlertBase, AlertImage} from '@enact/sandstone/Alert';
 import Button from '@enact/sandstone/Button';
 import CheckboxItem from '@enact/sandstone/CheckboxItem';
 import ProgressBar from '@enact/sandstone/ProgressBar';
+import Scroller from '@enact/sandstone/Scroller';
+import ri from '@enact/ui/resolution';
 
 Alert.displayName = 'Alert';
 AlertImage.displayName = 'AlertImage';
@@ -136,7 +138,11 @@ export const WithDifferentTypesOfComponentsAndLongChildren = (args) => (
 		<div>
 			<CheckboxItem>This is CheckboxItem</CheckboxItem>
 		</div>
-		{args['children']}
+		<Scroller style={{height: ri.scaleToRem(800)}}>
+			<div style={{height: ri.scaleToRem(1600)}}>
+				{args['children']}
+			</div>
+		</Scroller>
 	</Alert>
 );
 

--- a/samples/sampler/stories/qa/ProgressBar.js
+++ b/samples/sampler/stories/qa/ProgressBar.js
@@ -1,6 +1,9 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
+import Alert from '@enact/sandstone/Alert';
+import Button from '@enact/sandstone/Button';
 import ProgressBar, {ProgressBarBase} from '@enact/sandstone/ProgressBar';
+import {useCallback, useState} from 'react';
 
 const Config = mergeComponentMetadata('ProgressBar', ProgressBarBase, ProgressBar);
 
@@ -29,5 +32,54 @@ boolean('disabled', TheBasicProgressBar, Config, false);
 
 TheBasicProgressBar.storyName = 'The basic ProgressBar';
 TheBasicProgressBar.parameters = {
+	propTables: [Config]
+};
+
+
+export const inAlert = (args) => {
+	const [open, setOpen] = useState(false);
+
+	const handleOpenAlert = useCallback(() => {
+		setOpen(true);
+	}, []);
+
+	const handleCloseAlert = useCallback(() => {
+		setOpen(false);
+	}, []);
+
+	return (
+		<>
+			<ProgressBar
+				backgroundProgress={args['backgroundProgress']}
+				tooltip={args['tooltip']}
+				highlighted={args['highlighted']}
+				progress={args['progress']}
+				orientation={args['orientation']}
+				disabled={args['disabled']}
+			/>
+			<Button onClick={handleOpenAlert}>open</Button>
+			<Alert open={open} type="overlay" onClose={handleCloseAlert}>
+				<ProgressBar
+					backgroundProgress={args['backgroundProgress']}
+					tooltip={args['tooltip']}
+					highlighted={args['highlighted']}
+					progress={args['progress']}
+					orientation={args['orientation']}
+					disabled={args['disabled']}
+				/>
+			</Alert>
+		</>
+	);
+};
+
+range('backgroundProgress', inAlert, Config, {min: 0, max: 1, step: 0.01}, 0.5);
+boolean('tooltip', inAlert, Config, false);
+boolean('highlighted', inAlert, Config, false);
+range('progress', inAlert, Config, {min: 0, max: 1, step: 0.01}, 0.4);
+select('orientation', inAlert, ['horizontal', 'vertical'], Config, 'horizontal');
+boolean('disabled', inAlert, Config, false);
+
+inAlert.storyName = 'inAlert';
+inAlert.parameters = {
 	propTables: [Config]
 };

--- a/samples/sampler/stories/qa/ProgressBar.js
+++ b/samples/sampler/stories/qa/ProgressBar.js
@@ -35,8 +35,7 @@ TheBasicProgressBar.parameters = {
 	propTables: [Config]
 };
 
-
-export const inAlert = (args) => {
+export const ProgressBarInAlert = (args) => {
 	const [open, setOpen] = useState(false);
 
 	const handleOpenAlert = useCallback(() => {
@@ -72,14 +71,14 @@ export const inAlert = (args) => {
 	);
 };
 
-range('backgroundProgress', inAlert, Config, {min: 0, max: 1, step: 0.01}, 0.5);
-boolean('tooltip', inAlert, Config, false);
-boolean('highlighted', inAlert, Config, false);
-range('progress', inAlert, Config, {min: 0, max: 1, step: 0.01}, 0.4);
-select('orientation', inAlert, ['horizontal', 'vertical'], Config, 'horizontal');
-boolean('disabled', inAlert, Config, false);
+range('backgroundProgress', ProgressBarInAlert, Config, {min: 0, max: 1, step: 0.01}, 0.5);
+boolean('tooltip', ProgressBarInAlert, Config, false);
+boolean('highlighted', ProgressBarInAlert, Config, false);
+range('progress', ProgressBarInAlert, Config, {min: 0, max: 1, step: 0.01}, 0.4);
+select('orientation', ProgressBarInAlert, ['horizontal', 'vertical'], Config, 'horizontal');
+boolean('disabled', ProgressBarInAlert, Config, false);
 
-inAlert.storyName = 'inAlert';
-inAlert.parameters = {
+ProgressBarInAlert.storyName = 'inAlert';
+ProgressBarInAlert.parameters = {
 	propTables: [Config]
 };

--- a/samples/sampler/stories/qa/ProgressBar.js
+++ b/samples/sampler/stories/qa/ProgressBar.js
@@ -1,9 +1,6 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
-import Alert from '@enact/sandstone/Alert';
-import Button from '@enact/sandstone/Button';
 import ProgressBar, {ProgressBarBase} from '@enact/sandstone/ProgressBar';
-import {useCallback, useState} from 'react';
 
 const Config = mergeComponentMetadata('ProgressBar', ProgressBarBase, ProgressBar);
 
@@ -32,53 +29,5 @@ boolean('disabled', TheBasicProgressBar, Config, false);
 
 TheBasicProgressBar.storyName = 'The basic ProgressBar';
 TheBasicProgressBar.parameters = {
-	propTables: [Config]
-};
-
-export const ProgressBarInAlert = (args) => {
-	const [open, setOpen] = useState(false);
-
-	const handleOpenAlert = useCallback(() => {
-		setOpen(true);
-	}, []);
-
-	const handleCloseAlert = useCallback(() => {
-		setOpen(false);
-	}, []);
-
-	return (
-		<>
-			<ProgressBar
-				backgroundProgress={args['backgroundProgress']}
-				tooltip={args['tooltip']}
-				highlighted={args['highlighted']}
-				progress={args['progress']}
-				orientation={args['orientation']}
-				disabled={args['disabled']}
-			/>
-			<Button onClick={handleOpenAlert}>open</Button>
-			<Alert open={open} type="overlay" onClose={handleCloseAlert}>
-				<ProgressBar
-					backgroundProgress={args['backgroundProgress']}
-					tooltip={args['tooltip']}
-					highlighted={args['highlighted']}
-					progress={args['progress']}
-					orientation={args['orientation']}
-					disabled={args['disabled']}
-				/>
-			</Alert>
-		</>
-	);
-};
-
-range('backgroundProgress', ProgressBarInAlert, Config, {min: 0, max: 1, step: 0.01}, 0.5);
-boolean('tooltip', ProgressBarInAlert, Config, false);
-boolean('highlighted', ProgressBarInAlert, Config, false);
-range('progress', ProgressBarInAlert, Config, {min: 0, max: 1, step: 0.01}, 0.4);
-select('orientation', ProgressBarInAlert, ['horizontal', 'vertical'], Config, 'horizontal');
-boolean('disabled', ProgressBarInAlert, Config, false);
-
-ProgressBarInAlert.storyName = 'inAlert';
-ProgressBarInAlert.parameters = {
 	propTables: [Config]
 };

--- a/styles/colors-light.less
+++ b/styles/colors-light.less
@@ -22,7 +22,7 @@
 @sand-overlay-bg-color-rgb: var(--sand-alert-overlay-bg-color-rgb, 187, 187, 187); // #bbbbbb
 @sand-progress-color-rgb: var(--sand-progress-color-rgb, 55, 58, 65); // #373a41
 @sand-progress-bg-color-rgb: var(--sand-progress-bg-color-rgb, 161, 161, 161); // #a1a1a1
-@sand-progress-bg-color: rgb(@sand-progress-bg-color-rgb, 40%); // 40% alpha by default
+@sand-progress-bg-color-alpha: var(--sand-progress-bg-color-alpha, 40%);
 @sand-progress-highlighted-color: var(--sand-progress-highlighted-color, #000000);
 
 // component colors
@@ -43,6 +43,7 @@
 // component colors
 @sand-alert-overlay-progress-color-rgb: var(--sand-alert-overlay-progress-color-rgb, 230, 230, 230); // #e6e6e6
 @sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 55, 58, 65); // #373a41
+@sand-alert-overlay-progress-bg-color-alpha: var(--sand-progress-bg-color-alpha, 100%);
 @sand-alert-overlay-checkbox-color: var(--sand-alert-overlay-checkbox-color, #e6e6e6);
 @sand-alert-overlay-checkbox-disabled-selected-color: var(--sand-alert-overlay-checkbox-disabled-selected-color, #4c5059);
 @sand-alert-overlay-item-disabled-focus-bg-color: var(--sand-alert-overlay-item-disabled-focus-bg-color, #e6e6e6);

--- a/styles/colors-light.less
+++ b/styles/colors-light.less
@@ -21,7 +21,8 @@
 @sand-disabled-selected-focus-bg-color: var(--sand-disabled-selected-focus-bg-color, #4c5059);
 @sand-overlay-bg-color-rgb: var(--sand-alert-overlay-bg-color-rgb, 187, 187, 187); // #bbbbbb
 @sand-progress-color-rgb: var(--sand-progress-color-rgb, 55, 58, 65); // #373a41
-@sand-progress-bg-color: var(--sand-progress-bg-color, #a1a1a166); // 40% alpha by default
+@sand-progress-bg-color-rgb: var(--sand-progress-bg-color-rgb, 161, 161, 161); // #a1a1a1
+@sand-progress-bg-color: rgb(@sand-progress-bg-color-rgb, 40%); // 40% alpha by default
 @sand-progress-highlighted-color: var(--sand-progress-highlighted-color, #000000);
 
 // component colors
@@ -41,7 +42,7 @@
 
 // component colors
 @sand-alert-overlay-progress-color-rgb: var(--sand-alert-overlay-progress-color-rgb, 230, 230, 230); // #e6e6e6
-@sand-alert-overlay-progress-bg-color: var(--sand-alert-overlay-progress-bg-color, #373a41);
+@sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 55, 58, 65); // #373a41
 @sand-alert-overlay-checkbox-color: var(--sand-alert-overlay-checkbox-color, #e6e6e6);
 @sand-alert-overlay-checkbox-disabled-selected-color: var(--sand-alert-overlay-checkbox-disabled-selected-color, #4c5059);
 @sand-alert-overlay-item-disabled-focus-bg-color: var(--sand-alert-overlay-item-disabled-focus-bg-color, #e6e6e6);

--- a/styles/colors-light.less
+++ b/styles/colors-light.less
@@ -43,7 +43,7 @@
 // component colors
 @sand-alert-overlay-progress-color-rgb: var(--sand-alert-overlay-progress-color-rgb, 230, 230, 230); // #e6e6e6
 @sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 55, 58, 65); // #373a41
-@sand-alert-overlay-progress-bg-color-alpha: var(--sand-progress-bg-color-alpha, 100%);
+@sand-alert-overlay-progress-bg-color-alpha: var(--sand-alert-overlay-progress-bg-color-alpha, 100%);
 @sand-alert-overlay-checkbox-color: var(--sand-alert-overlay-checkbox-color, #e6e6e6);
 @sand-alert-overlay-checkbox-disabled-selected-color: var(--sand-alert-overlay-checkbox-disabled-selected-color, #4c5059);
 @sand-alert-overlay-item-disabled-focus-bg-color: var(--sand-alert-overlay-item-disabled-focus-bg-color, #e6e6e6);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -117,7 +117,7 @@
 // component colors
 @sand-alert-overlay-progress-color-rgb: var(--sand-alert-overlay-progress-color-rgb, 55, 58, 65); // #373a41
 @sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 161, 161, 161); //  #a1a1a166, 40% alpha by default
-@sand-alert-overlay-progress-bg-color-alpha: var(--sand-progress-bg-color-alpha, 40%);
+@sand-alert-overlay-progress-bg-color-alpha: var(--sand-alert-overlay-progress-bg-color-alpha, 40%);
 @sand-alert-overlay-checkbox-color: var(--sand-alert-overlay-checkbox-color, #858b92);
 @sand-alert-overlay-checkbox-disabled-selected-color: var(--sand-alert-overlay-checkbox-disabled-selected-color, #ffffff);
 @sand-alert-overlay-formcheckboxitem-focus-text-color: var(--sand-alert-overlay-formcheckboxitem-focus-text-color, #575e66);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -81,7 +81,8 @@
 @sand-progress-color: rgb(@sand-progress-color-rgb);
 @sand-progress-buffer-color: var(--sand-progress-buffer-color, #6b6d73); // @sand-progress-color with opacity 30% on @sand-progress-bg-color
 @sand-progress-bg-color-rgb: var(--sand-progress-bg-color-rgb, 55, 58, 65); // #373a41
-@sand-progress-bg-color: rgb(@sand-progress-bg-color-rgb);
+@sand-progress-bg-color-alpha: var(--sand-progress-bg-color-alpha, 100%);
+@sand-progress-bg-color: rgb(@sand-progress-bg-color-rgb, @sand-progress-bg-color-alpha);
 @sand-progress-highlighted-color: var(--sand-progress-highlighted-color, #ffffff);
 @sand-progress-slider-color: var(--sand-progress-slider-color, #8d9298);
 
@@ -115,7 +116,8 @@
 
 // component colors
 @sand-alert-overlay-progress-color-rgb: var(--sand-alert-overlay-progress-color-rgb, 55, 58, 65); // #373a41
-@sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 161, 161, 161, 40%); //  #a1a1a166, 40% alpha by default
+@sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 161, 161, 161); //  #a1a1a166, 40% alpha by default
+@sand-alert-overlay-progress-bg-color-alpha: var(--sand-progress-bg-color-alpha, 40%);
 @sand-alert-overlay-checkbox-color: var(--sand-alert-overlay-checkbox-color, #858b92);
 @sand-alert-overlay-checkbox-disabled-selected-color: var(--sand-alert-overlay-checkbox-disabled-selected-color, #ffffff);
 @sand-alert-overlay-formcheckboxitem-focus-text-color: var(--sand-alert-overlay-formcheckboxitem-focus-text-color, #575e66);

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -115,7 +115,7 @@
 
 // component colors
 @sand-alert-overlay-progress-color-rgb: var(--sand-alert-overlay-progress-color-rgb, 55, 58, 65); // #373a41
-@sand-alert-overlay-progress-bg-color: var(--sand-alert-overlay-progress-bg-color, #a1a1a166); // 40% alpha by default
+@sand-alert-overlay-progress-bg-color-rgb: var(--sand-alert-overlay-progress-bg-color-rgb, 161, 161, 161, 40%); //  #a1a1a166, 40% alpha by default
 @sand-alert-overlay-checkbox-color: var(--sand-alert-overlay-checkbox-color, #858b92);
 @sand-alert-overlay-checkbox-disabled-selected-color: var(--sand-alert-overlay-checkbox-disabled-selected-color, #ffffff);
 @sand-alert-overlay-formcheckboxitem-focus-text-color: var(--sand-alert-overlay-formcheckboxitem-focus-text-color, #575e66);

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -39,7 +39,7 @@ const overlayColorTests = [
 	<Alert open title="With Scroller">
 		<div>
 			<div>This is Scroller</div>
-			<Scroller style={{height:'300px'}} verticalScrollbar='visible'>
+			<Scroller style={{height:'300px'}} verticalScrollbar="visible">
 				<div style={{height:'1000px'}}>
 					ScrollerTest
 				</div>
@@ -48,7 +48,7 @@ const overlayColorTests = [
 	</Alert>,
 	<Alert open title="With byEnter Scroller">
 		<div>
-			<div>This is focusableScrollbar='byEnter' Scroller</div>
+			<div>This is focusableScrollbar=byEnter Scroller</div>
 			<Scroller style={{height:'300px'}} focusableScrollbar="byEnter">
 				<div style={{height:'1000px'}}>
 					ScrollerTest

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -25,24 +25,36 @@ const overlayTests = [
 // TODO: Add tc for text / focus text / disabled boutton / checkbox / formcheckbox Item / item disabled
 const overlayColorTests = [
 	<Alert open title="With Progressbar">
-		<ProgressBar backgroundProgress={0.5} progress={0.25} />
+		<div>
+			<div>This is ProgressBar</div>
+			<ProgressBar backgroundProgress={0.5} progress={0.25} />
+		</div>
 	</Alert>,
 	<Alert open title="With disabled Progressbar">
-		<ProgressBar backgroundProgress={0.5} progress={0.25} disabled />
+		<div>
+			<div>This is ProgressBar</div>
+			<ProgressBar backgroundProgress={0.5} progress={0.25} disabled />
+		</div>
 	</Alert>,
 	<Alert open title="With Scroller">
-		<Scroller style={{height:'300px'}} focusableScrollbar>
-			<div style={{height:'1000px'}}>
-				ScrollerTest
-			</div>
-		</Scroller>
+		<div>
+			<div>This is Scroller</div>
+			<Scroller style={{height:'300px'}} verticalScrollbar='visible'>
+				<div style={{height:'1000px'}}>
+					ScrollerTest
+				</div>
+			</Scroller>
+		</div>
 	</Alert>,
 	<Alert open title="With byEnter Scroller">
-		<Scroller style={{height:'300px'}} focusableScrollbar="byEnter">
-			<div style={{height:'1000px'}}>
-				ScrollerTest
-			</div>
-		</Scroller>
+		<div>
+			<div>This is focusableScrollbar='byEnter' Scroller</div>
+			<Scroller style={{height:'300px'}} focusableScrollbar="byEnter">
+				<div style={{height:'1000px'}}>
+					ScrollerTest
+				</div>
+			</Scroller>
+		</div>
 	</Alert>
 ];
 
@@ -85,8 +97,9 @@ const LtrTests = [
 	...withProps({type: 'overlay', buttons: dropIn.oneButton, image: dropIn.image}, overlayTests),
 	...withProps({type: 'overlay', buttons: dropIn.twoButtons, image: dropIn.image}, overlayTests),
 
-	// With other components
-	...withProps({type: 'overlay'}, overlayColorTests)
+	// // With other components
+	...withProps({type: 'overlay'}, overlayColorTests),
+	...withProps({type: 'fullscreen'}, overlayColorTests)
 ];
 
 const AlertTests = [

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -1,6 +1,7 @@
 import Alert, {AlertImage}  from '../../../../Alert';
 import Button from '../../../../Button';
 import ProgressBar from '@enact/sandstone/ProgressBar';
+import Scroller from '../../../../Scroller';
 
 import img from '../../images/300x300.png';
 
@@ -28,6 +29,20 @@ const overlayColorTests = [
 	</Alert>,
 	<Alert open title="With disabled Progressbar">
 		<ProgressBar backgroundProgress={0.5} progress={0.25} disabled />
+	</Alert>,
+	<Alert open title="With Scroller">
+		<Scroller style={{height:'300px'}} focusableScrollbar>
+			<div style={{height:'1000px'}}>
+				ScrollerTest
+			</div>
+		</Scroller>
+	</Alert>,
+	<Alert open title="With byEnter Scroller">
+		<Scroller style={{height:'300px'}} focusableScrollbar="byEnter">
+			<div style={{height:'1000px'}}>
+				ScrollerTest
+			</div>
+		</Scroller>
 	</Alert>
 ];
 

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -1,5 +1,6 @@
 import Alert, {AlertImage}  from '../../../../Alert';
 import Button from '../../../../Button';
+import ProgressBar from '@enact/sandstone/ProgressBar';
 
 import img from '../../images/300x300.png';
 
@@ -17,6 +18,17 @@ const fullscreenTests = [
 const overlayTests = [
 	<Alert open>Alert!</Alert>,
 	<Alert open>{LoremString}</Alert>
+];
+
+// Overlay color test
+// TODO: Add tc for text / focus text / disabled boutton / checkbox / formcheckbox Item / item disabled
+const overlayColorTests = [
+	<Alert open title="With Progressbar">
+		<ProgressBar backgroundProgress={0.5} progress={0.25} />
+	</Alert>,
+	<Alert open title="With disabled Progressbar">
+		<ProgressBar backgroundProgress={0.5} progress={0.25} disabled />
+	</Alert>
 ];
 
 const dropIn = {
@@ -56,7 +68,10 @@ const LtrTests = [
 	...withProps({type: 'fullscreen', buttons: dropIn.oneButton, image: dropIn.image}, fullscreenTests),
 	...withProps({type: 'fullscreen', buttons: dropIn.twoButtons, image: dropIn.image}, fullscreenTests),
 	...withProps({type: 'overlay', buttons: dropIn.oneButton, image: dropIn.image}, overlayTests),
-	...withProps({type: 'overlay', buttons: dropIn.twoButtons, image: dropIn.image}, overlayTests)
+	...withProps({type: 'overlay', buttons: dropIn.twoButtons, image: dropIn.image}, overlayTests),
+
+	// With other components
+	...withProps({type: 'overlay'}, overlayColorTests)
 ];
 
 const AlertTests = [


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ProgressBar is not distinguished in Alert 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix override color about progressbar
This issue is releated with https://github.com/enactjs/sandstone/pull/1220 / https://github.com/enactjs/sandstone/pull/1257

After 1220, skin should override `@sand-progress-bg-color-rgb` value instead of `@sand-progress-bg-color`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7722

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)