### PR TITLE
WRO-12192: Change to use ActionGuide with Button in VideoPlayer

### DIFF
--- a/ActionGuide/ActionGuide.js
+++ b/ActionGuide/ActionGuide.js
@@ -12,7 +12,6 @@
 
 import kind from '@enact/core/kind';
 import Pure from '@enact/ui/internal/Pure';
-import Touchable from '@enact/ui/Touchable';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 
@@ -21,8 +20,6 @@ import {Marquee} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './ActionGuide.module.less';
-
-const TouchableDiv = Touchable('div');
 
 /**
  * An Action Guide component.
@@ -82,10 +79,10 @@ const ActionGuideBase = kind({
 
 	render: ({icon, children, css, ...rest}) => {
 		return (
-			<TouchableDiv {...rest}>
+			<div {...rest}>
 				<Icon size="small" className={css.icon}>{icon}</Icon>
 				<Marquee className={css.label} marqueeOn="render" alignment="center">{children}</Marquee>
-			</TouchableDiv>
+			</div>
 		);
 	}
 });

--- a/ActionGuide/ActionGuide.js
+++ b/ActionGuide/ActionGuide.js
@@ -15,7 +15,7 @@ import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 
-import Icon from '../Icon';
+import Button from '../Button';
 import {Marquee} from '../Marquee';
 import Skinnable from '../Skinnable';
 
@@ -36,6 +36,14 @@ const ActionGuideBase = kind({
 	name: 'ActionGuide',
 
 	propTypes: /** @lends sandstone/ActionGuide.ActionGuideBase.prototype */ {
+		/**
+		 * The "aria-label" for the button.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		buttonAriaLabel: PropTypes.string,
+
 		/**
 		 * The contents for the action guide.
 		 *
@@ -58,13 +66,30 @@ const ActionGuideBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Disables the button.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		disabled: PropTypes.bool,
+
+		/**
 		 * The icon displayed within the action guide.
 		 *
 		 * @type {String}
 		 * @default 'arrowsmalldown'
 		 * @public
 		 */
-		icon: PropTypes.string
+		icon: PropTypes.string,
+
+		/**
+		 * Called when Button is clicked.
+		 *
+		 * @type {Function}
+		 * @param {Object} event
+		 * @public
+		 */
+		onClick: PropTypes.func
 	},
 
 	defaultProps: {
@@ -77,10 +102,10 @@ const ActionGuideBase = kind({
 		publicClassNames: ['actionGuide']
 	},
 
-	render: ({icon, children, css, ...rest}) => {
+	render: ({buttonAriaLabel, children, css, disabled, icon, onClick, ...rest}) => {
 		return (
 			<div {...rest}>
-				<Icon size="small" className={css.icon}>{icon}</Icon>
+				<Button aria-label={buttonAriaLabel ? buttonAriaLabel : null} className={css.icon} disabled={disabled} icon={icon} minWidth={false} onClick={onClick} size="small" />
 				<Marquee className={css.label} marqueeOn="render" alignment="center">{children}</Marquee>
 			</div>
 		);

--- a/ActionGuide/ActionGuide.module.less
+++ b/ActionGuide/ActionGuide.module.less
@@ -6,7 +6,8 @@
 
 .actionGuide {
 	text-align: center;
-	width: 100%;
+	max-width: @sand-actionguide-max-width;
+	margin: 0 auto;
 	line-height: 0;
 
 	.label {
@@ -15,9 +16,7 @@
 		});
 		font-size: @sand-actionguide-label-font-size;
 		height: @sand-actionguide-label-height;
-		max-width: @sand-actionguide-label-max-width;
 		line-height: @sand-actionguide-label-height;
-		margin: 0 auto;
 	}
 
 	.icon {

--- a/ActionGuide/tests/ActionGuide-specs.js
+++ b/ActionGuide/tests/ActionGuide-specs.js
@@ -22,6 +22,15 @@ describe('ActionGuide', () => {
 		expect(actual).toBeInTheDocument();
 	});
 
+	test('should set "buttonAriaLabel" to action guide', () => {
+		const label = 'custom aria-label';
+		render(<ActionGuideBase data-testid="actionGuide" buttonAriaLabel={label} />);
+
+		const actual = screen.getByRole('button', {name : label});
+
+		expect(actual).toBeInTheDocument();
+	});
+
 	describe('CSS override', () => {
 		test('should allow `actionGuide` to be augmented', () => {
 			const css = {actionGuide: 'test-action-guide'};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,7 +331,6 @@ No significant changes.
 
 - Shadow effect to using box-shadow instead of drop-shadow for performance on embedded environment
 - `sandstone/FixedPopupPanels` and `sandstone/PopupTabLayout` to disable left key handler to go to the previous panel in RTL locales
-- `sandstone/MediaPlayer.MediaControls` to show more components when a user flicks on action guide
 - `sandstone/Scroller` and `sandstone/VirtualList` overscroll effect style to match latest designs
 - `sandstone/Slider` to interact by wheel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
+- `sandstone/ActionGuide` prop `buttonAriaLabel` and `sandstone/MediaControls` prop `actionGuideButtonAriaLabel` to override aria-label of `ActionGuide` button
 - `sandstone/FormCheckboxItem` CSS variable `--sand-formcheckboxitem-focus-text-color` for a customization of the focused text color
 
 ### Changed
 
 - `--sand-checkbox-disabled-selected-color` to `--sand-checkbox-disabled-selected-text-color`
 - `@sand-alert-overlay-checkbox-disabled-selected-color` to `@sand-alert-overlay-checkbox-disabled-selected-text-color`
+- `sandstone/ActionGuide` to replace `Icon` with `Button`
+- `sandstone/VideoPlayer` to not expand video player using key down via 5way
 
 ### Fixed
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -184,14 +184,6 @@ const MediaControlsBase = kind({
 		onClose: PropTypes.func,
 
 		/**
-		 * Called when the user flicks on the action guide.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onFlickFromActionGuide: PropTypes.func,
-
-		/**
 		 * Called when the user clicks the JumpBackward button
 		 *
 		 * @type {Function}
@@ -335,7 +327,6 @@ const MediaControlsBase = kind({
 		mediaDisabled,
 		moreComponentsSpotlightId,
 		noJumpButtons,
-		onFlickFromActionGuide,
 		onJumpBackwardButtonClick,
 		onJumpForwardButtonClick,
 		onKeyDownFromMediaButtons,
@@ -362,7 +353,7 @@ const MediaControlsBase = kind({
 					{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 				</Container>
 				{actionGuideShowing ?
-					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} css={css} className={actionGuideClassName} icon="arrowsmalldown" onFlick={onFlickFromActionGuide}>{actionGuideLabel}</ActionGuide> :
+					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} css={css} className={actionGuideClassName} icon="arrowsmalldown">{actionGuideLabel}</ActionGuide> :
 					null
 				}
 				{moreComponentsRendered ?
@@ -674,18 +665,10 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.bottomComponentsHeight = bottomElement ? bottomElement.scrollHeight : 0;
 		};
 
-		canShowMoreComponents = () => (!this.props.moreActionDisabled && !this.state.showMoreComponents);
-
 		handleKeyDownFromMediaButtons = (ev) => {
-			if (is('down', ev.keyCode) && this.canShowMoreComponents()) {
+			if (is('down', ev.keyCode) && !this.state.showMoreComponents && !this.props.moreActionDisabled) {
 				this.showMoreComponents();
 				ev.stopPropagation();
-			}
-		};
-
-		handleFlickFromActionGuide = ({direction, velocityY}) => {
-			if (direction === 'vertical' && velocityY < 0 && this.canShowMoreComponents()) {
-				this.showMoreComponents();
 			}
 		};
 
@@ -746,7 +729,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 		};
 
 		handleWheel = (ev) => {
-			if (this.canShowMoreComponents() && this.props.visible && ev.deltaY > 0) {
+			if (!this.state.showMoreComponents && this.props.visible && !this.props.moreActionDisabled && ev.deltaY > 0) {
 				this.showMoreComponents();
 			}
 		};
@@ -857,7 +840,6 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 					mediaControlsRef={this.mediaControlsRef}
 					moreComponentsRendered={this.state.moreComponentsRendered}
 					onClose={this.handleClose}
-					onFlickFromActionGuide={this.handleFlickFromActionGuide}
 					onKeyDownFromMediaButtons={this.handleKeyDownFromMediaButtons}
 					onPlayButtonClick={this.handlePlayButtonClick}
 					onTransitionEnd={this.handleTransitionEnd}

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -91,6 +91,22 @@ const MediaControlsBase = kind({
 		actionGuideAriaLabel: PropTypes.string,
 
 		/**
+		 * The `aria-label` for the action guide button.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		actionGuideButtonAriaLabel: PropTypes.string,
+
+		/**
+		 * Disables the ActionGuide.
+		 *
+		 * @type {Boolean}
+		 * @public
+		 */
+		actionGuideDisabled: PropTypes.bool,
+
+		/**
 		 * The label for the action guide.
 		 *
 		 * @type {String}
@@ -174,6 +190,15 @@ const MediaControlsBase = kind({
 		 * @public
 		 */
 		noJumpButtons: PropTypes.bool,
+
+		/**
+		 * Called when the button in ActionGuide is clicked.
+		 *
+		 * @type {Function}
+		 * @param {Object} event
+		 * @public
+		 */
+		onActionGuideClick: PropTypes.func,
 
 		/**
 		 * Called when cancel/back key events are fired.
@@ -315,6 +340,8 @@ const MediaControlsBase = kind({
 
 	render: ({
 		actionGuideAriaLabel,
+		actionGuideButtonAriaLabel,
+		actionGuideDisabled,
 		actionGuideLabel,
 		actionGuideShowing,
 		children,
@@ -327,6 +354,7 @@ const MediaControlsBase = kind({
 		mediaDisabled,
 		moreComponentsSpotlightId,
 		noJumpButtons,
+		onActionGuideClick,
 		onJumpBackwardButtonClick,
 		onJumpForwardButtonClick,
 		onKeyDownFromMediaButtons,
@@ -353,7 +381,7 @@ const MediaControlsBase = kind({
 					{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 				</Container>
 				{actionGuideShowing ?
-					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} css={css} className={actionGuideClassName} icon="arrowsmalldown">{actionGuideLabel}</ActionGuide> :
+					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} buttonAriaLabel={actionGuideButtonAriaLabel} css={css} className={actionGuideClassName} icon="arrowsmalldown" onClick={onActionGuideClick} disabled={actionGuideDisabled}>{actionGuideLabel}</ActionGuide> :
 					null
 				}
 				{moreComponentsRendered ?
@@ -557,6 +585,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.actionGuideHeight = 0;
 			this.animation = null;
 			this.bottomComponentsHeight = 0;
+			this.moreComponentsSpotlightId = 'moreComponents';
 			this.keyLoop = null;
 			this.pulsingKeyCode = null;
 			this.pulsing = null;
@@ -665,13 +694,6 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			this.bottomComponentsHeight = bottomElement ? bottomElement.scrollHeight : 0;
 		};
 
-		handleKeyDownFromMediaButtons = (ev) => {
-			if (is('down', ev.keyCode) && !this.state.showMoreComponents && !this.props.moreActionDisabled) {
-				this.showMoreComponents();
-				ev.stopPropagation();
-			}
-		};
-
 		handleKeyDown = (ev) => {
 			const {
 				mediaDisabled,
@@ -730,6 +752,12 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 
 		handleWheel = (ev) => {
 			if (!this.state.showMoreComponents && this.props.visible && !this.props.moreActionDisabled && ev.deltaY > 0) {
+				this.showMoreComponents();
+			}
+		};
+
+		handleActionGuideClick = () => {
+			if (!this.state.showMoreComponents) {
 				this.showMoreComponents();
 			}
 		};
@@ -810,7 +838,7 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 			if (this.state.showMoreComponents) {
 				this.paused.resume();
 				if (!Spotlight.getPointerMode()) {
-					Spotlight.move('down');
+					Spotlight.focus(this.moreComponentsSpotlightId);
 				}
 			}
 		};
@@ -838,11 +866,12 @@ const MediaControlsDecorator = hoc((config, Wrapped) => {
 				<Wrapped
 					{...props}
 					mediaControlsRef={this.mediaControlsRef}
+					actionGuideDisabled={this.props.moreActionDisabled}
 					moreComponentsRendered={this.state.moreComponentsRendered}
+					moreComponentsSpotlightId={this.moreComponentsSpotlightId}
+					onActionGuideClick={this.handleActionGuideClick}
 					onClose={this.handleClose}
-					onKeyDownFromMediaButtons={this.handleKeyDownFromMediaButtons}
 					onPlayButtonClick={this.handlePlayButtonClick}
-					onTransitionEnd={this.handleTransitionEnd}
 					ref={this.getMediaControls}
 					showMoreComponents={this.state.showMoreComponents}
 				/>

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -381,7 +381,7 @@ const MediaControlsBase = kind({
 					{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 				</Container>
 				{actionGuideShowing ?
-					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} buttonAriaLabel={actionGuideButtonAriaLabel} css={css} className={actionGuideClassName} icon="arrowsmalldown" onClick={onActionGuideClick} disabled={actionGuideDisabled}>{actionGuideLabel}</ActionGuide> :
+					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} buttonAriaLabel={actionGuideButtonAriaLabel == null ? $L('This is label 0') : actionGuideButtonAriaLabel} css={css} className={actionGuideClassName} icon="arrowsmalldown" onClick={onActionGuideClick} disabled={actionGuideDisabled}>{actionGuideLabel}</ActionGuide> :
 					null
 				}
 				{moreComponentsRendered ?

--- a/VideoPlayer/tests/VideoPlayer-specs.js
+++ b/VideoPlayer/tests/VideoPlayer-specs.js
@@ -3,10 +3,10 @@ import {act, createEvent, fireEvent, render, screen, waitFor} from '@testing-lib
 import userEvent from '@testing-library/user-event';
 
 import VideoPlayer from '../VideoPlayer';
+import {Button} from '../../Button';
+import {MediaControls} from '../../MediaPlayer';
 
 const focus = (slider) => fireEvent.focus(slider);
-const keyDown = (keyCode) => (button) => fireEvent.keyDown(button, {keyCode});
-const downKeyDown = keyDown(40);
 
 describe('VideoPlayer', () => {
 	test('should fire `onPlaying` with `playing` type when playing event is fired', () => {
@@ -107,11 +107,17 @@ describe('VideoPlayer', () => {
 		expect(backButton).toBeNull();
 	});
 
-	test('should fire `onToggleMore` with `onToggleMore` type when downkey pressed during pause button focus', async () => {
+	test('should fire `onToggleMore` with `onToggleMore` type when ActionGide button clicked', async () => {
 		const handleToggleMore = jest.fn();
 
 		render(
-			<VideoPlayer data-testid="videoplayer-id" onToggleMore={handleToggleMore} />
+			<VideoPlayer data-testid="videoplayer-id" onToggleMore={handleToggleMore}>
+				<MediaControls
+					actionGuideButtonAriaLabel="This is ActionGide button"
+				>
+					<Button size="small" icon="list" />
+				</MediaControls>
+			</VideoPlayer>
 		);
 
 		const overlay = screen.getByTestId('videoplayer-id').nextElementSibling;
@@ -120,10 +126,10 @@ describe('VideoPlayer', () => {
 
 		await screen.findByLabelText('go to previous');
 
-		const pauseButton = screen.getByLabelText('Pause');
+		const actionGuideButton = screen.getByLabelText('This is ActionGide button');
 		const expected = {type: 'onToggleMore'};
 
-		downKeyDown(pauseButton);
+		userEvent.click(actionGuideButton);
 
 		await waitFor(() => {
 			const actual = handleToggleMore.mock.calls.length && handleToggleMore.mock.calls[0][0];

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -38,7 +38,7 @@ const VideoPlayerView = () => (
 		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
 			<source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
-			<MediaControls actionGuideLabel="Press Down Button to Scroll">
+			<MediaControls actionGuideButtonAriaLabel="This is label 0.">
 				<bottomComponents>
 					<VirtualGridList
 						dataSize={20}

--- a/samples/sampler/npm-shrinkwrap.json
+++ b/samples/sampler/npm-shrinkwrap.json
@@ -1811,6 +1811,7 @@
             },
             "@babel/eslint-plugin": {
               "version": "7.17.7",
+              "resolved": false,
               "integrity": "sha512-JATUoJJXSgwI0T8juxWYtK1JSgoLpIGUsCHIv+NMXcUDA2vIe6nvAHR9vnuJgs/P1hOFw7vPwibixzfqBBLIVw==",
               "requires": {
                 "eslint-rule-composer": "^0.3.0"
@@ -3910,6 +3911,7 @@
             },
             "eslint-config-enact": {
               "version": "4.1.1",
+              "resolved": false,
               "integrity": "sha512-W3i5FGkm3Ow4pYEOuEm5uFzhZUyA3eg/EF4osb5u02irnKKnJuejBnFXo3OFSAxLrWz94q7ROTIK5/UMyGPnNg==",
               "requires": {
                 "@babel/core": "^7.17.8",
@@ -6804,6 +6806,7 @@
                     },
                     "mocha": {
                       "version": "10.0.0",
+                      "resolved": false,
                       "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
                       "requires": {
                         "@ungap/promise-all-settled": "1.1.2",
@@ -8430,6 +8433,7 @@
             },
             "eslint-config-prettier": {
               "version": "8.5.0",
+              "resolved": false,
               "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
             },
             "eslint-import-resolver-node": {
@@ -8472,6 +8476,7 @@
             },
             "eslint-plugin-enact": {
               "version": "1.0.1",
+              "resolved": false,
               "integrity": "sha512-rkMDrRTNGUwQmqE7ulaL2lJGpGofWDWlKdRjU85dJBnbM+AQVjuN6BzRw7B2xEoyCy4XqO9Dxl1bqSmvkgyBfg==",
               "requires": {
                 "doctrine": "^3.0.0",
@@ -9407,6 +9412,7 @@
                 },
                 "mocha": {
                   "version": "10.0.0",
+                  "resolved": false,
                   "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
                   "requires": {
                     "@ungap/promise-all-settled": "1.1.2",
@@ -9847,6 +9853,7 @@
             },
             "eslint-plugin-import": {
               "version": "2.26.0",
+              "resolved": false,
               "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
               "requires": {
                 "array-includes": "^3.1.4",
@@ -9889,6 +9896,7 @@
             },
             "eslint-plugin-jest": {
               "version": "26.5.3",
+              "resolved": false,
               "integrity": "sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==",
               "requires": {
                 "@typescript-eslint/utils": "^5.10.0"
@@ -9896,6 +9904,7 @@
             },
             "eslint-plugin-jsx-a11y": {
               "version": "6.5.1",
+              "resolved": false,
               "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
               "requires": {
                 "@babel/runtime": "^7.16.3",
@@ -9914,6 +9923,7 @@
             },
             "eslint-plugin-prettier": {
               "version": "4.0.0",
+              "resolved": false,
               "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
               "requires": {
                 "prettier-linter-helpers": "^1.0.0"
@@ -9921,6 +9931,7 @@
             },
             "eslint-plugin-react": {
               "version": "7.30.0",
+              "resolved": false,
               "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
               "requires": {
                 "array-includes": "^3.1.5",
@@ -9960,6 +9971,7 @@
             },
             "eslint-plugin-react-hooks": {
               "version": "4.5.0",
+              "resolved": false,
               "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw=="
             },
             "eslint-rule-composer": {

--- a/samples/sampler/stories/default/ActionGuide.js
+++ b/samples/sampler/stories/default/ActionGuide.js
@@ -32,7 +32,7 @@ export const _ActionGuide = (args) => {
 	}
 
 	return (
-		<ActionGuide icon={icon}>
+		<ActionGuide buttonAriaLabel={args['buttonAriaLabel']} icon={icon}>
 			{args['children']}
 		</ActionGuide>
 	);
@@ -41,6 +41,7 @@ export const _ActionGuide = (args) => {
 select('icon type', _ActionGuide, ['glyph', 'url src', 'custom'], Config, 'glyph');
 select('icon', _ActionGuide, ['', ...iconNames], Config, 'arrowsmalldown');
 select('src', _ActionGuide, [docs, factory, logo], Config, logo);
+text('buttonAriaLabel', _ActionGuide, Config, 'This is label 0');
 text('custom icon', _ActionGuide, Config);
 text('children', _ActionGuide, Config, 'Press some key to do something');
 

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -173,6 +173,7 @@ export const _VideoPlayer = (args) => {
 				</infoComponents>
 				<MediaControls
 					actionGuideAriaLabel={args['actionGuideAriaLabel']}
+					actionGuideButtonAriaLabel={args['actionGuideButtonAriaLabel']}
 					actionGuideLabel={args['actionGuideLabel']}
 					jumpBackwardIcon={args['jumpBackwardIcon']}
 					jumpButtonsDisabled={args['jumpButtonsDisabled']}
@@ -239,10 +240,16 @@ text(
 	'Press Down Key Using Remote Control'
 );
 text(
+	'actionGuideButtonAriaLabel',
+	_VideoPlayer,
+	MediaControlsConfig,
+	'This is label 0'
+);
+text(
 	'actionGuideLabel',
 	_VideoPlayer,
 	MediaControlsConfig,
-	'Press Down Button to Scroll'
+	''
 );
 select('jumpBackwardIcon', _VideoPlayer, icons, MediaControlsConfig, 'jumpbackward');
 boolean('jumpButtonsDisabled', _VideoPlayer, MediaControlsConfig);

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -156,7 +156,7 @@ class VideoPlayerWithfastForwardMode extends Component {
 					<Video>
 						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
 					</Video>
-					<MediaControls actionGuideLabel="Press Down Button">
+					<MediaControls>
 						<Button
 							icon="backward"
 							onClick={this.rewind}

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -299,7 +299,7 @@
 
 // ActionGuide
 // ---------------------------------------
-@sand-actionguide-label-max-width: 1500px;
+@sand-actionguide-max-width: 1500px;
 @sand-actionguide-label-height: 60px;
 @sand-actionguide-icon-margin: -24px 0 -18px 0;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Change the UX for VideoPlayer

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- ActionGuide to  replace `Icon` with `Button`
- not expand video player using key down via 5 way

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The default aria-label value for ActionGuideButton is temporary in this PR.
When the default value is decided, modify it to a different PR. 

### Links
[//]: # (Related issues, references)
WRO-12192

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)