### PR TITLE
WRO-11388: Scroller: Fixed to not show the focus effect of the body in pointer mode when focusableScrollbar is `byEnter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to not show the focus effect of the body in pointer mode when `focusableScrollbar` prop is `byEnter`
+
 ## [2.5.3] - 2022-08-30
 
 ### Added

--- a/Scroller/Scroller.module.less
+++ b/Scroller/Scroller.module.less
@@ -20,9 +20,11 @@
 	}
 
 	.focus({
-		&::before {
-			background-color: @sand-scroll-focusablebody-focus-bg-color;
-			opacity: 1;
+		:global(.spotlight-input-key)& {
+			&::before {
+				background-color: @sand-scroll-focusablebody-focus-bg-color;
+				opacity: 1;
+			}
 		}
 	})
 }


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus effect was shown when click the body in pointer mode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
According to the UX document, focus effect should not be shown in pointer mode.
So I fixed related style. the focus color will be shown only in key mode.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11388

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
