### PR TITLE
WRP-852: Fix ui-test and aria-label for ActionGuideButton in VideoPlayer

### DIFF
--- a/ActionGuide/ActionGuide.js
+++ b/ActionGuide/ActionGuide.js
@@ -106,7 +106,7 @@ const ActionGuideBase = kind({
 	render: ({buttonAriaLabel, children, css, disabled, icon, onClick, ...rest}) => {
 		return (
 			<div {...rest}>
-				<Button aria-label={buttonAriaLabel ? buttonAriaLabel : $L('more')} className={css.icon} disabled={disabled} icon={icon} minWidth={false} onClick={onClick} size="small" />
+				<Button aria-label={buttonAriaLabel ? buttonAriaLabel : $L('More')} className={css.icon} disabled={disabled} icon={icon} minWidth={false} onClick={onClick} size="small" />
 				<Marquee className={css.label} marqueeOn="render" alignment="center">{children}</Marquee>
 			</div>
 		);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
-## [Unreleased]
+## [unreleased]
+
+### Added
+
+- `sandstone/ActionGuide` prop `buttonAriaLabel` and `sandstone/MediaControls` prop `actionGuideButtonAriaLabel` to override aria-label of `ActionGuide` button
+
+### Changed
+
+- `sandstone/ActionGuide` to replace `Icon` with `Button`
+- `sandstone/VideoPlayer` to not expand video player using key down via 5way
 
 ### Fixed
 
@@ -16,15 +25,12 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/ActionGuide` prop `buttonAriaLabel` and `sandstone/MediaControls` prop `actionGuideButtonAriaLabel` to override aria-label of `ActionGuide` button
 - `sandstone/FormCheckboxItem` CSS variable `--sand-formcheckboxitem-focus-text-color` for a customization of the focused text color
 
 ### Changed
 
 - `--sand-checkbox-disabled-selected-color` to `--sand-checkbox-disabled-selected-text-color`
 - `@sand-alert-overlay-checkbox-disabled-selected-color` to `@sand-alert-overlay-checkbox-disabled-selected-text-color`
-- `sandstone/ActionGuide` to replace `Icon` with `Button`
-- `sandstone/VideoPlayer` to not expand video player using key down via 5way
 
 ### Fixed
 

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -38,7 +38,7 @@ const VideoPlayerView = () => (
 		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
 			<source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
-			<MediaControls actionGuideButtonAriaLabel="more">
+			<MediaControls actionGuideButtonAriaLabel="More">
 				<bottomComponents>
 					<VirtualGridList
 						dataSize={20}

--- a/samples/sampler/stories/default/ActionGuide.js
+++ b/samples/sampler/stories/default/ActionGuide.js
@@ -41,7 +41,7 @@ export const _ActionGuide = (args) => {
 select('icon type', _ActionGuide, ['glyph', 'url src', 'custom'], Config, 'glyph');
 select('icon', _ActionGuide, ['', ...iconNames], Config, 'arrowsmalldown');
 select('src', _ActionGuide, [docs, factory, logo], Config, logo);
-text('buttonAriaLabel', _ActionGuide, Config, 'more');
+text('buttonAriaLabel', _ActionGuide, Config, 'More');
 text('custom icon', _ActionGuide, Config);
 text('children', _ActionGuide, Config, 'Press some key to do something');
 

--- a/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
+++ b/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
@@ -67,12 +67,12 @@ describe('VideoPlayer', function () {
 		});
 
 		describe('5-way', function () {
-			it('should focus `play` button on 5-way back, then down', async function () {
+			it('should focus `more` button on 5-way back, then down', async function () {
 				await Page.delay(1000);
 				await Page.backKey();
 				await Page.spotlightDown();
 
-				expect(await videoPlayerDefault.playButton.isFocused()).to.be.true();
+				await expect(await videoPlayerDefault.mediaControlsActionGuide.isFocused()).to.be.true();
 			});
 
 			it('should focus `previous` buttons on 5-way left', async function () {
@@ -97,7 +97,7 @@ describe('VideoPlayer', function () {
 				await Page.delay(1000);
 				expect(await videoPlayerDefault.playButton.isFocused()).to.be.true();
 				await Page.spotlightDown();
-				await Page.spotlightDown();
+				await Page.spotlightSelect();
 
 				await Page.delay(500);
 
@@ -117,8 +117,10 @@ describe('VideoPlayer', function () {
 
 				expect(await videoPlayerDefault.playButton.isFocused()).to.be.true();
 				// Setp 4-2: 5-way Down again.
-				// Step 4-3: 5-way Up quickly.
+				// Step 4-3: 5-way Select.
+				// Step 4-4: 5-way Up quickly.
 				await Page.spotlightDown();
+				await Page.spotlightSelect();
 				await Page.spotlightUp();
 
 				await Page.delay(500);

--- a/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
+++ b/tests/ui/specs/VideoPlayer/VideoPlayer-specs.js
@@ -72,7 +72,7 @@ describe('VideoPlayer', function () {
 				await Page.backKey();
 				await Page.spotlightDown();
 
-				await expect(await videoPlayerDefault.mediaControlsActionGuide.isFocused()).to.be.true();
+				await expect(await videoPlayerDefault.mediaControlsActionGuideButton.isFocused()).to.be.true();
 			});
 
 			it('should focus `previous` buttons on 5-way left', async function () {

--- a/tests/ui/specs/VideoPlayer/VideoPlayerPage.js
+++ b/tests/ui/specs/VideoPlayer/VideoPlayerPage.js
@@ -48,7 +48,7 @@ class VideoPlayerInterface {
 	}
 
 	get mediaControlsActionGuide () {
-		return $(this.selector + ' .MediaPlayer_MediaControls_actionGuide');
+		return $(this.selector + ' .MediaPlayer_MediaControls_actionGuide>div[aria-label=More]');
 	}
 
 	get mediaControlsListButton () {

--- a/tests/ui/specs/VideoPlayer/VideoPlayerPage.js
+++ b/tests/ui/specs/VideoPlayer/VideoPlayerPage.js
@@ -47,7 +47,7 @@ class VideoPlayerInterface {
 		return $(this.selector + ' .MediaPlayer_MediaControls_controlsFrame');
 	}
 
-	get mediaControlsActionGuide () {
+	get mediaControlsActionGuideButton () {
 		return $(this.selector + ' .MediaPlayer_MediaControls_actionGuide>div[aria-label=More]');
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Need to fix ui test as change the UX for VideoPlayer
- Need to change aria-label for ActionGuideButton as change the UX for VideoPlayer

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Fix ui test as change the UX for VideoPlayer
- Change aria-label for ActionGuideButton 'more' to 'More'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-852

### Comments
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)