### PR TITLE
WRO-11048: Change the image used in the sample to svg

### DIFF
--- a/samples/qa-a11y/src/views/Alert.js
+++ b/samples/qa-a11y/src/views/Alert.js
@@ -11,7 +11,7 @@ import appCss from '../App/App.module.less';
 const AlertView = () => {
 	const [open, handleOpen] = useArrayState(8);
 	const svgGenerator = (width, height, bgColor, textColor, customText) => (
-		`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+		`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 	);
 
 	return (

--- a/samples/qa-a11y/src/views/Alert.js
+++ b/samples/qa-a11y/src/views/Alert.js
@@ -11,7 +11,9 @@ import appCss from '../App/App.module.less';
 const AlertView = () => {
 	const [open, handleOpen] = useArrayState(8);
 	const svgGenerator = (width, height, bgColor, textColor, customText) => (
-		`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+		`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+		`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+		`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 	);
 
 	return (

--- a/samples/qa-a11y/src/views/Alert.js
+++ b/samples/qa-a11y/src/views/Alert.js
@@ -6,8 +6,6 @@ import useArrayState from '../components/useArrayState';
 
 import appCss from '../App/App.module.less';
 
-
-
 const AlertView = () => {
 	const [open, handleOpen] = useArrayState(8);
 	const svgGenerator = (width, height, bgColor, textColor, customText) => (

--- a/samples/qa-a11y/src/views/Alert.js
+++ b/samples/qa-a11y/src/views/Alert.js
@@ -6,8 +6,13 @@ import useArrayState from '../components/useArrayState';
 
 import appCss from '../App/App.module.less';
 
+
+
 const AlertView = () => {
 	const [open, handleOpen] = useArrayState(8);
+	const svgGenerator = (width, height, bgColor, textColor, customText) => (
+		`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+	);
 
 	return (
 		<>
@@ -59,7 +64,7 @@ const AlertView = () => {
 				title="Heading Title"
 			>
 				<image>
-					<AlertImage src={'https://via.placeholder.com/250.png?text=image'} type="thumbnail" />
+					<AlertImage src={svgGenerator(250, 250, 'd8d8d8', '6e6e6e', 'image')} type="thumbnail" />
 				</image>
 				<span>Content</span>
 				<buttons>
@@ -126,7 +131,7 @@ const AlertView = () => {
 				type="overlay"
 			>
 				<image>
-					<AlertImage src={'https://via.placeholder.com/250.png?text=image'} type="thumbnail" />
+					<AlertImage src={svgGenerator(250, 250, 'd8d8d8', '6e6e6e', 'image')} type="thumbnail" />
 				</image>
 				<span>
 					Content

--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -13,7 +13,7 @@ const SelectableImageItem = (props) => {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
 	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );

--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -13,7 +13,7 @@ const SelectableImageItem = (props) => {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const labelAndSrc = {

--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -13,7 +13,9 @@ const SelectableImageItem = (props) => {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const labelAndSrc = {

--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -13,7 +13,7 @@ const SelectableImageItem = (props) => {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const labelAndSrc = {

--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -12,9 +12,13 @@ const SelectableImageItem = (props) => {
 	return <ImageItem {...props} onClick={handleClick} selected={checked} />; // eslint-disable-line react/jsx-no-bind
 };
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const labelAndSrc = {
 	label: 'Label',
-	src: 'http://via.placeholder.com/200x200/7ed31d/ffffff'
+	src: svgGenerator(200, 200, 'f3d31d', 'ffffff', '200 X 200')
 };
 
 const ImageItemView = () => (

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -12,8 +12,9 @@ const tabsWithIcons = [
 	{title: 'Button', icon: 'gear'},
 	{title: 'Item', icon: 'trash'}
 ];
+
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
 	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -13,7 +13,7 @@ const tabsWithIcons = [
 	{title: 'Item', icon: 'trash'}
 ];
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 const images = new Array(20).fill().map( (_, i) =>
 	<Image

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -12,12 +12,14 @@ const tabsWithIcons = [
 	{title: 'Button', icon: 'gear'},
 	{title: 'Item', icon: 'trash'}
 ];
-
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
 const images = new Array(20).fill().map( (_, i) =>
 	<Image
 		key={`image${i}`}
 		caption="Image"
-		src="http://via.placeholder.com/360x240/"
+		src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 		style={{marginBottom: scaleToRem(96)}}
 	/>
 );

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -13,7 +13,7 @@ const tabsWithIcons = [
 	{title: 'Item', icon: 'trash'}
 ];
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 const images = new Array(20).fill().map( (_, i) =>
 	<Image

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -13,7 +13,9 @@ const tabsWithIcons = [
 	{title: 'Item', icon: 'trash'}
 ];
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 const images = new Array(20).fill().map( (_, i) =>
 	<Image

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -8,7 +8,7 @@ import ri from '@enact/ui/resolution';
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
 	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -7,10 +7,14 @@ import ri from '@enact/ui/resolution';
 
 const items = [];
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 for (let i = 0; i < 20; i++) {
 	const
 		color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
-		source = `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`;
+		source = svgGenerator(300, 300, color, 'ffffff', `Image ${i}`);
 
 	items.push({source});
 }

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -8,7 +8,9 @@ import ri from '@enact/ui/resolution';
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 for (let i = 0; i < 20; i++) {

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -8,7 +8,7 @@ import ri from '@enact/ui/resolution';
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 for (let i = 0; i < 20; i++) {

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -12,7 +12,7 @@ import css from './VirtualGridList.module.less';
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -12,7 +12,9 @@ import css from './VirtualGridList.module.less';
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -12,10 +12,11 @@ import css from './VirtualGridList.module.less';
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
 	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
+
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	const {caption, label, src} = items[index];

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -10,6 +10,10 @@ import {useState} from 'react';
 import css from './VirtualGridList.module.less';
 
 const items = [];
+
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	const {caption, label, src} = items[index];
@@ -32,9 +36,9 @@ for (let i = 0; i < 100; i++) {
 		color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
 		label = `SubItem ${count}`,
 		src = {
-			'hd': `http://via.placeholder.com/200x200/${color}/ffffff/png?text=Image+${i}`,
-			'fhd': `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`,
-			'uhd': `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${i}`
+			'hd': svgGenerator(200, 200, color, 'ffffff', `Image ${i}`),
+			'fhd': svgGenerator(300, 300, color, 'ffffff', `Image ${i}`),
+			'uhd': svgGenerator(600, 600, color, 'ffffff', `Image ${i}`)
 		};
 
 	items.push({caption, label, src});

--- a/samples/qa-virtualgridlist/src/utils/index.js
+++ b/samples/qa-virtualgridlist/src/utils/index.js
@@ -1,7 +1,7 @@
 import {ITEM_SPACING, RECORD_COUNT, MIN_HEIGHT, MIN_WIDTH, MODIFIER_FREQUENCY} from '../defaultConfiguration';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
 	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );

--- a/samples/qa-virtualgridlist/src/utils/index.js
+++ b/samples/qa-virtualgridlist/src/utils/index.js
@@ -1,7 +1,9 @@
 import {ITEM_SPACING, RECORD_COUNT, MIN_HEIGHT, MIN_WIDTH, MODIFIER_FREQUENCY} from '../defaultConfiguration';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const createRecord = ({

--- a/samples/qa-virtualgridlist/src/utils/index.js
+++ b/samples/qa-virtualgridlist/src/utils/index.js
@@ -1,5 +1,9 @@
 import {ITEM_SPACING, RECORD_COUNT, MIN_HEIGHT, MIN_WIDTH, MODIFIER_FREQUENCY} from '../defaultConfiguration';
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const createRecord = ({
 	recordIndex = 0,
 	modifierFrequency = MODIFIER_FREQUENCY,
@@ -16,7 +20,7 @@ const createRecord = ({
 		subCaption,
 		selected: false,
 		showSelection,
-		src: `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${recordIndex}`
+		src: svgGenerator(300, 300, color, 'ffffff', `Image ${recordIndex}`)
 	};
 };
 

--- a/samples/qa-virtualgridlist/src/utils/index.js
+++ b/samples/qa-virtualgridlist/src/utils/index.js
@@ -1,7 +1,7 @@
 import {ITEM_SPACING, RECORD_COUNT, MIN_HEIGHT, MIN_WIDTH, MODIFIER_FREQUENCY} from '../defaultConfiguration';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const createRecord = ({

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
@@ -6,14 +6,18 @@ import {useCallback} from 'react';
 
 import css from './SampleVirtualGridList.module.less';
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const SampleVirtualGridList = ({index, onClick, ...rest}) => {
 	const renderItem = useCallback(({index, ...rest}) => { // eslint-disable-line no-shadow
 		const
 			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
 			source = {
-				'hd': `http://via.placeholder.com/200x200/${color}/ffffff/png?text=Image+${index}`,
-				'fhd': `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${index}`,
-				'uhd': `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${index}`
+				'hd': svgGenerator(200, 200, color, 'ffffff', `Image ${index}`),
+				'fhd': svgGenerator(300, 300, color, 'ffffff', `Image ${index}`),
+				'uhd': svgGenerator(600, 600, color, 'ffffff', `Image ${index}`)
 			};
 
 		return (

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
@@ -7,7 +7,7 @@ import {useCallback} from 'react';
 import css from './SampleVirtualGridList.module.less';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
 	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
@@ -7,7 +7,9 @@ import {useCallback} from 'react';
 import css from './SampleVirtualGridList.module.less';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const SampleVirtualGridList = ({index, onClick, ...rest}) => {

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
@@ -7,7 +7,7 @@ import {useCallback} from 'react';
 import css from './SampleVirtualGridList.module.less';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const SampleVirtualGridList = ({index, onClick, ...rest}) => {

--- a/samples/sampler/npm-shrinkwrap.json
+++ b/samples/sampler/npm-shrinkwrap.json
@@ -1928,6 +1928,7 @@
             },
             "@babel/eslint-plugin": {
               "version": "7.17.7",
+              "resolved": false,
               "integrity": "sha512-JATUoJJXSgwI0T8juxWYtK1JSgoLpIGUsCHIv+NMXcUDA2vIe6nvAHR9vnuJgs/P1hOFw7vPwibixzfqBBLIVw==",
               "requires": {
                 "eslint-rule-composer": "^0.3.0"
@@ -4027,6 +4028,7 @@
             },
             "eslint-config-enact": {
               "version": "4.1.1",
+              "resolved": false,
               "integrity": "sha512-W3i5FGkm3Ow4pYEOuEm5uFzhZUyA3eg/EF4osb5u02irnKKnJuejBnFXo3OFSAxLrWz94q7ROTIK5/UMyGPnNg==",
               "requires": {
                 "@babel/core": "^7.17.8",
@@ -6921,6 +6923,7 @@
                     },
                     "mocha": {
                       "version": "10.0.0",
+                      "resolved": false,
                       "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
                       "requires": {
                         "@ungap/promise-all-settled": "1.1.2",
@@ -8547,6 +8550,7 @@
             },
             "eslint-config-prettier": {
               "version": "8.5.0",
+              "resolved": false,
               "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
             },
             "eslint-import-resolver-node": {
@@ -8589,6 +8593,7 @@
             },
             "eslint-plugin-enact": {
               "version": "1.0.1",
+              "resolved": false,
               "integrity": "sha512-rkMDrRTNGUwQmqE7ulaL2lJGpGofWDWlKdRjU85dJBnbM+AQVjuN6BzRw7B2xEoyCy4XqO9Dxl1bqSmvkgyBfg==",
               "requires": {
                 "doctrine": "^3.0.0",
@@ -9524,6 +9529,7 @@
                 },
                 "mocha": {
                   "version": "10.0.0",
+                  "resolved": false,
                   "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
                   "requires": {
                     "@ungap/promise-all-settled": "1.1.2",
@@ -9964,6 +9970,7 @@
             },
             "eslint-plugin-import": {
               "version": "2.26.0",
+              "resolved": false,
               "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
               "requires": {
                 "array-includes": "^3.1.4",
@@ -10006,6 +10013,7 @@
             },
             "eslint-plugin-jest": {
               "version": "26.5.3",
+              "resolved": false,
               "integrity": "sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==",
               "requires": {
                 "@typescript-eslint/utils": "^5.10.0"
@@ -10013,6 +10021,7 @@
             },
             "eslint-plugin-jsx-a11y": {
               "version": "6.5.1",
+              "resolved": false,
               "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
               "requires": {
                 "@babel/runtime": "^7.16.3",
@@ -10031,6 +10040,7 @@
             },
             "eslint-plugin-prettier": {
               "version": "4.0.0",
+              "resolved": false,
               "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
               "requires": {
                 "prettier-linter-helpers": "^1.0.0"
@@ -10038,6 +10048,7 @@
             },
             "eslint-plugin-react": {
               "version": "7.30.0",
+              "resolved": false,
               "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
               "requires": {
                 "array-includes": "^3.1.5",
@@ -10077,6 +10088,7 @@
             },
             "eslint-plugin-react-hooks": {
               "version": "4.5.0",
+              "resolved": false,
               "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw=="
             },
             "eslint-rule-composer": {

--- a/samples/sampler/npm-shrinkwrap.json
+++ b/samples/sampler/npm-shrinkwrap.json
@@ -1928,7 +1928,6 @@
             },
             "@babel/eslint-plugin": {
               "version": "7.17.7",
-              "resolved": false,
               "integrity": "sha512-JATUoJJXSgwI0T8juxWYtK1JSgoLpIGUsCHIv+NMXcUDA2vIe6nvAHR9vnuJgs/P1hOFw7vPwibixzfqBBLIVw==",
               "requires": {
                 "eslint-rule-composer": "^0.3.0"
@@ -4028,7 +4027,6 @@
             },
             "eslint-config-enact": {
               "version": "4.1.1",
-              "resolved": false,
               "integrity": "sha512-W3i5FGkm3Ow4pYEOuEm5uFzhZUyA3eg/EF4osb5u02irnKKnJuejBnFXo3OFSAxLrWz94q7ROTIK5/UMyGPnNg==",
               "requires": {
                 "@babel/core": "^7.17.8",
@@ -6923,7 +6921,6 @@
                     },
                     "mocha": {
                       "version": "10.0.0",
-                      "resolved": false,
                       "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
                       "requires": {
                         "@ungap/promise-all-settled": "1.1.2",
@@ -8550,7 +8547,6 @@
             },
             "eslint-config-prettier": {
               "version": "8.5.0",
-              "resolved": false,
               "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
             },
             "eslint-import-resolver-node": {
@@ -8593,7 +8589,6 @@
             },
             "eslint-plugin-enact": {
               "version": "1.0.1",
-              "resolved": false,
               "integrity": "sha512-rkMDrRTNGUwQmqE7ulaL2lJGpGofWDWlKdRjU85dJBnbM+AQVjuN6BzRw7B2xEoyCy4XqO9Dxl1bqSmvkgyBfg==",
               "requires": {
                 "doctrine": "^3.0.0",
@@ -9529,7 +9524,6 @@
                 },
                 "mocha": {
                   "version": "10.0.0",
-                  "resolved": false,
                   "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
                   "requires": {
                     "@ungap/promise-all-settled": "1.1.2",
@@ -9970,7 +9964,6 @@
             },
             "eslint-plugin-import": {
               "version": "2.26.0",
-              "resolved": false,
               "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
               "requires": {
                 "array-includes": "^3.1.4",
@@ -10013,7 +10006,6 @@
             },
             "eslint-plugin-jest": {
               "version": "26.5.3",
-              "resolved": false,
               "integrity": "sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==",
               "requires": {
                 "@typescript-eslint/utils": "^5.10.0"
@@ -10021,7 +10013,6 @@
             },
             "eslint-plugin-jsx-a11y": {
               "version": "6.5.1",
-              "resolved": false,
               "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
               "requires": {
                 "@babel/runtime": "^7.16.3",
@@ -10040,7 +10031,6 @@
             },
             "eslint-plugin-prettier": {
               "version": "4.0.0",
-              "resolved": false,
               "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
               "requires": {
                 "prettier-linter-helpers": "^1.0.0"
@@ -10048,7 +10038,6 @@
             },
             "eslint-plugin-react": {
               "version": "7.30.0",
-              "resolved": false,
               "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
               "requires": {
                 "array-includes": "^3.1.5",
@@ -10088,7 +10077,6 @@
             },
             "eslint-plugin-react-hooks": {
               "version": "4.5.0",
-              "resolved": false,
               "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw=="
             },
             "eslint-rule-composer": {

--- a/samples/sampler/stories/default/Alert.js
+++ b/samples/sampler/stories/default/Alert.js
@@ -62,7 +62,7 @@ select('type', _Alert, ['fullscreen', 'overlay'], Config);
 text('children', _Alert, Config, 'Additional text content for Alert');
 boolean('image', _Alert, ImageConfig);
 select('type (image)', _Alert, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', _Alert, ImageConfig, "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' class='img-fluid rounded mx-auto d-block' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23d8d8d8'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%236e6e6e'%3Eimage%3C/text%3E%3C/svg%3E");
+text('src', _Alert, ImageConfig, "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' class='img-fluid rounded mx-auto d-block' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23d8d8d8'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%236e6e6e'%3Eimage%3C/text%3E%3C/svg%3E");
 
 _Alert.storyName = 'Alert';
 _Alert.parameters = {

--- a/samples/sampler/stories/default/Alert.js
+++ b/samples/sampler/stories/default/Alert.js
@@ -62,7 +62,7 @@ select('type', _Alert, ['fullscreen', 'overlay'], Config);
 text('children', _Alert, Config, 'Additional text content for Alert');
 boolean('image', _Alert, ImageConfig);
 select('type (image)', _Alert, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', _Alert, ImageConfig, 'https://via.placeholder.com/240.png?text=image');
+text('src', _Alert, ImageConfig, "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' class='img-fluid rounded mx-auto d-block' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23d8d8d8'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%236e6e6e'%3Eimage%3C/text%3E%3C/svg%3E");
 
 _Alert.storyName = 'Alert';
 _Alert.parameters = {

--- a/samples/sampler/stories/default/Alert.js
+++ b/samples/sampler/stories/default/Alert.js
@@ -62,7 +62,7 @@ select('type', _Alert, ['fullscreen', 'overlay'], Config);
 text('children', _Alert, Config, 'Additional text content for Alert');
 boolean('image', _Alert, ImageConfig);
 select('type (image)', _Alert, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', _Alert, ImageConfig, "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' class='img-fluid rounded mx-auto d-block' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23d8d8d8'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%236e6e6e'%3Eimage%3C/text%3E%3C/svg%3E");
+text('src', _Alert, ImageConfig, "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' class='img-fluid rounded mx-auto d-block' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23d8d8d8'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%236e6e6e'%3Eimage%3C/text%3E%3C/svg%3E");
 
 _Alert.storyName = 'Alert';
 _Alert.parameters = {

--- a/samples/sampler/stories/default/Alert.js
+++ b/samples/sampler/stories/default/Alert.js
@@ -4,6 +4,8 @@ import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 import Alert, {AlertBase, AlertImage} from '@enact/sandstone/Alert';
 import Button from '@enact/sandstone/Button';
 
+import {svgGenerator} from '../helper/svg';
+
 Alert.displayName = 'Alert';
 AlertImage.displayName = 'AlertImage';
 const Config = mergeComponentMetadata('Alert', AlertBase, Alert);
@@ -62,7 +64,7 @@ select('type', _Alert, ['fullscreen', 'overlay'], Config);
 text('children', _Alert, Config, 'Additional text content for Alert');
 boolean('image', _Alert, ImageConfig);
 select('type (image)', _Alert, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', _Alert, ImageConfig, "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 240 240' class='img-fluid rounded mx-auto d-block' width='240' height='240'%3E%3Crect width='240' height='240' fill='%23d8d8d8'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%236e6e6e'%3Eimage%3C/text%3E%3C/svg%3E");
+text('src', _Alert, ImageConfig, svgGenerator(240, 240, 'd8d8d8', '6e6e6e', 'image'));
 
 _Alert.storyName = 'Alert';
 _Alert.parameters = {

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -5,9 +5,9 @@ import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
 const src = {
-	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E200X200%3C/text%3E%3C/svg%3E`,
-	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E300X300%3C/text%3E%3C/svg%3E`,
-	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E600X600%3C/text%3E%3C/svg%3E`
+	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E`,
+	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E`,
+	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E`
 };
 
 const Config = mergeComponentMetadata('Image', UiImageBase, ImageBase, Image, ImageDecorator);

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -4,14 +4,10 @@ import {object, select} from '@enact/storybook-utils/addons/controls';
 import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
-
 const src = {
-	hd: svgGenerator(200, 200, 'd8d8d8', '6e6e6e', '200 X 200'),
-	fhd: svgGenerator(300, 300, 'd8d8d8', '6e6e6e', '300 X 300'),
-	uhd: svgGenerator(600, 600, 'd8d8d8', '6e6e6e', '600 X 600')
+	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E200X200%3C/text%3E%3C/svg%3E`,
+	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E300X300%3C/text%3E%3C/svg%3E`,
+	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E600X600%3C/text%3E%3C/svg%3E`
 };
 
 const Config = mergeComponentMetadata('Image', UiImageBase, ImageBase, Image, ImageDecorator);

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -5,9 +5,9 @@ import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
 const src = {
-	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E`,
-	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E`,
-	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E`
+	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E",
+	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E",
+	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E"
 };
 
 const Config = mergeComponentMetadata('Image', UiImageBase, ImageBase, Image, ImageDecorator);

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -5,7 +5,7 @@ import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const src = {

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -4,10 +4,12 @@ import {object, select} from '@enact/storybook-utils/addons/controls';
 import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
+import {svgGenerator} from '../helper/svg';
+
 const src = {
-	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E",
-	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E",
-	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E"
+	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
+	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
+	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
 };
 
 const Config = mergeComponentMetadata('Image', UiImageBase, ImageBase, Image, ImageDecorator);

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -4,10 +4,14 @@ import {object, select} from '@enact/storybook-utils/addons/controls';
 import Image, {ImageBase, ImageDecorator} from '@enact/sandstone/Image';
 import {ImageBase as UiImageBase} from '@enact/ui/Image';
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const src = {
-	hd: 'http://via.placeholder.com/200x200',
-	fhd: 'http://via.placeholder.com/300x300',
-	uhd: 'http://via.placeholder.com/600x600'
+	hd: svgGenerator(200, 200, 'd8d8d8', '6e6e6e', '200 X 200'),
+	fhd: svgGenerator(300, 300, 'd8d8d8', '6e6e6e', '300 X 300'),
+	uhd: svgGenerator(600, 600, 'd8d8d8', '6e6e6e', '600 X 600')
 };
 
 const Config = mergeComponentMetadata('Image', UiImageBase, ImageBase, Image, ImageDecorator);

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -7,14 +7,10 @@ import ri from '@enact/ui/resolution';
 const Config = mergeComponentMetadata('ImageItem', UiImageItem, ImageItemBase, ImageItem);
 ImageItem.displayName = 'ImageItem';
 
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
-
 const src = {
-	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
-	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
-	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
+	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E`,
+	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E`,
+	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E`
 };
 
 const prop = {

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -7,10 +7,14 @@ import ri from '@enact/ui/resolution';
 const Config = mergeComponentMetadata('ImageItem', UiImageItem, ImageItemBase, ImageItem);
 ImageItem.displayName = 'ImageItem';
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const src = {
-	hd: 'http://via.placeholder.com/200x200/7ed31d/ffffff',
-	fhd: 'http://via.placeholder.com/300x300/7ed31d/ffffff',
-	uhd: 'http://via.placeholder.com/600x600/7ed31d/ffffff'
+	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
+	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
+	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
 };
 
 const prop = {

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -4,13 +4,15 @@ import {ImageItem, ImageItemBase} from '@enact/sandstone/ImageItem';
 import {ImageItem as UiImageItem} from '@enact/ui/ImageItem';
 import ri from '@enact/ui/resolution';
 
+import {svgGenerator} from '../helper/svg';
+
 const Config = mergeComponentMetadata('ImageItem', UiImageItem, ImageItemBase, ImageItem);
 ImageItem.displayName = 'ImageItem';
 
 const src = {
-	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E",
-	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E",
-	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E"
+	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
+	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
+	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
 };
 
 const prop = {

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -8,7 +8,7 @@ const Config = mergeComponentMetadata('ImageItem', UiImageItem, ImageItemBase, I
 ImageItem.displayName = 'ImageItem';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const src = {

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -8,9 +8,9 @@ const Config = mergeComponentMetadata('ImageItem', UiImageItem, ImageItemBase, I
 ImageItem.displayName = 'ImageItem';
 
 const src = {
-	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E`,
-	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E`,
-	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E`
+	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E",
+	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E",
+	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E"
 };
 
 const prop = {

--- a/samples/sampler/stories/default/Panel.js
+++ b/samples/sampler/stories/default/Panel.js
@@ -10,6 +10,7 @@ import {scale} from '@enact/ui/resolution';
 import {Fragment} from 'react';
 
 import iconNames from '../helper/icons';
+import {svgGenerator} from '../helper/svg';
 
 Panel.displayName = 'Panel';
 Header.displayName = 'Header';
@@ -18,10 +19,6 @@ Tab.displayName = 'Tab';
 const TabConfig = mergeComponentMetadata('Tab', Tab);
 VirtualGridList.displayName = 'VirtualGridList';
 const VGLConfig = mergeComponentMetadata('VirtualGridList', VirtualGridList);
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 // Set up some defaults for info and controls
 const items = [],

--- a/samples/sampler/stories/default/Panel.js
+++ b/samples/sampler/stories/default/Panel.js
@@ -19,6 +19,10 @@ const TabConfig = mergeComponentMetadata('Tab', Tab);
 VirtualGridList.displayName = 'VirtualGridList';
 const VGLConfig = mergeComponentMetadata('VirtualGridList', VirtualGridList);
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 // Set up some defaults for info and controls
 const items = [],
 	defaultDataSize = 1000,
@@ -62,7 +66,7 @@ const updateDataSize = (dataSize) => {
 			children = `Item ${count}${shouldAddLongContent({index: i, modIndex: 2})}`,
 			label = `SubItem ${count}${shouldAddLongContent({index: i, modIndex: 3})}`,
 			color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
-			src = `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`;
+			src = svgGenerator(600, 600, color, 'ffffff', `Image ${i}`);
 
 		items.push({children, label, src});
 	}

--- a/samples/sampler/stories/default/Panel.js
+++ b/samples/sampler/stories/default/Panel.js
@@ -63,7 +63,7 @@ const updateDataSize = (dataSize) => {
 			children = `Item ${count}${shouldAddLongContent({index: i, modIndex: 2})}`,
 			label = `SubItem ${count}${shouldAddLongContent({index: i, modIndex: 3})}`,
 			color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
-			src = svgGenerator(600, 600, color, 'ffffff', `Image ${i}`);
+			src = svgGenerator(300, 300, color, 'ffffff', `Image ${i}`);
 
 		items.push({children, label, src});
 	}

--- a/samples/sampler/stories/default/Panel.js
+++ b/samples/sampler/stories/default/Panel.js
@@ -20,7 +20,7 @@ VirtualGridList.displayName = 'VirtualGridList';
 const VGLConfig = mergeComponentMetadata('VirtualGridList', VirtualGridList);
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 // Set up some defaults for info and controls

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -25,7 +25,7 @@ const items = [];
 for (let i = 0; i < 100; i++) {
 	const text = `Item ${i}`,
 		color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
-		source = svgGenerator(360, 240, color, 'ffffff', `Image ${i}`),
+		source = svgGenerator(300, 300, color, 'ffffff', `Image ${i}`),
 		caption = 'Sample list';
 	items.push({text, source, caption});
 }

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -16,13 +16,11 @@ import {scale} from '@enact/ui/resolution';
 import {useState} from 'react';
 import compose from 'ramda/src/compose';
 
+import {svgGenerator} from '../helper/svg';
+
 const Config = mergeComponentMetadata('Panels', Panels);
 
 const items = [];
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 for (let i = 0; i < 100; i++) {
 	const text = `Item ${i}`,

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -21,7 +21,7 @@ const Config = mergeComponentMetadata('Panels', Panels);
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 for (let i = 0; i < 100; i++) {

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -21,7 +21,7 @@ const Config = mergeComponentMetadata('Panels', Panels);
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 for (let i = 0; i < 100; i++) {

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -20,10 +20,14 @@ const Config = mergeComponentMetadata('Panels', Panels);
 
 const items = [];
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 for (let i = 0; i < 100; i++) {
 	const text = `Item ${i}`,
 		color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
-		source = `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`,
+		source = svgGenerator(360, 240, color, 'ffffff', `Image ${i}`),
 		caption = 'Sample list';
 	items.push({text, source, caption});
 }
@@ -139,32 +143,32 @@ export const _Panels = (args) => {
 						<Scroller style={{height: scale(1000)}}>
 							<Image
 								caption="Image"
-								src="http://via.placeholder.com/360x240/"
+								src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 								style={{marginTop: '24px'}}
 							/>
 							<Image
 								caption="Image"
-								src="http://via.placeholder.com/360x240/"
+								src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 								style={{marginTop: '24px'}}
 							/>
 							<Image
 								caption="Image"
-								src="http://via.placeholder.com/360x240/"
+								src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 								style={{marginTop: '24px'}}
 							/>
 							<Image
 								caption="Image"
-								src="http://via.placeholder.com/360x240/"
+								src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 								style={{marginTop: '24px'}}
 							/>
 							<Image
 								caption="Image"
-								src="http://via.placeholder.com/360x240/"
+								src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 								style={{marginTop: '24px'}}
 							/>
 							<Image
 								caption="Image"
-								src="http://via.placeholder.com/360x240/"
+								src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 								style={{marginTop: '24px'}}
 							/>
 						</Scroller>

--- a/samples/sampler/stories/default/TabLayout.js
+++ b/samples/sampler/stories/default/TabLayout.js
@@ -10,6 +10,7 @@ import Scroller from '@enact/sandstone/Scroller';
 import TabLayout, {TabLayoutBase, Tab} from '@enact/sandstone/TabLayout';
 import {scaleToRem} from '@enact/ui/resolution';
 
+import {svgGenerator} from '../helper/svg';
 import spriteGear2k from '../../images/sprite-gear-2k.png';
 import spriteGear4k from '../../images/sprite-gear-4k.png';
 
@@ -30,10 +31,6 @@ const tabSelections = {
 	'with icons': tabsWithIcons,
 	'without icons': tabsWithoutIcons
 };
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 export default {
 	title: 'Sandstone/TabLayout',

--- a/samples/sampler/stories/default/TabLayout.js
+++ b/samples/sampler/stories/default/TabLayout.js
@@ -32,7 +32,7 @@ const tabSelections = {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 export default {

--- a/samples/sampler/stories/default/TabLayout.js
+++ b/samples/sampler/stories/default/TabLayout.js
@@ -32,7 +32,7 @@ const tabSelections = {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 export default {

--- a/samples/sampler/stories/default/TabLayout.js
+++ b/samples/sampler/stories/default/TabLayout.js
@@ -31,6 +31,10 @@ const tabSelections = {
 	'without icons': tabsWithoutIcons
 };
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 export default {
 	title: 'Sandstone/TabLayout',
 	component: 'TabLayout'
@@ -44,7 +48,7 @@ export const _TabLayout = (args) => {
 			inline
 			key={`image${i}`}
 			label="ImageItem label"
-			src="http://via.placeholder.com/360x240/"
+			src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
 			style={{
 				width: scaleToRem(768),
 				height: scaleToRem(588)

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -14,7 +14,7 @@ const items = [];
 const size = 20;
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 // eslint-disable-next-line enact/prop-types

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -14,7 +14,7 @@ const items = [];
 const size = 20;
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 // eslint-disable-next-line enact/prop-types

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -9,13 +9,10 @@ import {VirtualGridList} from '@enact/sandstone/VirtualList';
 import ri from '@enact/ui/resolution';
 
 import icons from '../helper/icons';
+import {svgGenerator} from '../helper/svg';
 
 const items = [];
 const size = 20;
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -12,6 +12,11 @@ import icons from '../helper/icons';
 
 const items = [];
 const size = 20;
+
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	const {source} = items[index];
@@ -24,8 +29,7 @@ const updateDataSize = (dataSize) => {
 
 	for (let i = 0; i < dataSize; i++) {
 		const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
-			source = `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`;
-
+			source = svgGenerator(300, 300, color, 'ffffff', `Image ${i}`);
 		items.push({source});
 	}
 

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -6,6 +6,8 @@ import {VirtualGridList} from '@enact/sandstone/VirtualList';
 import ri from '@enact/ui/resolution';
 import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
+import {svgGenerator} from '../helper/svg';
+
 import css from './VirtualGridList.module.less';
 
 const prop = {
@@ -32,10 +34,6 @@ const prop = {
 			</ImageItem>
 		);
 	};
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 const updateDataSize = (dataSize) => {
 	const itemNumberDigits = dataSize > 0 ? (dataSize - 1 + '').length : 0,

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -33,6 +33,10 @@ const prop = {
 		);
 	};
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const updateDataSize = (dataSize) => {
 	const itemNumberDigits = dataSize > 0 ? (dataSize - 1 + '').length : 0,
 		headingZeros = Array(itemNumberDigits).join('0');
@@ -45,9 +49,9 @@ const updateDataSize = (dataSize) => {
 			subText = `SubItem ${count}${shouldAddLongContent({index: i, modIndex: 3})}`,
 			color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16),
 			source = {
-				hd: `http://via.placeholder.com/200x200/${color}/ffffff/png?text=Image+${i}`,
-				fhd: `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`,
-				uhd: `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${i}`
+				hd: svgGenerator(200, 200, color, 'ffffff', `Image ${i}`),
+				fhd: svgGenerator(300, 300, color, 'ffffff', `Image ${i}`),
+				uhd: svgGenerator(600, 600, color, 'ffffff', `Image ${i}`)
 			};
 
 		items.push({text, subText, source});

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -34,7 +34,7 @@ const prop = {
 	};
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const updateDataSize = (dataSize) => {

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -34,7 +34,7 @@ const prop = {
 	};
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const updateDataSize = (dataSize) => {

--- a/samples/sampler/stories/helper/svg.js
+++ b/samples/sampler/stories/helper/svg.js
@@ -1,0 +1,8 @@
+// SVG image For Samples
+//
+
+export const svgGenerator = (width, height, bgColor, textColor, customText) => (
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);

--- a/samples/sampler/stories/qa/Alert.js
+++ b/samples/sampler/stories/qa/Alert.js
@@ -8,6 +8,8 @@ import ProgressBar from '@enact/sandstone/ProgressBar';
 import Scroller from '@enact/sandstone/Scroller';
 import ri from '@enact/ui/resolution';
 
+import {svgGenerator} from '../helper/svg';
+
 Alert.displayName = 'Alert';
 AlertImage.displayName = 'AlertImage';
 const Config = mergeComponentMetadata('Alert', AlertBase, Alert);
@@ -19,10 +21,6 @@ const inputData = {
 	longChildren:
 	'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac tellus in velit ornare commodo. Nam dignissim fringilla nulla, sit amet hendrerit sapien laoreet quis. Praesent quis tellus non diam viverra feugiat. In quis mattis purus, quis tristique mi. Mauris vitae tellus tempus, convallis ligula id, laoreet eros. Nullam eu tempus odio, non mollis tellus. Phasellus vitae iaculis nisl. Sed ipsum felis, suscipit vel est quis, interdum pretium dolor. Curabitur sit amet purus ac massa ullamcorper egestas ornare vel lectus. Nullam quis velit sed ex finibus cursus. Duis porttitor congue cursus.'
 };
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 export default {
 	title: 'Sandstone/Alert',

--- a/samples/sampler/stories/qa/Alert.js
+++ b/samples/sampler/stories/qa/Alert.js
@@ -20,6 +20,10 @@ const inputData = {
 	'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac tellus in velit ornare commodo. Nam dignissim fringilla nulla, sit amet hendrerit sapien laoreet quis. Praesent quis tellus non diam viverra feugiat. In quis mattis purus, quis tristique mi. Mauris vitae tellus tempus, convallis ligula id, laoreet eros. Nullam eu tempus odio, non mollis tellus. Phasellus vitae iaculis nisl. Sed ipsum felis, suscipit vel est quis, interdum pretium dolor. Curabitur sit amet purus ac massa ullamcorper egestas ornare vel lectus. Nullam quis velit sed ex finibus cursus. Duis porttitor congue cursus.'
 };
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 export default {
 	title: 'Sandstone/Alert',
 	component: 'Alert'
@@ -51,7 +55,7 @@ select('type', WithLongTitle, ['fullscreen', 'overlay'], Config);
 text('children', WithLongTitle, Config, 'Additional text content for Alert');
 boolean('image', WithLongTitle, ImageConfig);
 select('type (image)', WithLongTitle, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', WithLongTitle, ImageConfig, 'https://via.placeholder.com/240.png?text=image');
+text('src', WithLongTitle, ImageConfig, svgGenerator(240, 240, 'd8d8d8', '6e6e6e', 'image'));
 
 WithLongTitle.storyName = 'with long title';
 
@@ -81,7 +85,7 @@ select('type', WithLongChildren, ['fullscreen', 'overlay'], Config);
 text('children', WithLongChildren, Config, inputData.longChildren);
 boolean('image', WithLongChildren, ImageConfig);
 select('type (image)', WithLongChildren, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', WithLongChildren, ImageConfig, 'https://via.placeholder.com/240.png?text=image');
+text('src', WithLongChildren, ImageConfig, svgGenerator(240, 240, 'd8d8d8', '6e6e6e', 'image'));
 
 WithLongChildren.storyName = 'with long children';
 
@@ -111,7 +115,7 @@ select('type', WithLongTitleAndLongChildren, ['fullscreen', 'overlay'], Config);
 text('children', WithLongTitleAndLongChildren, Config, inputData.longChildren);
 boolean('image', WithLongTitleAndLongChildren, ImageConfig);
 select('type (image)', WithLongTitleAndLongChildren, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', WithLongTitleAndLongChildren, ImageConfig, 'https://via.placeholder.com/240.png?text=image');
+text('src', WithLongTitleAndLongChildren, ImageConfig, svgGenerator(240, 240, 'd8d8d8', '6e6e6e', 'image'));
 
 WithLongTitleAndLongChildren.storyName = 'with long title and long children';
 
@@ -152,6 +156,6 @@ select('type', WithDifferentTypesOfComponentsAndLongChildren, ['fullscreen', 'ov
 text('children', WithDifferentTypesOfComponentsAndLongChildren, Config, inputData.longChildren);
 boolean('image', WithDifferentTypesOfComponentsAndLongChildren, ImageConfig);
 select('type (image)', WithDifferentTypesOfComponentsAndLongChildren, ['icon', 'thumbnail'], ImageConfig, 'icon');
-text('src', WithDifferentTypesOfComponentsAndLongChildren, ImageConfig, 'https://via.placeholder.com/240.png?text=image');
+text('src', WithDifferentTypesOfComponentsAndLongChildren, ImageConfig, svgGenerator(240, 240, 'd8d8d8', '6e6e6e', 'image'));
 
 WithDifferentTypesOfComponentsAndLongChildren.storyName = 'with different types of components and long children';

--- a/samples/sampler/stories/qa/Alert.js
+++ b/samples/sampler/stories/qa/Alert.js
@@ -21,7 +21,7 @@ const inputData = {
 };
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 export default {

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -8,9 +8,9 @@ const Config = mergeComponentMetadata('ImageItem', ImageItemBase, UiImageItem, I
 ImageItem.displayName = 'ImageItem';
 
 const src = {
-	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E200X200%3C/text%3E%3C/svg%3E",
-	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E300X300%3C/text%3E%3C/svg%3E",
-	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E600X600%3C/text%3E%3C/svg%3E"
+	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E`,
+	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E`,
+	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E`
 };
 
 const prop = {

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -7,10 +7,14 @@ import ri from '@enact/ui/resolution';
 const Config = mergeComponentMetadata('ImageItem', ImageItemBase, UiImageItem, ImageItem);
 ImageItem.displayName = 'ImageItem';
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const src = {
-	hd: 'http://via.placeholder.com/200x200/7ed31d/ffffff',
-	fhd: 'http://via.placeholder.com/300x300/7ed31d/ffffff',
-	uhd: 'http://via.placeholder.com/600x600/7ed31d/ffffff'
+	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
+	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
+	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
 };
 
 const prop = {

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -7,14 +7,10 @@ import ri from '@enact/ui/resolution';
 const Config = mergeComponentMetadata('ImageItem', ImageItemBase, UiImageItem, ImageItem);
 ImageItem.displayName = 'ImageItem';
 
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
-
 const src = {
-	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
-	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
-	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
+	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E200X200%3C/text%3E%3C/svg%3E",
+	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E300X300%3C/text%3E%3C/svg%3E",
+	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23ffffff'%3E600X600%3C/text%3E%3C/svg%3E"
 };
 
 const prop = {

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -4,13 +4,15 @@ import {ImageItem, ImageItemBase} from '@enact/sandstone/ImageItem';
 import {ImageItem as UiImageItem} from '@enact/ui/ImageItem';
 import ri from '@enact/ui/resolution';
 
+import {svgGenerator} from '../helper/svg';
+
 const Config = mergeComponentMetadata('ImageItem', ImageItemBase, UiImageItem, ImageItem);
 ImageItem.displayName = 'ImageItem';
 
 const src = {
-	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E",
-	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E",
-	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E"
+	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),
+	fhd: svgGenerator(300, 300, '7ed31d', 'ffffff', '300 X 300'),
+	uhd: svgGenerator(600, 600, '7ed31d', 'ffffff', '600 X 600')
 };
 
 const prop = {

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -8,7 +8,7 @@ const Config = mergeComponentMetadata('ImageItem', ImageItemBase, UiImageItem, I
 ImageItem.displayName = 'ImageItem';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const src = {

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -8,9 +8,9 @@ const Config = mergeComponentMetadata('ImageItem', ImageItemBase, UiImageItem, I
 ImageItem.displayName = 'ImageItem';
 
 const src = {
-	hd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E`,
-	fhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E`,
-	uhd: `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E`
+	hd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' class='img-fluid rounded mx-auto d-block' width='200' height='200'%3E%3Crect width='200' height='200' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E200 X 200%3C/text%3E%3C/svg%3E",
+	fhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 300' class='img-fluid rounded mx-auto d-block' width='300' height='300'%3E%3Crect width='300' height='300' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E300 X 300%3C/text%3E%3C/svg%3E",
+	uhd: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600' class='img-fluid rounded mx-auto d-block' width='600' height='600'%3E%3Crect width='600' height='600' fill='%237ed31d'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23ffffff'%3E600 X 600%3C/text%3E%3C/svg%3E"
 };
 
 const prop = {

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -14,6 +14,10 @@ import {useCallback, useState} from 'react';
 
 const Config = mergeComponentMetadata('Panels', Panels);
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const items = [];
 for (let i = 0; i < 20; i++) {
 	const headingZeros = Array(2).join('0');
@@ -21,7 +25,7 @@ for (let i = 0; i < 20; i++) {
 	const text = `Item ${count}`;
 	const subText = `SubItem ${count}`;
 	const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);
-	const source = `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${i}`;
+	const source = svgGenerator(600, 600, color, 'ffffff', `Image ${i}`);
 
 	items.push({text, subText, source});
 }

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -15,7 +15,7 @@ import {useCallback, useState} from 'react';
 const Config = mergeComponentMetadata('Panels', Panels);
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const items = [];

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -12,11 +12,9 @@ import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {useCallback, useState} from 'react';
 
-const Config = mergeComponentMetadata('Panels', Panels);
+import {svgGenerator} from '../helper/svg';
 
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
+const Config = mergeComponentMetadata('Panels', Panels);
 
 const items = [];
 for (let i = 0; i < 20; i++) {

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -17,6 +17,8 @@ import {Scroller as UiScroller, ScrollerBasic as UiScrollerBasic} from '@enact/u
 import PropTypes from 'prop-types';
 import {Component, useCallback, useLayoutEffect, useRef, useState} from 'react';
 
+import {svgGenerator} from '../helper/svg';
+
 import css from './Scroller.module.less';
 
 const Config = mergeComponentMetadata('Scroller', UiScrollerBasic, Scroller);
@@ -200,10 +202,6 @@ select('verticalScrollbar', ListOfThings, prop.scrollbarOption, Config);
 ListOfThings.storyName = 'List of things';
 
 let itemsArr = [];
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 const populateItems = ({index}) => {
 	const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -202,7 +202,7 @@ ListOfThings.storyName = 'List of things';
 let itemsArr = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 const populateItems = ({index}) => {

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -200,12 +200,17 @@ select('verticalScrollbar', ListOfThings, prop.scrollbarOption, Config);
 ListOfThings.storyName = 'List of things';
 
 let itemsArr = [];
+
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const populateItems = ({index}) => {
 	const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);
 	const source = {
-		hd: `http://via.placeholder.com/200x200/${color}/ffffff/png?text=Image+${index}`,
-		fhd: `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${index}`,
-		uhd: `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${index}`
+		hd: svgGenerator(200, 200, color, 'ffffff', `Image ${index}`),
+		fhd: svgGenerator(300, 300, color, 'ffffff', `Image ${index}`),
+		uhd: svgGenerator(600, 600, color, 'ffffff', `Image ${index}`)
 	};
 
 	return {src: source, index};
@@ -369,7 +374,7 @@ const updateDataSize = (dataSize) => {
 		const text = `Item ${count}`;
 		const subText = `SubItem ${count}`;
 		const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);
-		const source = `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image ${i}`;
+		const source = svgGenerator(300, 300, color, 'ffffff', `Image ${i}`);
 
 		imageItems.push({text, subText, source});
 	}

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -13,6 +13,8 @@ import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList/Virt
 import PropTypes from 'prop-types';
 import {Component} from 'react';
 
+import {svgGenerator} from '../helper/svg';
+
 const Config = mergeComponentMetadata('VirtualGridList', UiVirtualListBasic, VirtualGridList);
 
 const defaultDataSize = 1000;
@@ -28,10 +30,6 @@ const prop = {
 };
 
 const items = [];
-
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
 
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -30,7 +30,7 @@ const prop = {
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 // eslint-disable-next-line enact/prop-types

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -29,8 +29,8 @@ const prop = {
 
 const items = [];
 
-const svgGenerator = (width, height, bgColor, textColor, text) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${text}%3C/text%3E%3C/svg%3E`
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='4rem' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
 // eslint-disable-next-line enact/prop-types

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -30,7 +30,7 @@ const prop = {
 const items = [];
 
 const svgGenerator = (width, height, bgColor, textColor, text) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='30px' fill='%23${textColor}'%3E${text}%3C/text%3E%3C/svg%3E`
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${text}%3C/text%3E%3C/svg%3E`
 );
 
 // eslint-disable-next-line enact/prop-types

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -29,6 +29,10 @@ const prop = {
 
 const items = [];
 
+const svgGenerator = (width, height, bgColor, textColor, text) => (
+    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' class='img-fluid rounded mx-auto d-block' width='${width}' height='${height}'%3E%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='30px' fill='%23${textColor}'%3E${text}%3C/text%3E%3C/svg%3E`
+);
+
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	const {text, subText, source} = items[index];
@@ -60,7 +64,7 @@ const updateDataSize = (dataSize) => {
 		const text = `Item ${count}`;
 		const subText = `SubItem ${count}`;
 		const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);
-		const source = `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${i}`;
+		const source = svgGenerator(600, 600, color, 'ffffff', `Image ${i}`);
 
 		items.push({text, subText, source});
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a problem that image download often fails on the placeholder website used in samples

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Instead of downloading the image from the site, change it to create and use the image as svg

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11048

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)