### PR TITLE
WRO-679: Remove aria-hidden in Input component

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -372,7 +372,8 @@ const InputPopupBase = kind({
 		minLength,
 		...rest
 	}) => {
-
+		const id = `inputPopup`;
+		const ariaLabelledBy = popupAriaLabel ? null : `${id}_title ${id}_subtitle`;
 		const inputProps = extractInputFieldProps(rest);
 		const numberMode = (numberInputField !== 'field') && (type === 'number' || type === 'passwordnumber');
 		// Set up the back button
@@ -386,7 +387,7 @@ const InputPopupBase = kind({
 				size="small"
 			/>
 		) : null);
-		const heading = <Heading size="title" marqueeOn="render" alignment="center" className={css.title}>{title}</Heading>;
+		const heading = <Heading id={`${id}_title`} size="title" marqueeOn="render" alignment="center" className={css.title}>{title}</Heading>;
 
 		delete rest.length;
 		delete rest.onComplete;
@@ -395,12 +396,15 @@ const InputPopupBase = kind({
 		return (
 			<Popup
 				aria-label={popupAriaLabel}
+				aria-labelledby={ariaLabelledBy}
 				onClose={onClose}
 				onShow={onShow}
 				position={popupType === 'fullscreen' ? 'fullscreen' : 'center'}
 				className={popupClassName}
+				noAlertRole
 				noAnimation
 				open={open}
+				role="region"
 			>
 				{popupType === 'fullscreen' ? backButton : null}
 				<Layout orientation="vertical" align={`center ${numberMode ? 'space-between' : ''}`} className={css.body}>
@@ -412,7 +416,7 @@ const InputPopupBase = kind({
 								{heading}
 							</>
 						}
-						<Heading size="subtitle" marqueeOn="render" alignment="center" className={css.subtitle}>{subtitle}</Heading>
+						<Heading id={`${id}_subtitle`} size="subtitle" marqueeOn="render" alignment="center" className={css.subtitle}>{subtitle}</Heading>
 					</Cell>
 					<Cell shrink className={css.inputArea}>
 						{numberMode ?
@@ -439,7 +443,6 @@ const InputPopupBase = kind({
 								autoFocus
 								type={type}
 								defaultValue={value}
-								noReadoutOnFocus
 								placeholder={placeholder}
 								onBeforeChange={onBeforeChange}
 								onKeyDown={onInputKeyDown}

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -93,15 +93,6 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			dismissOnEnter: PropTypes.bool,
 
 			/**
-			 * Prevent reading on the first focus.
-			 *
-			 * @type {Boolean}
-			 * @default false
-			 * @private
-			 */
-			noReadoutOnFocus: PropTypes.bool,
-
-			/**
 			 * Called when the internal <input> is focused.
 			 *
 			 * @type {Function}
@@ -144,7 +135,6 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.focused = null;
 			this.node = null;
 			this.fromMouse = false;
-			this.ariaHidden = props.noReadoutOnFocus || null;
 			this.paused = new Pause('InputSpotlightDecorator');
 			this.handleKeyDown = handleKeyDown.bind(this);
 			this.prevStatus = {
@@ -170,8 +160,6 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		updateFocus = () => {
-			this.ariaHidden = null;
-
 			// focus node if `InputSpotlightDecorator` is pausing Spotlight or if Spotlight is paused
 			if (
 				this.node &&
@@ -374,13 +362,11 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		render () {
 			const props = Object.assign({}, this.props);
 			delete props.autoFocus;
-			delete props.noReadoutOnFocus;
 			delete props.onActivate;
 			delete props.onDeactivate;
 
 			return (
 				<Component
-					aria-hidden={this.ariaHidden}
 					{...props}
 					onBlur={this.onBlur}
 					onMouseDown={this.onMouseDown}

--- a/samples/qa-a11y/src/views/Input.js
+++ b/samples/qa-a11y/src/views/Input.js
@@ -8,38 +8,38 @@ const InputView = () => (
 	<>
 		<Section title="Default">
 			<Input alt="With No Placeholder" subtitle="Subtitle" title="Title" />
-			<Input alt="With defaultValue" defaultValue="Default Value" subtitle="Subtitle" title="Title" />
+			<Input alt="With DefaultValue" defaultValue="Default Value" subtitle="Subtitle" title="Title" />
 			<Input alt="With Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" />
-			<Input alt="Disabled with Placeholder" disabled placeholder="Placeholder" subtitle="Subtitle" title="Title" />
+			<Input alt="Disabled With Placeholder" disabled placeholder="Placeholder" subtitle="Subtitle" title="Title" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="With type">
-			<Input alt="Number Type With Title, Subtitle, and Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
-			<Input alt="Disabled Number Type with Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="number" value="1234" />
-			<Input alt="Passwordnumber Type with Title, Subtitle, and Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="passwordnumber" />
-			<Input alt="Disabled Passwordnumber Type with Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="passwordnumber" value="1234" />
-			<Input alt="Password Type With Title, Subtitle, and Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="password" />
-			<Input alt="Disabled Password Type With Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="password" value="1234" />
-			<Input alt="Url Type With Title, Subtitle, and Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="url" />
-			<Input alt="Disabled Url Type With Title, Subtitle, and Value" disabled subtitle="Subtitle" title="Title" type="url" value="http://enactjs.com" />
+			<Input alt="Number Type With Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
+			<Input alt="Disabled Number Type With Value" disabled subtitle="Subtitle" title="Title" type="number" value="1234" />
+			<Input alt="Passwordnumber Type With Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="passwordnumber" />
+			<Input alt="Disabled Passwordnumber Type With Value" disabled subtitle="Subtitle" title="Title" type="passwordnumber" value="1234" />
+			<Input alt="Password Type With Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="password" />
+			<Input alt="Disabled Password Type With Value" disabled subtitle="Subtitle" title="Title" type="password" value="1234" />
+			<Input alt="Url Type With Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" type="url" />
+			<Input alt="Disabled Url Type With Value" disabled subtitle="Subtitle" title="Title" type="url" value="http://enactjs.com" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="With iconAfter">
-			<Input alt="With iconAfter" iconAfter="lock" />
-			<Input alt="Disabled With iconAfter" disabled iconAfter="lock" />
+			<Input alt="With iconAfter Without Titles" iconAfter="lock" />
+			<Input alt="Disabled With iconAfter Without Titles" disabled iconAfter="lock" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="With dismissOnEnter">
-			<Input alt="With Placeholder and dismissOnEnter" dismissOnEnter placeholder="Placeholder" />
-			<Input alt="Disabled With Placeholder and dismissOnEnter" dismissOnEnter disabled placeholder="Placeholder" />
+			<Input alt="With Placeholder and dismissOnEnter Without Titles" dismissOnEnter placeholder="Placeholder" />
+			<Input alt="Disabled With Placeholder and dismissOnEnter Without Titles" dismissOnEnter disabled placeholder="Placeholder" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="Aria-labelled">
 			<Input alt="Aria-labelled" aria-label="This is a Label 0." subtitle="Subtitle" title="Title" />
 			<Input alt="Aria-labelled and Disabled" aria-label="This is a Label 1." subtitle="Subtitle" title="Title" disabled />
 			<Input alt="With popupAriaLabel" popupAriaLabel="This is a Label 2." subtitle="Subtitle" title="Title" />
-			<Input alt="Number Type With Title, Subtitle, and Placeholder" aria-label="This is a Label 3." popupAriaLabel="This is a Label 4." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
-			<Input alt="Number Type and backButtonAriaLabel With Title, Subtitle, and Placeholder" aria-label="This is a Label 5." backButtonAriaLabel="This is a Back." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
+			<Input alt="Number Type With Placeholder, Aria-labelled, and popupAriaLabel" aria-label="This is a Label 3." popupAriaLabel="This is a Label 4." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
+			<Input alt="Number Type With Placeholder Aria-labelled, and backButtonAriaLabel" aria-label="This is a Label 5." backButtonAriaLabel="This is a Back." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
 		</Section>
 	</>
 );

--- a/samples/qa-a11y/src/views/Input.js
+++ b/samples/qa-a11y/src/views/Input.js
@@ -7,10 +7,10 @@ import appCss from '../App/App.module.less';
 const InputView = () => (
 	<>
 		<Section title="Default">
-			<Input alt="With No Placeholder" />
-			<Input alt="With defaultValue" defaultValue="Default Value" />
-			<Input alt="With Placeholder" placeholder="Placeholder" />
-			<Input alt="Disabled with Placeholder" disabled placeholder="Placeholder" />
+			<Input alt="With No Placeholder" subtitle="Subtitle" title="Title" />
+			<Input alt="With defaultValue" defaultValue="Default Value" subtitle="Subtitle" title="Title" />
+			<Input alt="With Placeholder" placeholder="Placeholder" subtitle="Subtitle" title="Title" />
+			<Input alt="Disabled with Placeholder" disabled placeholder="Placeholder" subtitle="Subtitle" title="Title" />
 		</Section>
 
 		<Section className={appCss.marginTop} title="With type">
@@ -35,11 +35,11 @@ const InputView = () => (
 		</Section>
 
 		<Section className={appCss.marginTop} title="Aria-labelled">
-			<Input alt="Aria-labelled" aria-label="This is a Label 0." />
-			<Input alt="Aria-labelled and Disabled" aria-label="This is a Label 1." disabled />
-			<Input alt="With popupAriaLabel" popupAriaLabel="This is a Label 2." />
-			<Input alt="Number Type With Title, Subtitle, and Placeholder" aria-label="This is a Label 3." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
-			<Input alt="Number Type and backButtonAriaLabel With Title, Subtitle, and Placeholder" aria-label="This is a Label 4." backButtonAriaLabel="This is a Back." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
+			<Input alt="Aria-labelled" aria-label="This is a Label 0." subtitle="Subtitle" title="Title" />
+			<Input alt="Aria-labelled and Disabled" aria-label="This is a Label 1." subtitle="Subtitle" title="Title" disabled />
+			<Input alt="With popupAriaLabel" popupAriaLabel="This is a Label 2." subtitle="Subtitle" title="Title" />
+			<Input alt="Number Type With Title, Subtitle, and Placeholder" aria-label="This is a Label 3." popupAriaLabel="This is a Label 4." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
+			<Input alt="Number Type and backButtonAriaLabel With Title, Subtitle, and Placeholder" aria-label="This is a Label 5." backButtonAriaLabel="This is a Back." placeholder="Placeholder" subtitle="Subtitle" title="Title" type="number" />
 		</Section>
 	</>
 );


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Need refactoring to remove `aria-hidden` in Input component

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Revmoe `noReadoutOnFocus` prop and `aria-hidden` prop in Input component.
To meet the A11y UX specifications, I  use `role="region"` and `aria-labelledby` to read title and subtile when open Input popup  instead `aria-live="alert"`.

With `aria-live="alert"`, read all children element, so we needed `aria-hidden` to avoid reading the focused element twice.
But With `role="region"` and `aria-labelledby`, We can only read the title/subtitle. and the focus item will be read after.
I apply the same method used by Panel.

* The text read when Input popup open
AS-IS : go to previous Title SubTitle placeholder string  Input field
TO-BE: Title SubTitle placeholder string

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

According to the UX documentation, title is mandatory in inputPopup. So I added title and subtitle to a11y sample.

### Links
[//]: # (Related issues, references)
WRO-679

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
