### PR TITLE
WRO-10958: Change addon 'object' to 'select' in imageItem sample.

### DIFF
--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -1,6 +1,6 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
-import {object, select} from '@enact/storybook-utils/addons/controls';
+import {select} from '@enact/storybook-utils/addons/controls';
 import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
@@ -48,7 +48,7 @@ export const _Image = (args) => (
 	</Image>
 );
 
-object('src', _Image, Config, src);
+select('src', _Image, src, Config, src.hd);
 select('sizing', _Image, ['fill', 'fit', 'none'], Config);
 
 _Image.storyName = 'Image';

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -1,5 +1,5 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, object, select, text} from '@enact/storybook-utils/addons/controls';
+import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 import {ImageItem, ImageItemBase} from '@enact/sandstone/ImageItem';
 import {ImageItem as UiImageItem} from '@enact/ui/ImageItem';
 import ri from '@enact/ui/resolution';
@@ -47,7 +47,7 @@ text('label', _ImageItem, Config, 'ImageItem label');
 select('orientation', _ImageItem, prop.orientation, Config);
 boolean('selected', _ImageItem, Config);
 boolean('showSelection', _ImageItem, Config);
-object('src', _ImageItem, Config, src);
+select('src', _ImageItem, src, Config, src.hd);
 select('orientation', _ImageItem, prop.orientation, Config);
 text('children', _ImageItem, Config, 'ImageItem Caption');
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to change addon 'object' to 'select' in ImageItem sample.
- Need to change addon 'object' to 'select' in Image sample.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Change addon 'object' to 'select' in ImageItem sample.
- Change addon 'object' to 'select' in Image sample.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]:# (Related issues, references)
WRO-10958

### Comments
