### PR TITLE
WRO-8225: Fixed scoll by hover to work properly when `scrollMode` is translate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` and `sandstone/VirtualList` to scroll properly by hover when `hoverToScroll` is `true` and `scrollMode` is translate
+
 ## [2.5.0-rc.2] - 2022-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` and `sandstone/VirtualList` to scroll properly by hover when `hoverToScroll` is `true` and `scrollMode` is translate
+- `sandstone/Scroller` and `sandstone/VirtualList` to scroll properly by hover when `hoverToScroll` is `true` and `scrollMode` is `translate`
 
 ## [2.5.0-rc.2] - 2022-07-06
 

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -98,6 +98,7 @@ const HoverToScrollBase = (props) => {
 		if (typeof window === 'object' && mutableRef.current.hoverToScrollRafId !== null) {
 			window.cancelAnimationFrame(mutableRef.current.hoverToScrollRafId);
 			mutableRef.current.hoverToScrollRafId = null;
+			mutableRef.current.hoveredPosition = null;
 			if (typeof document === 'object') {
 				document.removeEventListener('keydown', handleGlobalKeyDown, {capture: true});
 			}

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -85,7 +85,7 @@ const HoverToScrollBase = (props) => {
 
 	const startRaf = useCallback((job) => {
 		scrollContainerHandleRef.isHoveringToScroll = true;
-		if (typeof window === 'object') {
+		if (typeof window === 'object' && mutableRef.current.hoveredPosition) {
 			mutableRef.current.hoverToScrollRafId = window.requestAnimationFrame(job);
 			if (typeof document === 'object') {
 				document.addEventListener('keydown', handleGlobalKeyDown, {capture: true});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
hoverToScroll props is not work properly with translate scrollMode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Cause : 
In Translate mode, the timing when the `update()` is called by the `onScroll` event is after `RequsetAnimation`(RAF).
Therefore, it does not `stop` and the `RAF` is executed forever.

Resolution:
So, in addition to calling `cancelAnimationFrame` in the `stopRaf` function, we should use more certain way to prevent the next `RAF` execution.
In this patch, I use the `hoveredPosition` variable we already have to check if the `RAF` has stopped to prevent further `RAF`s.


FYI : The current invoking order is as follows.
`startRaf` -> `requsetAnimationFrame` -> `scrollByHover` (Call scrollTo) -> `startRaf` ->  ......

* Native Scroller 
`startRaf` -> Call `requsetAnimationFrame` id=1 -> Execute `requsetAnimationFrame` id=1 -> `scrollByHover` (Call `scrollTo`) -> `startRaf` -> Call `requsetAnimationFrame` id=2  -> `update` -> `stopRaf` -> `cancelAnimationFrame` id=2 

* Translate
`startRaf` -> Call `requsetAnimationFrame` id=1 -> Execute `requsetAnimationFrame` id=1 -> `scrollByHover` (Call `scrollTo`) -> `startRaf` -> Call `requsetAnimationFrame` id=2  -> Execute `requsetAnimationFrame` id=2 -> `scrollByHover` (Call `scrollTo`)  -> `Update` -> `StopRaf` -> `cancelAnimationFrame` id=2  -> `startRaf`  -> ....

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Another bug was found where the scrollbar was not visible when scroll by hover in translate mode.
this is because showScrollbarTrack function in the ui/useScroll refer wrong isVerticalScrollbarVisible value . 
The issue is not reproduced after page refresh(f5), it happens when user change the scrollMode dynamically on Sampler.
This seems to be related to WRO-582.
So, the issue won't be handled on this issue. Hopefully this will be resolved in WRO-582 when functions are changed to useCallback.

### Links
[//]: # (Related issues, references)
WRO-8225

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)

