### PR TITLE
WRO-10614: TransferList POC: Added support for drag&drop for multiple items

### DIFF
--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -205,13 +205,14 @@ const TransferListBase = kind({
 			setNewList(list);
 		};
 
-		const rearrangeLists = (sourceList, destinationList, draggedElementIndex, dragOverElementIndex, setSourceList, setDestinationList) => {
+		const rearrangeLists = (sourceList, destinationList, draggedElementIndex, draggedElementList, dragOverElementIndex, setSourceList, setDestinationList) => {
 			const draggedItem = sourceList[draggedElementIndex];
 
 			if (allowMultipleDrag) {
 				selectedItems.map((item, arrayIndex) => {
+					if(item.list !== draggedElementList) return;
 					destinationList.splice(Number(dragOverElement.current) + arrayIndex, 0, item.element);
-					sourceList.splice(sourceList.findIndex((element) => element === item.element), 1);
+					sourceList.splice(sourceList.findIndex((element) => element === item.element && item.list === draggedElementList), 1);
 				});
 			} else {
 				sourceList.splice(draggedElementIndex, 1);
@@ -254,7 +255,7 @@ const TransferListBase = kind({
 			}
 			setSelectedItems(selectedListCopy);
 
-			rearrangeLists(firstListCopy, secondListCopy, index, dragOverElement.current, setFirstListLocal, setSecondListLocal);
+			rearrangeLists(firstListCopy, secondListCopy, index, list, dragOverElement.current, setFirstListLocal, setSecondListLocal);
 		};
 
 		const onDropLeftHandler = (ev) => {
@@ -281,7 +282,7 @@ const TransferListBase = kind({
 				setSelectedItems(selectedListCopy);
 			}
 
-			rearrangeLists(secondListCopy, firstListCopy, index, dragOverElement.current, setSecondListLocal, setFirstListLocal);
+			rearrangeLists(secondListCopy, firstListCopy, index, list, dragOverElement.current, setSecondListLocal, setFirstListLocal);
 		};
 
 		return (

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable react/jsx-no-bind */
+/* global Image */
 
 import kind from '@enact/core/kind';
 import {Cell, Layout} from '@enact/ui/Layout';
@@ -260,7 +261,7 @@ const TransferListBase = kind({
 
 			if (allowMultipleDrag) {
 				selectedItems.map((item, arrayIndex) => {
-					if(item.list !== draggedElementList) return;
+					if (item.list !== draggedElementList) return;
 					destinationList.splice(Number(dragOverElement.current) + arrayIndex, 0, item.element);
 					sourceList.splice(sourceList.findIndex((element) => element === item.element && item.list === draggedElementList), 1);
 				});

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -69,10 +69,14 @@ const TransferListBase = kind({
 
 		const dragOverElement = useRef();
 
+		// used for custom drag image
+		const img = new Image();
+		img.src = "https://via.placeholder.com/100x100";
+
 		useEffect(() => {
 
-			const seletCheckboxItem = document.querySelectorAll('.checkbox');
-			seletCheckboxItem.forEach(element => {
+			const selectCheckboxItem = document.querySelectorAll('.checkbox');
+			selectCheckboxItem.forEach(element => {
 				const [index, list] = element.id.split('-');
 
 				const eventListeners = ['dragstart', 'drag'];
@@ -82,8 +86,6 @@ const TransferListBase = kind({
 							console.log('dragging element with index', index, 'from list ', list);
 							ev.dataTransfer.setData('text/plain', `${index}-${list}`);
 							ev.dataTransfer.effectAllowed = 'move';
-							const img = new Image();
-							img.src = "https://via.placeholder.com/100x100";
 							ev.dataTransfer.setDragImage(img, 0, 0);
 						});
 					}

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -83,9 +83,8 @@ const TransferListBase = kind({
 							ev.dataTransfer.setData('text/plain', `${index}-${list}`);
 							ev.dataTransfer.effectAllowed = 'move';
 							const img = new Image();
-							img.src = "dragdrop.png";
-							console.log(img)
-							ev.dataTransfer.setDragImage(img, 10, 10);
+							img.src = "https://via.placeholder.com/100x100";
+							ev.dataTransfer.setDragImage(img, 0, 0);
 						});
 					}
 					if (event === 'drag') {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -52,7 +52,7 @@ const TransferListBase = kind({
 						className="checkbox"
 						id={`${index}-${list}`}
 						key={index + list}
-						onClick={clickHandle}
+						onPointerDown={clickHandle}
 						selected={-1 !== selectedItems.findIndex((pair) => pair.element === element && pair.list === list)}
 					>
 						{element}
@@ -209,30 +209,18 @@ const TransferListBase = kind({
 			const draggedItem = sourceList[draggedElementIndex];
 
 			if (allowMultipleDrag) {
-				// check if dragged item is selected or not
-				const potentialIndex = selectedItems.findIndex((pair) => pair.element === draggedItem);
-
-				if (potentialIndex === -1) {
-					// move also the dragged item
-					destinationList.splice(Number(dragOverElement.current), 0, draggedItem);
-					sourceList.splice(sourceList.findIndex((element) => element === draggedItem), 1);
-				}
-
 				selectedItems.map((item, arrayIndex) => {
 					destinationList.splice(Number(dragOverElement.current) + arrayIndex, 0, item.element);
 					sourceList.splice(sourceList.findIndex((element) => element === item.element), 1);
 				});
-
-				dragOverElement.current = null;
-				setSourceList(sourceList);
-				setDestinationList(destinationList);
 			} else {
 				sourceList.splice(draggedElementIndex, 1);
 				destinationList.splice(dragOverElementIndex, 0, draggedItem);
-				dragOverElement.current = null;
-				setSourceList(sourceList);
-				setDestinationList(destinationList);
 			}
+
+			dragOverElement.current = null;
+			setSourceList(sourceList);
+			setDestinationList(destinationList);
 		};
 
 		const getTransferData = (dataTransferObj) => {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -1,5 +1,4 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-/* eslint-disable react/jsx-no-bind */
 /* global Image */
 
 import kind from '@enact/core/kind';
@@ -58,11 +57,6 @@ const TransferListBase = kind({
 					onSelect(element, index, list);
 				}, [element, index, list, onSelect]); // eslint-disable-line react-hooks/exhaustive-deps
 
-				const handleKeyDown = useCallback((ev) => {
-					if (ev.code !== 'Enter') return;
-					onSelect(element, index, list);
-				}, [element, index, list, onSelect])
-
 				const handleSpotlightDown = useCallback((ev) => {
 					if (elements.length - 1 !== index) return;
 					ev.preventDefault();
@@ -82,8 +76,7 @@ const TransferListBase = kind({
 						className={componentCss.draggableItem}
 						id={`${index}-${list}`}
 						key={index + list}
-						onKeyDown={handleKeyDown}
-						onPointerDown={handleClick}
+						onClick={handleClick}
 						onSpotlightDown={handleSpotlightDown}
 						onSpotlightUp={handleSpotlightUp}
 						selected={selected}
@@ -259,7 +252,7 @@ const TransferListBase = kind({
 			}
 		}, [selectedItems]);
 
-		const rearrangeList = (dragOverElementIndex, itemIndex, list, setNewList) => {
+		const rearrangeList = (dragOverElementIndex, itemIndex, list, listName, setNewList) => {
 			const draggedItem = list[itemIndex];
 			list.splice(itemIndex, 1);
 			list.splice(dragOverElementIndex, 0, draggedItem);
@@ -270,6 +263,13 @@ const TransferListBase = kind({
 			const draggedItem = sourceList[draggedElementIndex];
 
 			if (allowMultipleDrag) {
+				const potentialIndex = selectedItems.findIndex((pair) => pair.element === draggedItem);
+
+				if (potentialIndex === -1) {
+					destinationList.splice(Number(dragOverElement.current), 0, draggedItem);
+					sourceList.splice(sourceList.findIndex((element) => element === draggedItem), 1);
+				}
+
 				selectedItems.map((item, arrayIndex) => {
 					if (item.list !== draggedElementList) return;
 					destinationList.splice(Number(dragOverElement.current) + arrayIndex, 0, item.element);
@@ -301,7 +301,7 @@ const TransferListBase = kind({
 			const firstListCopy = [...firstListLocal];
 
 			if (list === 'second') {
-				rearrangeList(dragOverElement.current, index, secondListCopy, setSecondListLocal);
+				rearrangeList(dragOverElement.current, index, secondListCopy, list, setSecondListLocal);
 				return;
 			}
 
@@ -327,7 +327,7 @@ const TransferListBase = kind({
 			const secondListCopy = [...secondListLocal];
 
 			if (list === 'first') {
-				rearrangeList(dragOverElement.current, index, firstListCopy, setFirstListLocal);
+				rearrangeList(dragOverElement.current, index, firstListCopy, list, setFirstListLocal);
 				return;
 			}
 

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -214,10 +214,8 @@ const TransferListBase = kind({
 				}
 
 				selectedItems.map((item, arrayIndex) => {
-					if (item.list === 'first') {
-						destinationList.splice(Number(dragOverElement.current) + arrayIndex, 0, item.element);
-						sourceList.splice(sourceList.findIndex((element) => element === item.element), 1);
-					}
+					destinationList.splice(Number(dragOverElement.current) + arrayIndex, 0, item.element);
+					sourceList.splice(sourceList.findIndex((element) => element === item.element), 1);
 				});
 
 				dragOverElement.current = null;
@@ -279,9 +277,16 @@ const TransferListBase = kind({
 			}
 
 			const potentialIndex = selectedItems.findIndex((pair) => pair.element === secondListCopy[index] && pair.list === list);
+
 			if (potentialIndex !== -1) {
 				const selectedListCopy = [...selectedItems];
-				selectedListCopy.splice(potentialIndex, 1);
+				if (allowMultipleDrag) {
+					selectedItems.map((item) => {
+						selectedListCopy.splice(selectedListCopy.findIndex((pair) => pair.element === item.element && pair.list === item.list), 1);
+					});
+				} else {
+					selectedListCopy.splice(potentialIndex, 1);
+				}
 				setSelectedItems(selectedListCopy);
 			}
 

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -58,6 +58,11 @@ const TransferListBase = kind({
 					onSelect(element, index, list);
 				}, [element, index, list, onSelect]); // eslint-disable-line react-hooks/exhaustive-deps
 
+				const handleKeyDown = useCallback((ev) => {
+					if (ev.code !== 'Enter') return;
+					onSelect(element, index, list);
+				}, [element, index, list, onSelect])
+
 				const handleSpotlightDown = useCallback((ev) => {
 					if (elements.length - 1 !== index) return;
 					ev.preventDefault();
@@ -77,6 +82,7 @@ const TransferListBase = kind({
 						className={componentCss.draggableItem}
 						id={`${index}-${list}`}
 						key={index + list}
+						onKeyDown={handleKeyDown}
 						onPointerDown={handleClick}
 						onSpotlightDown={handleSpotlightDown}
 						onSpotlightUp={handleSpotlightUp}

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -82,6 +82,10 @@ const TransferListBase = kind({
 							console.log('dragging element with index', index, 'from list ', list);
 							ev.dataTransfer.setData('text/plain', `${index}-${list}`);
 							ev.dataTransfer.effectAllowed = 'move';
+							const img = new Image();
+							img.src = "dragdrop.png";
+							console.log(img)
+							ev.dataTransfer.setDragImage(img, 10, 10);
 						});
 					}
 					if (event === 'drag') {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -256,17 +256,15 @@ const TransferListBase = kind({
 
 			const potentialIndex = selectedItems.findIndex((pair) => pair.element === firstListCopy[index] && pair.list === list);
 
-			if (potentialIndex !== -1) {
-				const selectedListCopy = [...selectedItems];
-				if (allowMultipleDrag) {
-					selectedItems.map((item) => {
-						selectedListCopy.splice(selectedListCopy.findIndex((pair) => pair.element === item.element && pair.list === item.list), 1);
-					});
-				} else {
-					selectedListCopy.splice(potentialIndex, 1);
-				}
-				setSelectedItems(selectedListCopy);
+			const selectedListCopy = [...selectedItems];
+			if (allowMultipleDrag) {
+				selectedItems.map((item) => {
+					selectedListCopy.splice(selectedListCopy.findIndex((pair) => pair.element === item.element && pair.list === item.list), 1);
+				});
+			} else {
+				selectedListCopy.splice(potentialIndex, 1);
 			}
+			setSelectedItems(selectedListCopy);
 
 			rearrangeLists(firstListCopy, secondListCopy, index, dragOverElement.current, setFirstListLocal, setSecondListLocal);
 		};

--- a/samples/sampler/stories/default/TransferList.js
+++ b/samples/sampler/stories/default/TransferList.js
@@ -1,7 +1,7 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean} from '@enact/storybook-utils/addons/controls';
 
-import TransferList from '../../../../TransferList';
+import TransferList, {TransferListBase, TransferListDecorator} from '@enact/sandstone/TransferList';
 
 TransferList.displayName = 'TransferList';
 

--- a/samples/sampler/stories/default/TransferList.js
+++ b/samples/sampler/stories/default/TransferList.js
@@ -1,5 +1,9 @@
-import ri from '@enact/ui/resolution';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
+import {boolean} from '@enact/storybook-utils/addons/controls';
+
 import TransferList from '../../../../TransferList';
+
+const Config = mergeComponentMetadata('TransferList', TransferList);
 
 TransferList.displayName = 'TransferList';
 
@@ -8,12 +12,15 @@ export default {
 	component: 'TransferList'
 };
 
-export const _TransferList = () => (
+export const _TransferList = (args) => (
 	<TransferList
+		allowMultipleDrag={args['allowMultipleDrag']}
 		firstList={['Item1', 'Item2', 'Item3', 'Item4', 'Item5', 'Item6', 'Item7', 'Item8']}
 		secondList={['Item9', 'Item10', 'Item11', 'Item12', 'Item13', 'Item14', 'Item15', 'Item16']}
 	/>
 );
+
+boolean('allowMultipleDrag', _TransferList, Config, true);
 
 _TransferList.storyName = 'TransferList';
 _TransferList.parameters = {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For dragging and dropping items from a list to another, by default only the item that is dragged was moved to the other list

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a new prop "allowMultipleDrag". When this is true, all the selected items, together with the dragged item will be moved to the destination list


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-614

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)