### PR TITLE
WRO-14595: Add selected order for each selected item

### DIFF
--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -119,7 +119,16 @@ const TransferListBase = kind({
 		 * @type {Function}
 		 * @public
 		 */
-		setSecondList: PropTypes.func
+		setSecondList: PropTypes.func,
+
+		/**
+		 * Allows items to display the order in which the items were selected.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		showSelectionOrder: PropTypes.bool
 	},
 
 	defaultProps: {
@@ -130,7 +139,8 @@ const TransferListBase = kind({
 		moveOnSpotlight: false,
 		secondList: {},
 		setFirstList: null,
-		setSecondList: null
+		setSecondList: null,
+		showSelectionOrder: false
 	},
 
 	styles: {
@@ -140,10 +150,11 @@ const TransferListBase = kind({
 	},
 
 	computed: {
-		renderItem: () => ({elements, list, onSelect, selectedItems, ...rest}) => (data) => {	// eslint-disable-line	enact/display-name
+		renderItem: () => ({elements, list, onSelect, selectedItems, showSelection, ...rest}) => (data) => {	// eslint-disable-line	enact/display-name
 			const {index, 'data-index': dataIndex} = data;
 			const element = elements[index];
-			const selected = -1 !== selectedItems.findIndex((pair) => pair.element === element && pair.list === list);
+			const selectedIndex = selectedItems.findIndex((args) => args.element === element && args.list === list) + 1;
+			const selected = selectedIndex !== 0;
 
 			const handleClick = () => {
 				onSelect(element, index, list);
@@ -173,6 +184,7 @@ const TransferListBase = kind({
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightUp={handleSpotlightUp}	// eslint-disable-line  react/jsx-no-bind
 					selected={selected}
+					slotAfter={(selected && showSelection) && selectedIndex}
 				>
 					{element}
 				</CheckboxItem>
@@ -180,7 +192,7 @@ const TransferListBase = kind({
 		}
 	},
 
-	render: ({allowMultipleDrag, css, firstList, height: defaultHeight, itemSize: defaultItemSize, moveOnSpotlight, renderItem, secondList, setFirstList, setSecondList}) => {
+	render: ({allowMultipleDrag, css, firstList, height: defaultHeight, itemSize: defaultItemSize, moveOnSpotlight, renderItem, secondList, setFirstList, setSecondList, showSelectionOrder}) => {
 		const [firstListLocal, setFirstListLocal] = useState(firstList);
 		const [secondListLocal, setSecondListLocal] = useState(secondList);
 		const [selectedItems, setSelectedItems] = useState([]);
@@ -539,7 +551,8 @@ const TransferListBase = kind({
 			list: 'first',
 			onSelect: setSelected,
 			selectedItems: selectedItems,
-			onSpotlightRight: handleSpotlightRight
+			onSpotlightRight: handleSpotlightRight,
+			showSelection: showSelectionOrder
 		};
 
 		const secondListSpecs = {
@@ -547,7 +560,8 @@ const TransferListBase = kind({
 			list: 'second',
 			onSelect: setSelected,
 			selectedItems: selectedItems,
-			onSpotlightLeft: handleSpotlightLeft
+			onSpotlightLeft: handleSpotlightLeft,
+			showSelection: showSelectionOrder
 		};
 
 		return (

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -150,7 +150,7 @@ const TransferListBase = kind({
 	},
 
 	computed: {
-		renderItem: () => ({elements, list, onSelect, selectedItems, showSelection, ...rest}) => (data) => {	// eslint-disable-line	enact/display-name
+		renderItem: () => ({elements, list, onSelect, selectedItems, showSelectionOrder, ...rest}) => (data) => {	// eslint-disable-line	enact/display-name
 			const {index, 'data-index': dataIndex} = data;
 			const element = elements[index];
 			const selectedIndex = selectedItems.findIndex((args) => args.element === element && args.list === list) + 1;
@@ -184,7 +184,7 @@ const TransferListBase = kind({
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightUp={handleSpotlightUp}	// eslint-disable-line  react/jsx-no-bind
 					selected={selected}
-					slotAfter={(selected && showSelection) && selectedIndex}
+					slotAfter={(selected && showSelectionOrder) && selectedIndex}
 				>
 					{element}
 				</CheckboxItem>
@@ -550,18 +550,18 @@ const TransferListBase = kind({
 			elements: firstListLocal,
 			list: 'first',
 			onSelect: setSelected,
-			selectedItems: selectedItems,
+			selectedItems,
 			onSpotlightRight: handleSpotlightRight,
-			showSelection: showSelectionOrder
+			showSelectionOrder
 		};
 
 		const secondListSpecs = {
 			elements: secondListLocal,
 			list: 'second',
 			onSelect: setSelected,
-			selectedItems: selectedItems,
+			selectedItems,
 			onSpotlightLeft: handleSpotlightLeft,
-			showSelection: showSelectionOrder
+			showSelectionOrder
 		};
 
 		return (

--- a/samples/sampler/stories/default/TransferList.js
+++ b/samples/sampler/stories/default/TransferList.js
@@ -19,12 +19,14 @@ export const _TransferList = (args) => (
 		itemSize={args['itemSize']}
 		moveOnSpotlight={args['moveElementOnSpotlightDirections']}
 		secondList={['Item9', 'Item10', 'Item11', 'Item12', 'Item13', 'Item14', 'Item15', 'Item16']}
+		showSelectionOrder={args['showSelectionOrder']}
 	/>
 );
 
 boolean('allowMultipleDrag', _TransferList, Config, true);
 number('itemSize', _TransferList, Config, 201);
 boolean('moveElementOnSpotlightDirections', _TransferList, Config, false);
+boolean('showSelectionOrder', _TransferList, Config, false);
 
 _TransferList.storyName = 'TransferList';
 _TransferList.parameters = {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added selected order for each selected item and created a control for the story.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
TransferList now has a showSelectionOrder control that can display the order in which the items are being selected.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-14595

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com