### PR TITLE
WRO-13165: Don't change the a11y setting when open qa-a11y readAlert menu

### DIFF
--- a/samples/qa-a11y/src/views/ReadAlert.js
+++ b/samples/qa-a11y/src/views/ReadAlert.js
@@ -34,24 +34,19 @@ const ReadAlertView = () => {
 		}
 	}, []);
 
-	useEffect( () => {
+	const onToggle = useCallback(({selected: selAudioGuidance}) => {
 		if (window.PalmServiceBridge) {
+			setAudioGuidance(selAudioGuidance);
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',
 				method: 'setSystemSettings',
 				parameters: {
 					category: 'option',
 					settings: {
-						audioGuidance: audioGuidance ? 'on' : 'off'
+						audioGuidance: selAudioGuidance ? 'on' : 'off'
 					}
 				}
 			});
-		}
-	});
-
-	const onToggle = useCallback(({selected: selAudioGuidance}) => {
-		if (window.PalmServiceBridge) {
-			setAudioGuidance(selAudioGuidance);
 		}
 	}, []);
 
@@ -60,7 +55,7 @@ const ReadAlertView = () => {
 			<Section title="AudioGuidance On or Off">
 				<CheckboxItem
 					alt="Toggle"
-					defaultSelected={audioGuidance}
+					selected={audioGuidance}
 					disabled={toggleDisabled}
 					onToggle={onToggle}
 				>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
'READ ALERT' is read out when clicked on OK button.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The readAlert page itself is switching off and on accessibility. It is regression from https://github.com/enactjs/sandstone/pull/1192/files#diff-e371e57e16809e27da46201a26f7f79140ce83fc985c92183daec5d084a4decd

Since the setting value should not need to be changed when the page is loaded, I remove the wrong useEffect code.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13165

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
