### PR TITLE
Change the bg color of focused item in game skin

### DIFF
--- a/styles/colors-game.less
+++ b/styles/colors-game.less
@@ -11,7 +11,7 @@
 
 @sand-game-skin-heading-border-color: #8151ff;
 @sand-game-skin-item-focus-bg-gradient-1: fade(#603091, 0%);
-@sand-game-skin-item-focus-bg-gradient-2: #982929;
+@sand-game-skin-item-focus-bg-gradient-2: #6D2FA1;
 
 
 // UI Conceptual Colors

--- a/styles/colors-game.less
+++ b/styles/colors-game.less
@@ -11,7 +11,7 @@
 
 @sand-game-skin-heading-border-color: #8151ff;
 @sand-game-skin-item-focus-bg-gradient-1: fade(#603091, 0%);
-@sand-game-skin-item-focus-bg-gradient-2: #6D2FA1;
+@sand-game-skin-item-focus-bg-gradient-2: #6d2fa1;
 
 
 // UI Conceptual Colors


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
There is a request from GUI to change the background color of focused item.

### Resolution
The background color of focused item is changed to `#6D2FA1` from `#982929` in Game skin.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
WRO-11412


### Comments
