### PR TITLE
WRO-2545: Fixed ss test Sandstone-View outer div overflow property value to hidden

### DIFF
--- a/tests/screenshot/apps/Sandstone-View.js
+++ b/tests/screenshot/apps/Sandstone-View.js
@@ -128,7 +128,7 @@ class App extends ReactComponent {
 		}
 
 		return (
-			<div {...props}>
+			<div style={{overflow: 'hidden'}} {...props}>
 				<div className={wrapperClasses} style={wrapperStyle}>{testElement}</div>
 			</div>
 		);

--- a/tests/screenshot/apps/components/ContextualMenuDecorator.js
+++ b/tests/screenshot/apps/components/ContextualMenuDecorator.js
@@ -1,5 +1,3 @@
-import ri from '@enact/ui/resolution';
-
 import Button from '../../../../Button';
 import ContextualMenuDecorator from '../../../../ContextualMenuDecorator';
 
@@ -11,11 +9,8 @@ const popupProps = {
 };
 const menuItems = ['Item 1', 'Item 2', 'Item 3'];
 
-const padded = '540px';
-const paddedRtl = ri.scaleToRem(120);
-
 const wrapper = {
-	padded
+	padded: '540px'
 };
 
 const ContextualMenuDecoratorTests = [
@@ -56,38 +51,27 @@ const ContextualMenuDecoratorTests = [
 		<ContextualMenuButton popupWidth="large" popupProps={popupProps} menuItems={menuItems} open direction="below center">Button</ContextualMenuButton>,
 		<ContextualMenuButton popupWidth="large" popupProps={popupProps} menuItems={menuItems} open direction="left middle">Button</ContextualMenuButton>,
 		<ContextualMenuButton popupWidth="large" popupProps={popupProps} menuItems={menuItems} open direction="right middle">Button</ContextualMenuButton>,
-	]),
+
 		// *************************************************************
 		// locale = 'ar-SA'
 		// *************************************************************
 		{
 			locale: 'ar-SA',
-			wrapper: {
-				padded: `${paddedRtl} ${paddedRtl} ${paddedRtl} 0`
-			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="above center">Button</ContextualMenuButton>
 		},
 		{
 			locale: 'ar-SA',
-			wrapper: {
-				padded: `${paddedRtl} ${paddedRtl} ${paddedRtl} 0`
-			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="below center">Button</ContextualMenuButton>
 		},
 		{
 			locale: 'ar-SA',
-			wrapper: {
-				padded: `${paddedRtl} ${paddedRtl} ${paddedRtl} 0`
-			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="left middle">Button</ContextualMenuButton>
 		},
 		{
 			locale: 'ar-SA',
-			wrapper: {
-				padded: `${paddedRtl} ${padded} ${paddedRtl} 0`
-			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="right middle">Button</ContextualMenuButton>
 		}
+	])
 ];
 
 export default ContextualMenuDecoratorTests;

--- a/tests/screenshot/apps/components/ContextualMenuDecorator.js
+++ b/tests/screenshot/apps/components/ContextualMenuDecorator.js
@@ -1,3 +1,5 @@
+import ri from '@enact/ui/resolution';
+
 import Button from '../../../../Button';
 import ContextualMenuDecorator from '../../../../ContextualMenuDecorator';
 
@@ -10,6 +12,8 @@ const popupProps = {
 const menuItems = ['Item 1', 'Item 2', 'Item 3'];
 
 const padded = '540px';
+const paddedRtl = ri.scaleToRem(120);
+
 const wrapper = {
 	padded
 };
@@ -52,27 +56,38 @@ const ContextualMenuDecoratorTests = [
 		<ContextualMenuButton popupWidth="large" popupProps={popupProps} menuItems={menuItems} open direction="below center">Button</ContextualMenuButton>,
 		<ContextualMenuButton popupWidth="large" popupProps={popupProps} menuItems={menuItems} open direction="left middle">Button</ContextualMenuButton>,
 		<ContextualMenuButton popupWidth="large" popupProps={popupProps} menuItems={menuItems} open direction="right middle">Button</ContextualMenuButton>,
-
+	]),
 		// *************************************************************
 		// locale = 'ar-SA'
 		// *************************************************************
 		{
 			locale: 'ar-SA',
+			wrapper: {
+				padded: `${paddedRtl} ${paddedRtl} ${paddedRtl} 0`
+			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="above center">Button</ContextualMenuButton>
 		},
 		{
 			locale: 'ar-SA',
+			wrapper: {
+				padded: `${paddedRtl} ${paddedRtl} ${paddedRtl} 0`
+			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="below center">Button</ContextualMenuButton>
 		},
 		{
 			locale: 'ar-SA',
+			wrapper: {
+				padded: `${paddedRtl} ${paddedRtl} ${paddedRtl} 0`
+			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="left middle">Button</ContextualMenuButton>
 		},
 		{
 			locale: 'ar-SA',
+			wrapper: {
+				padded: `${paddedRtl} ${padded} ${paddedRtl} 0`
+			},
 			component: <ContextualMenuButton popupProps={popupProps} menuItems={menuItems} open direction="right middle">Button</ContextualMenuButton>
 		}
-	])
 ];
 
 export default ContextualMenuDecoratorTests;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In ContextualMenuDecorator screenshot test, there were some symptoms that button in screenshot image get truncated as attached image.
![ContextualMenuDecoratorButton](https://user-images.githubusercontent.com/77044692/177893659-c61602a7-d704-4d71-9844-d46a99d18098.png)
Because of the large padding value set in ContextualMenuDecorator screenshot test view, vertical scrollbar created when screenshot image generated. And this scroll bar moved the button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
As screenshot test view need to be fit in 1920 * 1080 size,  we added overflow property value to be hidden.
This style can prevent the same problem from occurring in other RTL locale tests.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-2545

### Comments
