### PR TITLE
WRO-12412: Fixed ImageItem to have proper size with importing VirtualList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/ImageItem` to have proper size when imported with `sandstone/Dropdown` or `sandstone/VirtualList` in the same file
+
 ## [2.5.4] - 2022-09-23
 
 ### Fixed

--- a/ImageItem/ImageItem.module.less
+++ b/ImageItem/ImageItem.module.less
@@ -73,10 +73,6 @@
 				transition: transform 200ms ease-in-out, box-shadow 200ms ease-in-out;
 				will-change: transform, box-shadow;
 
-				&.scaled {
-					transform: @sand-imageitem-vertical-focus-image-transform;
-				}
-
 				.selectionIcon {
 					transition: transform 200ms ease-in-out;
 				}
@@ -170,10 +166,6 @@
 				background-color: @sand-imageitem-selected-selection-icon-bg-color;
 				color: @sand-imageitem-selected-selection-icon-color;
 			}
-		}
-
-		&.vertical.fullImage .image.scaled {
-			box-shadow: @sand-imageitem-focus-bg-shadow;
 		}
 
 		.focus({

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -13,7 +13,7 @@ import {useEventKey, useEventFocus} from './useEvent';
 import usePreventScroll from './usePreventScroll';
 import {useSpotlightConfig, useSpotlightRestore} from './useSpotlight';
 
-import ImageItemCss from '../ImageItem/ImageItem.module.less';
+import css from './useThemeVirtualList.module.less';
 
 const SpotlightAccelerator = new Accelerator();
 const SpotlightPlaceholder = Spottable('div');
@@ -310,13 +310,13 @@ const useSpottable = (props, instances) => {
 	}
 
 	function addScaleEffect (elem) {
-		elem.classList.add(ImageItemCss.scaled);
+		elem.classList.add(css.scaled);
 		mutableRef.current.scaledTarget = elem;
 	}
 
 	function removeScaleEffect () {
 		if (mutableRef.current.scaledTarget) {
-			mutableRef.current.scaledTarget.classList.remove(ImageItemCss.scaled);
+			mutableRef.current.scaledTarget.classList.remove(css.scaled);
 		}
 	}
 

--- a/VirtualList/useThemeVirtualList.module.less
+++ b/VirtualList/useThemeVirtualList.module.less
@@ -1,0 +1,14 @@
+// useThemeVirtualList.module.less
+//
+@import '../styles/skin.less';
+@import '../styles/variables.less';
+
+.scaled {
+	transform: @sand-imageitem-vertical-focus-image-transform;
+}
+
+.applySkins({
+	.scaled {
+		box-shadow: @sand-imageitem-focus-bg-shadow;
+	}
+});

--- a/tests/screenshot/apps/components/VirtualGridList.js
+++ b/tests/screenshot/apps/components/VirtualGridList.js
@@ -1,4 +1,5 @@
 import ri from '@enact/ui/resolution';
+import {Component} from 'react';
 
 import img from '../../images/600x600.png';
 import ImageItem from '../../../../ImageItem';
@@ -38,6 +39,65 @@ const updateDataSize = (dataSize) => {
 };
 
 updateDataSize(defaultDataSize);
+
+class SnapToCenterVGL extends Component {
+	constructor (props) {
+		super(props);
+	}
+
+	componentDidMount () {
+		this.scrollTo({index: 1, animate: false, focus: this.props.focus, stickTo: 'center'});
+	}
+
+	renderItem = ({index, ...rest}) => {
+		const {src} = items[index];
+		let customProps = {};
+		if (index === 0 || index === items.length - 1) {
+			customProps = {
+				style: {
+					visibility: 'hidden'
+				},
+				spotlightDisabled: true
+			};
+		}
+
+		return (
+			<ImageItem
+				{...rest}
+				src={src}
+				style={{
+					paddingLeft: ri.scaleToRem(240),
+					paddingRight: ri.scaleToRem(240)
+				}}
+				{...customProps}
+			/>
+		);
+	};
+
+	getScrollTo = (scrollTo) => {
+		this.scrollTo = scrollTo;
+	};
+
+	render () {
+		return (
+			<VirtualGridList
+				cbScrollTo={this.getScrollTo}
+				dataSize={updateDataSize(10)}
+				itemRenderer={this.renderItem}
+				itemSize={{
+					minWidth: ri.scale(1230),
+					minHeight: ri.scale(540)
+				}}
+				snapToCenter
+				spacing={0}
+				style={{
+					width: ri.scaleToRem(2400)
+				}}
+				verticalScrollbar="hidden"
+			/>
+		);
+	}
+}
 
 const VirtualGridListTests = [
 	<div>
@@ -85,6 +145,12 @@ const VirtualGridListTests = [
 			spacing={ri.scale(60)}
 			style={{height: ri.scale(300)}}
 		/>
+	</div>,
+	<div>
+		<SnapToCenterVGL focus />
+	</div>,
+	<div>
+		<SnapToCenterVGL />
 	</div>
 ];
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ImageItem would have the wrong size of an image when it's horizontal with importing VirtualList or Dropdown like below.
![image](https://user-images.githubusercontent.com/5037429/191416611-cb3236f8-0ca9-4120-b857-d736b62bda8a.png)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The root cause of this issue is that VirtualList imports ImageItem.module.less in useThemeVirtualList.js to apply the scale class to ImageItem when `snapToCenter` is true.
When webpack bundles css, the sandstone/ImageItem/ImageItem.module.less is imported first for the above reason and then ui/Imageitem/ImageItem.module.less imported so the issue occurred.
To resolve this, I made `useThemeVirtualList.module.less` to have the scale class instead of importing ImageItem.module.less.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
With this change, the scale effect is going to apply to any ImageItem instead of "vertical, full image" only.

### Links
[//]: # (Related issues, references)
WRO-12412

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)