### PR TITLE
WRO-7575: [Storybook6.5] Fix ContexualPopup of ContextualMenuDecorator is opened with narrow width

### DIFF
--- a/ContextualMenuDecorator/ContextualMenuDecorator.js
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.js
@@ -213,12 +213,11 @@ const ContextualMenuDecoratorBase = hoc(defaultConfig, (config, Wrapped) => {
 			// implementation with the Repeater for the items since the popup class could be set
 			// on the component by itself
 			popupClassName: ({popupWidth, popupClassName, styler}) => {
-				const sizeClass = popupWidth !== 'auto' && popupWidth;
 				return styler.join(
 					'popup',
 					'container',
 					popupClassName,
-					sizeClass
+					popupWidth
 				);
 			},
 			popupComponent: ({menuItems}) => (menuItems && menuItems.length > MAX_VISIBLE_MENU_ITEMS ? ScrollingRepeater : Repeater),

--- a/ContextualMenuDecorator/ContextualMenuDecorator.module.less
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.module.less
@@ -28,25 +28,17 @@
 	&.container {
 		width: @sand-contextualmenu-small-width;
 		padding: @sand-contextualmenu-container-padding;
-		color: green;
 
 		.innerContainer {
 			max-height: @sand-contextualmenu-innercontainer-max-height;
 		}
 
-		//&.auto {
-		//	min-width: 612px;
-		//	color: blue;
-		//}
-
 		&.small {
 			width: @sand-contextualmenu-small-width;
-			color: red;
 		}
 
 		&.large {
 			width: @sand-contextualmenu-large-width;
-			color: pink;
 		}
 
 		// Passed as itemProps css to Item to remove inter-item spacing

--- a/ContextualMenuDecorator/ContextualMenuDecorator.module.less
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.module.less
@@ -26,15 +26,13 @@
 	// need to use an arbitrary additional CSS rule for precedence
 	*/
 	&.container {
-		min-width: @sand-contextualmenu-small-width;
-		padding: @sand-contextualmenu-container-padding;
+		&.auto, &.small, &.large {
+			min-width: @sand-contextualmenu-small-width;
+			padding: @sand-contextualmenu-container-padding;
+		}
 
 		.innerContainer {
 			max-height: @sand-contextualmenu-innercontainer-max-height;
-		}
-
-		&.auto {
-			min-width:  @sand-contextualmenu-auto-width;
 		}
 
 		&.small {

--- a/ContextualMenuDecorator/ContextualMenuDecorator.module.less
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.module.less
@@ -26,19 +26,27 @@
 	// need to use an arbitrary additional CSS rule for precedence
 	*/
 	&.container {
-		min-width: @sand-contextualmenu-small-width;
+		width: @sand-contextualmenu-small-width;
 		padding: @sand-contextualmenu-container-padding;
+		color: green;
 
 		.innerContainer {
 			max-height: @sand-contextualmenu-innercontainer-max-height;
 		}
 
+		//&.auto {
+		//	min-width: 612px;
+		//	color: blue;
+		//}
+
 		&.small {
 			width: @sand-contextualmenu-small-width;
+			color: red;
 		}
 
 		&.large {
 			width: @sand-contextualmenu-large-width;
+			color: pink;
 		}
 
 		// Passed as itemProps css to Item to remove inter-item spacing

--- a/ContextualMenuDecorator/ContextualMenuDecorator.module.less
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.module.less
@@ -26,11 +26,15 @@
 	// need to use an arbitrary additional CSS rule for precedence
 	*/
 	&.container {
-		width: @sand-contextualmenu-small-width;
+		min-width: @sand-contextualmenu-small-width;
 		padding: @sand-contextualmenu-container-padding;
 
 		.innerContainer {
 			max-height: @sand-contextualmenu-innercontainer-max-height;
+		}
+
+		&.auto {
+			min-width:  @sand-contextualmenu-small-width;
 		}
 
 		&.small {

--- a/ContextualMenuDecorator/ContextualMenuDecorator.module.less
+++ b/ContextualMenuDecorator/ContextualMenuDecorator.module.less
@@ -34,7 +34,7 @@
 		}
 
 		&.auto {
-			min-width:  @sand-contextualmenu-small-width;
+			min-width:  @sand-contextualmenu-auto-width;
 		}
 
 		&.small {

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -405,7 +405,6 @@
 @sand-contextualmenu-max-height: (@sand-contextualmenu-innercontainer-max-height + .extract(@sand-contextualmenu-container-padding, top)[] + .extract(@sand-contextualmenu-container-padding, bottom)[]);
 @sand-contextualmenu-large-width: 960px;
 @sand-contextualmenu-small-width: 612px;
-@sand-contextualmenu-auto-width: @sand-contextualmenu-small-width;
 
 // ContextualPopup
 // ---------------------------------------

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -405,6 +405,7 @@
 @sand-contextualmenu-max-height: (@sand-contextualmenu-innercontainer-max-height + .extract(@sand-contextualmenu-container-padding, top)[] + .extract(@sand-contextualmenu-container-padding, bottom)[]);
 @sand-contextualmenu-large-width: 960px;
 @sand-contextualmenu-small-width: 612px;
+@sand-contextualmenu-auto-width: @sand-contextualmenu-small-width;
 
 // ContextualPopup
 // ---------------------------------------


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ContextualMenuDecorator has a narrow width with `popupWidth=auto` on storybook6.5

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Increased css specifity for `auto`, `small` and `large` classNames

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7575

### Comments
