### PR TITLE
WRO-12236: Fix `Slider` tooltip arrow to show properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` to not show the focus effect of the body in pointer mode when `focusableScrollbar` prop is `byEnter`
+- `sandstone/Slider` tooltip arrow to show properly
 
 ## [2.5.3] - 2022-08-30
 

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -32,7 +32,7 @@
 		--sand-tooltip-offset: @sand-slider-tooltip-offset;
 
 		position: absolute;
-		will-change: left, bottom;
+		will-change: transform;
 
 		&::before {
 			content: "";


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In some environment, the position of `Slider`'s tooltip arrow is not properly synced when a value is changed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs when some old versions of browsers handle `will-change: left, bottom` attribute. As a workaround, `will-change: transform` is used to fix this.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-12236

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
