### PR TITLE
WRO-4920: Ignore scrollThumb and scrollbarPlaceholder when focus persist and restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Panels.Panel` to restore focus properly when it has `sandstone/Scroller` with `focusableScrollbar`
+
 ## [2.5.0-rc.2] - 2022-07-06
 
 ### Fixed

--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -261,7 +261,7 @@ const PanelDecorator = hoc({defaultElement: `.${componentCss.body} *`}, (config,
 			defaultElement,
 			enterTo: 'last-focused',
 			lastFocusedPersist: (node, all) => {
-				const filtered = all.filter(element => element && element.dataset && !element.dataset.spotlightIgnoreRestore);
+				const filtered = all.filter(element => element && !element.dataset?.spotlightIgnoreRestore);
 				const container = typeof node === 'string';
 				return {
 					container,
@@ -270,7 +270,7 @@ const PanelDecorator = hoc({defaultElement: `.${componentCss.body} *`}, (config,
 				};
 			},
 			lastFocusedRestore: ({container, key}, all) => {
-				const filtered = all.filter(element => element && element.dataset && !element.dataset.spotlightIgnoreRestore);
+				const filtered = all.filter(element => element && !element.dataset?.spotlightIgnoreRestore);
 				return container ? key : filtered[key];
 			},
 			preserveId: true

--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -260,6 +260,19 @@ const PanelDecorator = hoc({defaultElement: `.${componentCss.body} *`}, (config,
 			continue5WayHold: true,
 			defaultElement,
 			enterTo: 'last-focused',
+			lastFocusedPersist: (node, all) => {
+				const filtered = all.filter(element => element && element.dataset && !element.dataset.spotlightIgnoreRestore);
+				const container = typeof node === 'string';
+				return {
+					container,
+					element: !container,
+					key: container ? node : filtered.indexOf(node)
+				};
+			},
+			lastFocusedRestore: ({container, key}, all) => {
+				const filtered = all.filter(element => element && element.dataset && !element.dataset.spotlightIgnoreRestore);
+				return container ? key : filtered[key];
+			},
 			preserveId: true
 		}),
 		Slottable({slots: ['header']}),

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -203,11 +203,11 @@ const WithVirtualListSamplesBase = ({args, rtl}) => {
 						<subtitle>2-Item VirtualList filling just the space it needs</subtitle>
 					</Header>
 					<VirtualList
-						id={'virtualList_$' + index}
+						id={'virtualList_' + index}
 						itemSize={itemSize}
 						itemRenderer={itemRenderer}
 						dataSize={2}
-						spotlightId={'virtualList_$' + index}
+						spotlightId={'virtualList_' + index}
 					/>
 				</Panel>
 			</FixedPopupPanels>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -142,9 +142,11 @@ const WithVirtualListSamplesBase = ({args, rtl}) => {
 							size={itemHeight * 4}
 							component={VirtualList}
 							childProps={{onClick: nextPanel, onKeyDown: handleKeyDown}}
+							id={'virtualList_' + index}
 							itemSize={itemSize}
 							itemRenderer={itemRenderer}
 							dataSize={20}
+							spotlightId={'virtualList_' + index}
 						/>
 						<Cell shrink component={BodyText}>
 							This text should be visible.
@@ -166,9 +168,11 @@ const WithVirtualListSamplesBase = ({args, rtl}) => {
 						<Cell size={itemHeight * 3}>
 							<VirtualList
 								childProps={{onClick: nextPanel, onKeyDown: handleKeyDown}}
+								id={'virtualList_' + index}
 								itemSize={itemSize}
 								itemRenderer={itemRenderer}
 								dataSize={3}
+								spotlightId={'virtualList_' + index}
 							/>
 						</Cell>
 						<Cell shrink component={BodyText}>
@@ -186,9 +190,11 @@ const WithVirtualListSamplesBase = ({args, rtl}) => {
 					</Header>
 					<VirtualList
 						childProps={{onClick: nextPanel, onKeyDown: handleKeyDown}}
+						id={'virtualList_' + index}
 						itemSize={itemSize}
 						itemRenderer={itemRenderer}
 						dataSize={20}
+						spotlightId={'virtualList_' + index}
 					/>
 				</Panel>
 				<Panel>
@@ -196,7 +202,13 @@ const WithVirtualListSamplesBase = ({args, rtl}) => {
 						<title>Panel 4</title>
 						<subtitle>2-Item VirtualList filling just the space it needs</subtitle>
 					</Header>
-					<VirtualList itemSize={itemSize} itemRenderer={itemRenderer} dataSize={2} />
+					<VirtualList
+						id={'virtualList_$' + index}
+						itemSize={itemSize}
+						itemRenderer={itemRenderer}
+						dataSize={2}
+						spotlightId={'virtualList_$' + index}
+					/>
 				</Panel>
 			</FixedPopupPanels>
 			<Button onClick={toggleOpen}>Open FixedPopupPanels</Button>

--- a/useScroll/ScrollbarPlaceholder.js
+++ b/useScroll/ScrollbarPlaceholder.js
@@ -37,7 +37,7 @@ const ScrollbarPlaceholder = () => {
 		}, 0); // Wait for unmounting placeholder node.
 	}, []);
 
-	return (showPlaceholder ? (<SpotlightPlaceholder onSpotlightDisappear={resetFocus} />) : null);
+	return (showPlaceholder ? (<SpotlightPlaceholder onSpotlightDisappear={resetFocus} data-spotlight-ignore-restore />) : null);
 };
 
 ScrollbarPlaceholder.displayName = 'ScrollbarPlaceholder';

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -113,7 +113,12 @@ const ScrollbarTrack = forwardRef((props, ref) => {
 	}, [consumeEventWithScroll, ref, rtl, vertical]);
 	return (
 		<div {...rest} className={classNames(className, scrollbarTrackCss && scrollbarTrackCss.scrollbarTrack)} ref={ref}>
-			<ScrollbarThumb aria-label={ariaLabel} className={classNames(css.thumb, scrollbarTrackCss && scrollbarTrackCss.thumb)} onKeyDown={onKeyDown}>
+			<ScrollbarThumb
+				aria-label={ariaLabel}
+				className={classNames(css.thumb, scrollbarTrackCss && scrollbarTrackCss.thumb)}
+				data-spotlight-ignore-restore
+				onKeyDown={onKeyDown}
+			>
 				<div className={classNames(css.directionIndicator, css.backward)} />
 				<div className={classNames(css.directionIndicator, css.forward)} />
 			</ScrollbarThumb>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus restored to wrong element when returning panel in case focusable scrollbar


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Ignore scrollThumb and scrollbarPlaceholder when focus persist and restore.
This method has already been applied at https://github.com/enactjs/enact/pull/2994 (for moonstone)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I found FixedPopupPanels/WithVirtualList qa-sampler does not restore focus. So I fixed it in this PR.

### Links
[//]: # (Related issues, references)
WRO-4920

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
