### PR TITLE
WRO-13221: Fixed VirtualList to scroll properly by hover when scrollbar is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/MediaPlayer.MediaControls` to focus properly when pressing up key from buttons after holding left or right keys
+- `sandstone/Scroller` and `sandstone/VirtualList` to scroll properly by hover when scrollbar is hidden or `dataSize` is changed
 
 ## [2.5.4] - 2022-09-23
 

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -84,17 +84,17 @@ const HoverToScrollBase = (props) => {
 	}, [direction, scrollContainer]);
 
 	const startRaf = useCallback((job) => {
-		scrollContainerHandleRef.isHoveringToScroll = true;
+		scrollContainer.isHoveringToScroll = true;
 		if (typeof window === 'object' && mutableRef.current.hoveredPosition) {
 			mutableRef.current.hoverToScrollRafId = window.requestAnimationFrame(job);
 			if (typeof document === 'object') {
 				document.addEventListener('keydown', handleGlobalKeyDown, {capture: true});
 			}
 		}
-	}, [handleGlobalKeyDown, scrollContainerHandleRef]);
+	}, [handleGlobalKeyDown, scrollContainer]);
 
 	const stopRaf = useCallback(() => {
-		scrollContainerHandleRef.isHoveringToScroll = false;
+		scrollContainer.isHoveringToScroll = false;
 		if (typeof window === 'object' && mutableRef.current.hoverToScrollRafId !== null) {
 			window.cancelAnimationFrame(mutableRef.current.hoverToScrollRafId);
 			mutableRef.current.hoverToScrollRafId = null;
@@ -103,7 +103,7 @@ const HoverToScrollBase = (props) => {
 				document.removeEventListener('keydown', handleGlobalKeyDown, {capture: true});
 			}
 		}
-	}, [handleGlobalKeyDown, scrollContainerHandleRef]);
+	}, [handleGlobalKeyDown, scrollContainer]);
 
 	const getPointerEnterHandler = useCallback((position) => {
 		if (typeof window === 'object') {
@@ -183,7 +183,7 @@ const HoverToScrollBase = (props) => {
 				setBefore(null);
 			}
 		}
-	}, [update, direction, scrollContainer]);
+	}, [update, direction, scrollContainer, props]);
 
 	useLayoutEffect(() => {
 		return () => {

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -51,7 +51,7 @@ const directionToFocus = {
 const HoverToScrollBase = (props) => {
 	const {
 		direction,
-		scrollContainerHandleRef,
+		scrollContainerHandle: {current: scrollContainer},
 		scrollObserver: {addObserverOnScroll, removeObserverOnScroll}
 	} = props;
 
@@ -70,7 +70,7 @@ const HoverToScrollBase = (props) => {
 	const handleGlobalKeyDown = useCallback(({keyCode}) => {
 		let position = mutableRef.current.hoveredPosition;
 
-		if (scrollContainerHandleRef.rtl && direction === 'horizontal') {
+		if (scrollContainer.rtl && direction === 'horizontal') {
 			position = position === 'after' ? 'before' : 'after';
 		}
 
@@ -79,9 +79,9 @@ const HoverToScrollBase = (props) => {
 				directionToFocus[direction][position],
 				getLastPointerPosition()
 			);
-			scrollContainerHandleRef.stop();
+			scrollContainer.stop();
 		}
-	}, [direction, scrollContainerHandleRef]);
+	}, [direction, scrollContainer]);
 
 	const startRaf = useCallback((job) => {
 		scrollContainerHandleRef.isHoveringToScroll = true;
@@ -108,7 +108,7 @@ const HoverToScrollBase = (props) => {
 	const getPointerEnterHandler = useCallback((position) => {
 		if (typeof window === 'object') {
 			const {axis, clientSize, maxPosition, scrollPosition} = getBoundsPropertyNames(direction);
-			const bounds = scrollContainerHandleRef.getScrollBounds();
+			const bounds = scrollContainer.getScrollBounds();
 
 			return function ({pointerType}) {
 				if (pointerType === 'mouse') {
@@ -121,12 +121,12 @@ const HoverToScrollBase = (props) => {
 
 					const scrollByHover = () => {
 						if (getLastInputType() === 'mouse') {
-							scrollContainerHandleRef.scrollTo({
+							scrollContainer.scrollTo({
 								position: {
 									[axis]: clamp(
 										0,
 										bounds[maxPosition],
-										scrollContainerHandleRef[scrollPosition] + distance
+										scrollContainer[scrollPosition] + distance
 									)
 								},
 								animate: false
@@ -142,11 +142,11 @@ const HoverToScrollBase = (props) => {
 		} else {
 			return nop;
 		}
-	}, [direction, scrollContainerHandleRef, startRaf, stopRaf]);
+	}, [direction, scrollContainer, startRaf, stopRaf]);
 
 	const update = useCallback(() => {
 		const {canScrollFunc, maxPosition, scrollPosition} = getBoundsPropertyNames(direction);
-		const {[canScrollFunc]: canScroll, getScrollBounds, [scrollPosition]: currentPosition} = scrollContainerHandleRef;
+		const {[canScrollFunc]: canScroll, getScrollBounds, [scrollPosition]: currentPosition} = scrollContainer;
 		const bounds = getScrollBounds();
 		const position = mutableRef.current.hoveredPosition;
 		let curAfter = false, curBefore = false;
@@ -162,7 +162,7 @@ const HoverToScrollBase = (props) => {
 
 		setAfter(curAfter);
 		setBefore(curBefore);
-	}, [direction, after, before, scrollContainerHandleRef, stopRaf]);
+	}, [direction, after, before, scrollContainer, stopRaf]);
 
 	// Hooks
 
@@ -174,8 +174,8 @@ const HoverToScrollBase = (props) => {
 	}, [update, addObserverOnScroll, removeObserverOnScroll]);
 
 	useLayoutEffect(() => {
-		if (scrollContainerHandleRef) {
-			const {[getBoundsPropertyNames(direction).canScrollFunc]: canScroll, getScrollBounds} = scrollContainerHandleRef;
+		if (scrollContainer) {
+			const {[getBoundsPropertyNames(direction).canScrollFunc]: canScroll, getScrollBounds} = scrollContainer;
 			if (canScroll && getScrollBounds) {
 				update();
 			} else {
@@ -183,7 +183,7 @@ const HoverToScrollBase = (props) => {
 				setBefore(null);
 			}
 		}
-	}, [update, direction, scrollContainerHandleRef]);
+	}, [update, direction, scrollContainer]);
 
 	useLayoutEffect(() => {
 		return () => {
@@ -216,7 +216,7 @@ HoverToScrollBase.displayName = 'HoverToScrollBase';
 
 HoverToScrollBase.propTypes = /** @lends sandstone/useScroll.HoverToScroll.HoverToScrollBase.prototype */ {
 	direction: PropTypes.string,
-	scrollContainerHandleRef: PropTypes.object
+	scrollContainerHandle: PropTypes.object
 };
 
 /**
@@ -227,11 +227,11 @@ HoverToScrollBase.propTypes = /** @lends sandstone/useScroll.HoverToScroll.Hover
  * @ui
  * @private
  */
-const HoverToScroll = ({scrollContainerHandleRef, ...rest}) => {
-	return scrollContainerHandleRef ? (
+const HoverToScroll = ({scrollContainerHandle, ...rest}) => {
+	return scrollContainerHandle ? (
 		<>
-			<HoverToScrollBase scrollContainerHandleRef={scrollContainerHandleRef} {...rest} direction="horizontal" />
-			<HoverToScrollBase scrollContainerHandleRef={scrollContainerHandleRef} {...rest} direction="vertical" />
+			<HoverToScrollBase scrollContainerHandle={scrollContainerHandle} {...rest} direction="horizontal" />
+			<HoverToScrollBase scrollContainerHandle={scrollContainerHandle} {...rest} direction="vertical" />
 		</>
 	) : null;
 };
@@ -239,7 +239,7 @@ const HoverToScroll = ({scrollContainerHandleRef, ...rest}) => {
 HoverToScroll.displayName = 'HoverToScroll';
 
 HoverToScroll.propTypes = /** @lends sandstone/useScroll.HoverToScroll.prototype */ {
-	scrollContainerHandleRef: PropTypes.object
+	scrollContainerHandle: PropTypes.object
 };
 
 export default HoverToScroll;

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -509,7 +509,7 @@ const useScroll = (props) => {
 	});
 
 	assignProperties('hoverToScrollProps', {
-		scrollContainerHandleRef: scrollContainerHandle.current,
+		scrollContainerHandle,
 		scrollObserver
 	});
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When horizontalScrollbar or verticalScrollbar is set to `hidden` scroll did not work with hover action in VirtualList.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To resolve the issue, we have to revert https://github.com/enactjs/sandstone/pull/1150.

In PR 1150, It fixed `HoverToScrollBase` to receive `scrollContainerHandle.current` instead of `scrollContainerHandle`.
However, this fix caused an error when the scrollbar is hidden, as VirtualList rendered only once in this case. 

So we reverted PR 1150. And then we have to fix `HoverToScroll` to scroll properly by hover after `dataSize` is changed(after rendering). Add the props to the useLayoutEffect (line 177) dependency list so that the update() function can be called each time after rendering.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13221

### Comments
