### PR TITLE
WRO-9259: Fix some stories are not shown with storybook 6.5

### DIFF
--- a/samples/sampler/.qa-storybook/preview.js
+++ b/samples/sampler/.qa-storybook/preview.js
@@ -53,6 +53,7 @@ export const parameters = {
 		container: DocsContainer,
 		page: DocsPage,
 		iframeHeight: 360,
+		inlineStories: false,
 		theme: themes.light
 	},
 	options: {

--- a/samples/sampler/.storybook/preview.js
+++ b/samples/sampler/.storybook/preview.js
@@ -52,6 +52,7 @@ export const parameters = {
 		container: DocsContainer,
 		page: DocsPage,
 		iframeHeight: 360,
+		inlineStories: false,
 		theme: themes.light
 	},
 	options: {

--- a/samples/sampler/stories/default/KeyGuide.js
+++ b/samples/sampler/stories/default/KeyGuide.js
@@ -37,5 +37,17 @@ _KeyGuide.storyName = 'KeyGuide';
 _KeyGuide.parameters = {
 	info: {
 		text: 'Explains the operation of remote keys'
+	},
+	// Work around for https://github.com/storybookjs/storybook/issues/18269
+	docs: {
+		source: {
+			code: `<KeyGuide open>
+	{[
+		{icon: 'red', children: 'This is long name item', key: 1},
+		{icon: 'plus', children: 'Item 1', key: 2},
+		{icon: 'minus', children: 'Item 2', key: 3}
+	]}
+</KeyGuide>`
+		}
 	}
 };

--- a/samples/sampler/stories/qa/Dropdown.js
+++ b/samples/sampler/stories/qa/Dropdown.js
@@ -258,6 +258,13 @@ text('title', WithArrayOfChildrenObjects, Config, 'Dropdown');
 select('width', WithArrayOfChildrenObjects, ['tiny', 'small', 'medium', 'large', 'x-large', 'huge'], Config);
 
 WithArrayOfChildrenObjects.storyName = 'with array of children objects';
+WithArrayOfChildrenObjects.parameters = {
+	docs: {
+		source: {
+			code: '() => <WithArrayOfChildrenObjects />'
+		}
+	}
+};
 
 export const WithAutoDismiss = () => <AutoDismissDropdown />;
 

--- a/samples/sampler/stories/qa/Text.js
+++ b/samples/sampler/stories/qa/Text.js
@@ -269,6 +269,13 @@ export const Languages = (args) => {
 
 select('font-weight',	Languages, ['100', '200', '300', '400', '500', '600', '700', '800', '900'], Config, '400');
 Languages.storyName = 'Languages';
+Languages.parameters = {
+	docs: {
+		source: {
+			code: '() => <Languages />'
+		}
+	}
+};
 
 export const MixedScripts = () => (
 	<div>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After migrating Storybook 6.5, sampler- KeyGuide, qa-sampler- Dropdown - with array of children objects, and Text - Languages stories are not opened.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue is caused by `jsxDecorator` function from `@storybook/react/dist/esm/client/docs/jsxDecorator.js` (https://github.com/storybookjs/storybook/blob/main/app/react/src/client/docs/jsxDecorator.tsx#L206)
When I looked at this code, this is for the show code section in Docs tab in the sampler. So I think we could work around it by skipping the part that throws errors since it's not related to rendering the story.
We could "skip" this code by setting docs.source.code of story's parameter according to https://github.com/storybookjs/storybook/blob/main/app/react/src/client/docs/jsxDecorator.tsx#L158.
If we skip this code, I confirmed that the three stories(sampler- KeyGuide, qa-sampler- Dropdown - with array of children objects, and Text - Languages) are rendered well.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I put a note for work around and we could remove this workaround after storybook fixes the issue(https://github.com/storybookjs/storybook/issues/18269).
Also, I fixed the preview of Docs is not showing properly by adding `inlineStories: false`.
According to https://storybook.js.org/docs/react/writing-docs/docs-page#inline-stories-vs-iframe-stories, the param became `true` by default, so our preview is not showing well.

### Links
[//]: # (Related issues, references)
WRO-9259

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)