### PR TITLE
WRO-10211: Apply `usePublicClassNames` to `EditableWrapper`

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -1,7 +1,7 @@
 import {forwardCustom} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';
-import {mergeClassNameMaps} from '@enact/core/util';
+import {usePublicClassNames} from '@enact/core/usePublicClassNames';
 import Spotlight from '@enact/spotlight';
 import Accelerator from '@enact/spotlight/Accelerator';
 import {Announce} from '@enact/ui/AnnounceDecorator';
@@ -67,7 +67,7 @@ const EditableWrapper = (props) => {
 	const customCss = editable?.css || {};
 	const removeItemFuncRef = editable?.removeItemFuncRef;
 
-	const mergedCss = mergeClassNameMaps(componentCss, customCss, Object.keys(componentCss));
+	const mergedCss = usePublicClassNames({componentCss, customCss, publicClassNames: true});
 
 	const dataSize = children?.length;
 

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -3,8 +3,7 @@ import {forward, forwardCustom, stop, stopImmediate} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';
 import platform from '@enact/core/platform';
-import {cap, clamp, Job} from '@enact/core/util';
-import {usePublicClassNames} from '@enact/core/usePublicClassNames';
+import {cap, clamp, Job, mergeClassNameMaps} from '@enact/core/util';
 import ForwardRef from '@enact/ui/ForwardRef';
 import IdProvider from '@enact/ui/internal/IdProvider';
 import Layout, {Cell} from '@enact/ui/Layout';
@@ -909,7 +908,7 @@ const PickerBase = class extends ReactComponent {
 			...rest
 		} = this.props;
 
-		const css = usePublicClassNames({componentCss, incomingCss, publicClassNames: true});
+		const css = mergeClassNameMaps(componentCss, incomingCss, allowedClassNames);
 		const voiceProps = extractVoiceProps(rest);
 		const voiceLabelsExt = voiceProps['data-webos-voice-labels-ext'];
 		delete voiceProps['data-webos-voice-label'];

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -3,7 +3,8 @@ import {forward, forwardCustom, stop, stopImmediate} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';
 import platform from '@enact/core/platform';
-import {cap, clamp, Job, mergeClassNameMaps} from '@enact/core/util';
+import {cap, clamp, Job} from '@enact/core/util';
+import {usePublicClassNames} from '@enact/core/usePublicClassNames';
 import ForwardRef from '@enact/ui/ForwardRef';
 import IdProvider from '@enact/ui/internal/IdProvider';
 import Layout, {Cell} from '@enact/ui/Layout';
@@ -908,7 +909,7 @@ const PickerBase = class extends ReactComponent {
 			...rest
 		} = this.props;
 
-		const css = mergeClassNameMaps(componentCss, incomingCss, allowedClassNames);
+		const css = usePublicClassNames({componentCss, incomingCss, publicClassNames: true});
 		const voiceProps = extractVoiceProps(rest);
 		const voiceLabelsExt = voiceProps['data-webos-voice-labels-ext'];
 		delete voiceProps['data-webos-voice-label'];


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As we added `usePublicClassNames` from https://github.com/enactjs/enact/pull/3079, we'd like to adopt it to sandstone/Scroller/EditableWrapper.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Applied `usePublicClassNames` to `EditableWrapper`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
WRO-10211


### Comments
