### PR TITLE
WRP-4977: Fixed MediaControls to disable hidden button properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Input` to read out properly after closing it in a `sandstone/PopupTabLayout`
-- `sandstone/MediaPlayer.MediaControls` to disable the button when the button is hidden
+- `sandstone/MediaPlayer.MediaControls` to disable buttons when hidden
 
 ## [2.6.0] - 2022-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Input` to read out properly after closing it in a `sandstone/PopupTabLayout`
+- `sandstone/MediaPlayer.MediaControls` to disable the button when the button is hidden
 
 ## [2.6.0] - 2022-12-05
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -334,7 +334,8 @@ const MediaControlsBase = kind({
 		actionGuideClassName: ({styler, showMoreComponents}) => styler.join({hidden: showMoreComponents}),
 		actionGuideShowing: ({bottomComponents, children}) => countReactChildren(children) || bottomComponents,
 		className: ({visible, styler}) => styler.append({hidden: !visible}),
-		moreButtonsClassName: ({styler, showMoreComponents}) => styler.join({'hidden': !showMoreComponents}, 'mediaControls', 'moreButtonsComponents'),
+		moreButtonsClassName: ({styler}) => styler.join('mediaControls', 'moreButtonsComponents'),
+		moreComponentsClassName: ({styler, showMoreComponents}) => styler.join({hidden: !showMoreComponents}, 'moreComponents'),
 		moreComponentsRendered: ({showMoreComponents, moreComponentsRendered}) => showMoreComponents || moreComponentsRendered
 	},
 
@@ -366,6 +367,7 @@ const MediaControlsBase = kind({
 		showMoreComponents,
 		moreComponentsRendered,
 		moreButtonsClassName,
+		moreComponentsClassName,
 		actionGuideClassName,
 		spotlightDisabled,
 		spotlightId,
@@ -385,7 +387,7 @@ const MediaControlsBase = kind({
 					null
 				}
 				{moreComponentsRendered ?
-					<Container spotlightId={moreComponentsSpotlightId} className={css.moreComponents} spotlightDisabled={!showMoreComponents || spotlightDisabled}>
+					<Container spotlightId={moreComponentsSpotlightId} className={moreComponentsClassName} spotlightDisabled={!showMoreComponents || spotlightDisabled}>
 						<Container className={moreButtonsClassName} >
 							{children}
 						</Container>

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -334,7 +334,7 @@ const MediaControlsBase = kind({
 		actionGuideClassName: ({styler, showMoreComponents}) => styler.join({hidden: showMoreComponents}),
 		actionGuideShowing: ({bottomComponents, children}) => countReactChildren(children) || bottomComponents,
 		className: ({visible, styler}) => styler.append({hidden: !visible}),
-		moreButtonsClassName: ({styler}) => styler.join('mediaControls', 'moreButtonsComponents'),
+		moreButtonsClassName: ({styler, showMoreComponents}) => styler.join({'hidden': !showMoreComponents}, 'mediaControls', 'moreButtonsComponents'),
 		moreComponentsRendered: ({showMoreComponents, moreComponentsRendered}) => showMoreComponents || moreComponentsRendered
 	},
 

--- a/MediaPlayer/MediaControls.module.less
+++ b/MediaPlayer/MediaControls.module.less
@@ -26,6 +26,7 @@
 		transition: opacity @sand-mediaplayer-controls-actionguide-time linear;
 		&.hidden {
 			opacity: 0;
+			visibility: hidden;
 		}
 	}
 
@@ -49,6 +50,9 @@
 
 		> :first-child {
 			margin-top: @sand-mediaplayer-controls-moreComponents-margin-top;
+			&.hidden {
+				visibility: hidden;
+			}
 		}
 	}
 

--- a/MediaPlayer/MediaControls.module.less
+++ b/MediaPlayer/MediaControls.module.less
@@ -36,6 +36,9 @@
 		right: 0;
 		height: 0px;
 		opacity: 0;
+		&.hidden {
+			visibility: hidden;
+		}
 
 		.moreButtonsComponents {
 			> * {
@@ -50,9 +53,6 @@
 
 		> :first-child {
 			margin-top: @sand-mediaplayer-controls-moreComponents-margin-top;
-			&.hidden {
-				visibility: hidden;
-			}
 		}
 	}
 

--- a/MediaPlayer/MediaControls.module.less
+++ b/MediaPlayer/MediaControls.module.less
@@ -24,6 +24,7 @@
 	.actionGuide {
 		padding-top: @sand-mediaplayer-controls-actionguide-padding-top;
 		transition: opacity @sand-mediaplayer-controls-actionguide-time linear;
+
 		&.hidden {
 			opacity: 0;
 			visibility: hidden;
@@ -36,6 +37,7 @@
 		right: 0;
 		height: 0px;
 		opacity: 0;
+
 		&.hidden {
 			visibility: hidden;
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Buttons in the MediaControls were focusable and clickable even though it was hidden. 
They need to be disabled when they are hidden.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `visibility:hidden` css property to the related elements(moreButtonComponents, actionGuide).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-4977

### Comments
