### PR TITLE
WRO-11353: Fix storybook/docs tab

### DIFF
--- a/samples/sampler/.storybook/components/DocsContainer.js
+++ b/samples/sampler/.storybook/components/DocsContainer.js
@@ -1,0 +1,25 @@
+import {DocsContainer as BaseContainer} from '@storybook/addon-docs';
+
+export const DocsContainer = ({ children, context }) => {
+	return (
+		<BaseContainer
+			context={{
+				...context,
+				storyById: (id) => {
+					const storyContext = context.storyById(id);
+					return {
+						...storyContext,
+						parameters: {
+							...storyContext?.parameters,
+							docs: {
+								...storyContext?.parameters?.docs,
+							},
+						},
+					};
+				},
+			}}
+		>
+			{children}
+		</BaseContainer>
+	);
+};

--- a/samples/sampler/.storybook/components/DocsPage.js
+++ b/samples/sampler/.storybook/components/DocsPage.js
@@ -1,0 +1,10 @@
+import {Description, Primary, Subtitle, Title} from '@storybook/addon-docs';
+
+export const DocsPage = () => (
+	<>
+		<Title />
+		<Subtitle />
+		<Description />
+		<Primary />
+	</>
+);

--- a/samples/sampler/.storybook/main.js
+++ b/samples/sampler/.storybook/main.js
@@ -10,8 +10,8 @@ module.exports = {
 	addons: [
 		'@enact/storybook-utils/addons/actions/register',
 		'@enact/storybook-utils/addons/controls/register',
-		'@enact/storybook-utils/addons/docs/register',
-		'@enact/storybook-utils/addons/toolbars/register'
+		'@enact/storybook-utils/addons/toolbars/register',
+		'@storybook/addon-docs'
 	],
 	webpackFinal: async (config, {configType}) => {
 		return webpack(config, configType, __dirname);

--- a/samples/sampler/.storybook/preview.js
+++ b/samples/sampler/.storybook/preview.js
@@ -1,8 +1,9 @@
 import {configureActions} from '@enact/storybook-utils/addons/actions';
 import {getBooleanType, getObjectType} from '@enact/storybook-utils/addons/controls';
-import {DocsPage, DocsContainer} from '@enact/storybook-utils/addons/docs';
 import {themes} from '@storybook/theming';
 
+import {DocsContainer} from './components/DocsContainer';
+import {DocsPage} from './components/DocsPage'
 import ThemeEnvironment from '../src/ThemeEnvironment'
 
 // NOTE: Locales taken from strawman. Might need to add more in the future.

--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@enact/storybook-utils": "^4.2.0",
     "@storybook/addons": "6.3.12",
+    "@storybook/addon-docs": "^6.3.12",
     "@storybook/react": "6.3.12",
     "@storybook/theming": "6.3.12",
     "babel-loader": "^8.2.5",


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Error messages are shown in chrome devtools console tab when docs page is opened in Storybook

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Created custom DocsContainer and DocsPage components in order to render the docs page

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11353

### Comments
