### PR TITLE
WRO-9081: Fixed `FixedPopupPanles` and `PopupTabLayout` to restore scroll position when going back to the previous panel by left key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to restore scroll position when back to the previous panel by left key
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to restore scroll position when go back to the previous panel by left key
 - `sandstone/Panels.Panel` to restore focus properly when it has `sandstone/Scroller` with `focusableScrollbar`
 
 ## [2.5.0] - 2022-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to restore scroll position when go back to the previous panel by left key
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to restore scroll position when going back to the previous panel by left key
 - `sandstone/Panels.Panel` to restore focus properly when it has `sandstone/Scroller` with `focusableScrollbar`
 
 ## [2.5.0] - 2022-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to restore scroll position when back to the previous panel by left key
 - `sandstone/Panels.Panel` to restore focus properly when it has `sandstone/Scroller` with `focusableScrollbar`
 
 ## [2.5.0] - 2022-07-19

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -9,7 +9,7 @@
  * @exports Header
  */
 
-import {forKey, forProp, forward, forwardCustom, handle, stop} from '@enact/core/handle';
+import {forKey, forProp, forward, forwardCustom, handle, preventDefault, stop} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
@@ -50,6 +50,7 @@ const fixedPopupPanelsHandlers = {
 		({target}) => (document.querySelector(`section.${css.body}`).contains(target)),
 		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forwardCustom('onBack'),
+		preventDefault,
 		stop
 	)
 };

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -12,6 +12,7 @@
 import {forKey, forProp, forward, forwardCustom, handle, preventDefault, stop} from '@enact/core/handle';
 import useHandlers from '@enact/core/useHandlers';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
+import Spotlight from '@enact/spotlight';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import compose from 'ramda/src/compose';
 
@@ -50,6 +51,10 @@ const fixedPopupPanelsHandlers = {
 		({target}) => (document.querySelector(`section.${css.body}`).contains(target)),
 		({target}) => (getTargetByDirectionFromElement('left', target) === null),
 		forwardCustom('onBack'),
+		() => {
+			Spotlight.setPointerMode(false);
+			return true;
+		},
 		preventDefault,
 		stop
 	)

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -386,6 +386,10 @@ const tabPanelsHandlers = {
 			return document.querySelector(`section.${componentCss.body}`).contains(ev.target);
 		},
 		forwardCustom('onBack'),
+		() => {
+			Spotlight.setPointerMode(false);
+			return true;
+		},
 		preventDefault,
 		stop
 	)

--- a/PopupTabLayout/PopupTabLayout.js
+++ b/PopupTabLayout/PopupTabLayout.js
@@ -9,7 +9,7 @@
  * @exports TabPanel
  */
 
-import {forKey, forProp, forward, forwardCustom, handle, stop} from '@enact/core/handle';
+import {forKey, forProp, forward, forwardCustom, handle, preventDefault, stop} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import useHandlers from '@enact/core/useHandlers';
 import {cap} from '@enact/core/util';
@@ -386,6 +386,7 @@ const tabPanelsHandlers = {
 			return document.querySelector(`section.${componentCss.body}`).contains(ev.target);
 		},
 		forwardCustom('onBack'),
+		preventDefault,
 		stop
 	)
 };

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -485,32 +485,35 @@ const WithVariousItemsSamplesBase = ({args, rtl}) => {
 							<Button size="small" icon="arrowlargeright" onClick={nextPanel} />
 						</slotAfter>
 					</Header>
-					<Column>
-						<Cell shrink component={BodyText}>
-							A 3-Cell Layout with various items
-						</Cell>
-						<Cell>
-							<span>This is the first panel.</span>
-							<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
-							<br />
-							<br />
-							<Button size="small" onClick={handleClose}>Button2</Button>
-							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
-							<br />
-							<br />
-							<Slider />
-							<br />
-							<Button size="small" disabled>Button4</Button>
-							<Dropdown width={100} style={{margin: 0}} title="A dropdown">
-								{['a', 'b', 'c', 'd', 'e', 'f']}
-							</Dropdown>
-							<br />
-							<br />
-						</Cell>
-						<Cell shrink component={BodyText}>
-							This text should be visible.
-						</Cell>
-					</Column>
+					<Scroller>
+						<Column>
+							<Cell shrink component={BodyText}>
+								A 3-Cell Layout with various items
+							</Cell>
+							<Cell>
+								<span>This is the first panel.</span>
+								<Button size="small" disabled onClick={nextPanel} onKeyDown={handleKeyDown}>Button1</Button>
+								<br />
+								<br />
+								<Button size="small" onClick={handleClose}>Button2</Button>
+								<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button3</Button>
+								<br />
+								<br />
+								<Slider />
+								<br />
+								<Button size="small" disabled>Button4</Button>
+								<Dropdown width={100} style={{margin: 0}} title="A dropdown">
+									{['a', 'b', 'c', 'd', 'e', 'f']}
+								</Dropdown>
+								<br />
+								<br />
+							</Cell>
+							<Cell shrink component={BodyText}>
+								This text should be visible.
+							</Cell>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button5</Button>
+						</Column>
+					</Scroller>
 				</Panel>
 				<Panel>
 					<Header>

--- a/samples/sampler/stories/qa/FixedPopupPanels.js
+++ b/samples/sampler/stories/qa/FixedPopupPanels.js
@@ -512,6 +512,10 @@ const WithVariousItemsSamplesBase = ({args, rtl}) => {
 								This text should be visible.
 							</Cell>
 							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button5</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button6</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button7</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button8</Button>
+							<Button size="small" onClick={nextPanel} onKeyDown={handleKeyDown}>Button9</Button>
 						</Column>
 					</Scroller>
 				</Panel>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -277,6 +277,8 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Sound Out</Item>
 								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Balance</Item>
 								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Equalizer</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Apply to All inputs</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Reset</Item>
 							</Scroller>
 						</TabPanel>
 						<TabPanel>

--- a/samples/sampler/stories/qa/PopupTabLayout.js
+++ b/samples/sampler/stories/qa/PopupTabLayout.js
@@ -270,7 +270,14 @@ const WithVariousItemsSamplesBase = ({rtl}) => {
 					<TabPanels index={indexSound} onBack={handleSoundPrev}>
 						<TabPanel>
 							<Header title="Sound Settings" type="compact" />
-							<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Advanced Audio</Item>
+							<Scroller>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Advanced Audio</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Volume</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Select Mode</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Sound Out</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Balance</Item>
+								<Item onClick={handleSoundNext} onKeyDown={handleKeyDown(setIndexSound, indexSound)} slotAfter={<Icon>arrowsmallright</Icon>}>Equalizer</Item>
+							</Scroller>
 						</TabPanel>
 						<TabPanel>
 							<Header title="Advanced Audio" type="compact" />

--- a/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
+++ b/tests/ui/specs/FixedPopupPanels/FixedPopupPanels-specs.js
@@ -61,7 +61,7 @@ describe('FixedPopupPanels', function () {
 			await Interface.waitForEnter(2, async () => {
 				await Page.spotlightSelect();
 			});
-			await Page.delay(500);
+			await Page.delay(1000);
 
 			await Page.spotlightUp();
 			await Page.delay(500);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Cannot restore scroll position when go back to the previous panel by left key on FixedPopupPanles or PopupTabLayout

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Invoke preventDefault for scroll. (keyDown event prevented scroll action)
- Invoke Spotlight.setPointerMode(false); to change mode after click and left key for PC

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
There was Intermittent fail on ui-test, So i fixed it although it has nothing to do with this issue. 

### Links
[//]: # (Related issues, references)
WRO-9081

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
