### PR TITLE
WRO-10990: Fixed `VideoPlayer` to not seek inifinitely when pointer moves while holding key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/VideoPlayer` to not seek infinitely when pointer moved while holding left or right key
+- `sandstone/VideoPlayer` to not seek infinitely when pointer moves while holding left or right key
 
 ## [2.5.2] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Icon` supported icon list, adding a new icon `musicsrc` 
 
+### Fixed
+
+- `sandstone/VideoPlayer` to not seek infinitely when pointer moved while holding left or right key
+
 ## [2.5.2] - 2022-08-17
 
 No significant changes.

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -2141,7 +2141,6 @@ const VideoPlayerBase = class extends Component {
 								no5WayJump={no5WayJump}
 								onClose={this.handleMediaControlsClose}
 								onFastForward={this.handleFastForward}
-								onJump={this.handleJump}
 								onJumpBackwardButtonClick={this.onJumpBackward}
 								onJumpForwardButtonClick={this.onJumpForward}
 								onPause={this.handlePause}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`VideoPlayer` seeks infinitely when pointer moves while holding left or right key

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Currently, `VideoPlayer` seeking logic is two fold. One is inside `VideoPlayer` and another is in `MediaControls`.
The one in `MediaControls` seems redundant and causes this issue so I removed `onJump` handler from it.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-10990

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
