### PR TITLE
WRO-7341: Fixed qa-a11y panel sample to restore focus properly

### DIFF
--- a/samples/qa-a11y/src/views/Panels.js
+++ b/samples/qa-a11y/src/views/Panels.js
@@ -33,6 +33,7 @@ const PanelsView = () => {
 					dataSize={itemList.length}
 					itemRenderer={customItem}
 					itemSize={ri.scale(156)}
+					spotlightId="virtual-list"
 				/>
 			</Panel>
 			<Panel>

--- a/samples/qa-a11y/src/views/Panels.js
+++ b/samples/qa-a11y/src/views/Panels.js
@@ -31,9 +31,10 @@ const PanelsView = () => {
 				<Header title="Panel 0" />
 				<VirtualList
 					dataSize={itemList.length}
+					id={'virtualList_$' + index}
 					itemRenderer={customItem}
 					itemSize={ri.scale(156)}
-					spotlightId="virtual-list"
+					spotlightId={'virtualList_$' + index}
 				/>
 			</Panel>
 			<Panel>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In qa-a11y panel sample, when navigating from panel 1 to panel 0, focus did not properly restored to the last focused item.

If the `virtualList` in panel 0 does not set spotlightId, data-spotlight-id is set to container-#. And when switching to panel 0, the data-spotlight-id of panel 0 is updated, for example from container-9 to container-13.

In this case, the spotlight cannot restore focus to the `virtualList` as the spotlight remember the lastFocusedElement information as old data (e.g., container-9).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `spotlightId` prop in `VirtualList` to restore focus properly when it remounts while transitioning the panel.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I think the virtualList's spotlightId deletion is a regression from https://github.com/enactjs/sandstone/pull/628. 

### Links
[//]: # (Related issues, references)
WRO-7341

### Comments
