### PR TITLE
WRO-9819: [VideoPlayer] Back button is not visible

### DIFF
--- a/VideoPlayer/VideoPlayer.module.less
+++ b/VideoPlayer/VideoPlayer.module.less
@@ -54,6 +54,7 @@
 
 		.back {
 			position: absolute;
+			z-index: 100; // Value assigned as part of the VideoPlayer API so layers may be inserted in-between
 			top: @sand-video-back-button-top;
 			.position-start-end(@sand-video-back-button-left, initial);
 		}

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -186,24 +186,19 @@ class VideoPlayerWithLayer extends Component {
 		super(props);
 	}
 
-	setVideoPlayer = (node) => {
-		this.videoPlayer = node;
-	};
-
 	render () {
 		return (
 			<div>
 				<VideoPlayer
 					feedbackHideDelay={0}
 					muted
-					ref={this.setVideoPlayer}
 					title={'Big Buck Bunny'}
 				>
 					<Video>
 						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
 					</Video>
 				</VideoPlayer>
-				<div style={{left: 0, top: 0, width: 500, height: 1080, backgroundColor: "green", position: "absolute"}}>{"screen saver"}</div>
+				<div style={{left: 0, top: 0, bottom: 0, width: 500, backgroundColor: "green", position: "absolute"}}>{"screen saver"}</div>
 			</div>
 		);
 	}

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -180,3 +180,35 @@ FastForwardWithVariousPlaybackRates.parameters = {
 		hideNoControlsWarning: true
 	}
 };
+
+class VideoPlayerWithlayer extends Component {
+	constructor (props) {
+		super(props);
+	}
+
+	setVideoPlayer = (node) => {
+		this.videoPlayer = node;
+	};
+
+	render () {
+		return (
+			<div>
+				<VideoPlayer
+					feedbackHideDelay={0}
+					muted
+					ref={this.setVideoPlayer}
+					title={'Big Buck Bunny'}
+				>
+					<Video>
+						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
+					</Video>
+				</VideoPlayer>
+				<div style={{left: 0, top: 0, width: 500, height: 1080, backgroundColor: "green", position: "absolute"}}>{"screen saver"}</div>
+			</div>
+		);
+	}
+}
+
+export const ShowBackbutton = () => <VideoPlayerWithlayer />;
+
+ShowBackbutton.storyName = 'Show a back button and a control panel';

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -181,7 +181,7 @@ FastForwardWithVariousPlaybackRates.parameters = {
 	}
 };
 
-class VideoPlayerWithlayer extends Component {
+class VideoPlayerWithLayer extends Component {
 	constructor (props) {
 		super(props);
 	}
@@ -209,6 +209,6 @@ class VideoPlayerWithlayer extends Component {
 	}
 }
 
-export const ShowBackbutton = () => <VideoPlayerWithlayer />;
+export const ShowBackbutton = () => <VideoPlayerWithLayer />;
 
 ShowBackbutton.storyName = 'Show a back button and a control panel';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
VideoPlayer: Back button is not visible when layer is created on top of VideoPlayer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add z-index value  for .back class selector.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-9819

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)