### PR TITLE
WRP-857: Add focusableScrollbar TC

### DIFF
--- a/Scroller/tests/Scroller-specs.js
+++ b/Scroller/tests/Scroller-specs.js
@@ -1,12 +1,24 @@
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {render, fireEvent, screen, waitFor} from '@testing-library/react';
 
 import Scroller from '../Scroller';
 
+const focus = (elm) => fireEvent.focus(elm);
+
+const keyDownUp = (keyCode) => (elm) => {
+	fireEvent.keyDown(elm, {keyCode});
+	return fireEvent.keyUp(elm, {keyCode});
+};
+
+const pressEnterKey = keyDownUp(14);
+const pressDownKey = keyDownUp(40);
+
 describe('Scroller', () => {
+	let clientSize;
 	let contents;
 
 	beforeEach(() => {
+		clientSize = {clientWidth: 1280, clientHeight: 720};
 		contents = (
 			<div>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br />
@@ -16,6 +28,7 @@ describe('Scroller', () => {
 	});
 
 	afterEach(() => {
+		clientSize = null;
 		contents = null;
 	});
 
@@ -61,7 +74,7 @@ describe('Scroller', () => {
 		);
 
 		test(
-			'should not render any scrollbar when when \'horizontalScrollbar\' and \'verticalScrollbar\' are "hidden"',
+			'should not render any scrollbar when \'horizontalScrollbar\' and \'verticalScrollbar\' are "hidden"',
 			() => {
 				render(
 					<Scroller
@@ -77,6 +90,63 @@ describe('Scroller', () => {
 
 				expect(verticalScrollbar).toBeNull();
 				expect(horizontalScrollbar).toBeNull();
+			}
+		);
+	});
+
+	describe('focusable Scrollbar', () => {
+		test('should have focuable body and thumb when \'focusableScrollbar\' is "byEnter"',
+			() => {
+				const id = 'scroller';
+
+				render(
+					<Scroller
+						data-testid={id}
+						focusableScrollbar="byEnter"
+						verticalScrollbar="visible"
+					>
+						{contents}
+					</Scroller>
+				);
+
+				const scroller = screen.getByTestId(id);
+				const scrollBody = scroller.children.item(0);
+				const virticalScrollbar = screen.getByLabelText("scroll up or down with up down button press ok button to read text");
+
+				const expected = "spottable";
+
+				// dispatching key event to increase code coverage
+				focus(virticalScrollbar);
+				pressDownKey(virticalScrollbar);
+				pressEnterKey(virticalScrollbar);
+
+				expect(scrollBody).toHaveClass(expected);
+				expect(virticalScrollbar).toHaveClass(expected);
+			}
+		);
+
+		test('should have focuable scroll thumb when \'focusableScrollbar\' is true',
+			() => {
+				const id = 'scroller';
+
+				render(
+					<Scroller
+						data-testid={id}
+						focusableScrollbar
+						verticalScrollbar="visible"
+					>
+						{contents}
+					</Scroller>
+				);
+
+				const scroller = screen.getByTestId(id);
+				const scrollBody = scroller.children.item(0);
+				const virticalScrollbar = screen.getByLabelText("scroll up or down with up down button");
+
+				const expected = "spottable";
+
+				expect(scrollBody).not.toHaveClass(expected);
+				expect(virticalScrollbar).toHaveClass(expected);
 			}
 		);
 	});

--- a/Scroller/tests/Scroller-specs.js
+++ b/Scroller/tests/Scroller-specs.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import {render, fireEvent, screen, waitFor} from '@testing-library/react';
+import {render, fireEvent, screen} from '@testing-library/react';
 
 import Scroller from '../Scroller';
 

--- a/Scroller/tests/Scroller-specs.js
+++ b/Scroller/tests/Scroller-specs.js
@@ -14,11 +14,9 @@ const pressEnterKey = keyDownUp(14);
 const pressDownKey = keyDownUp(40);
 
 describe('Scroller', () => {
-	let clientSize;
 	let contents;
 
 	beforeEach(() => {
-		clientSize = {clientWidth: 1280, clientHeight: 720};
 		contents = (
 			<div>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br />
@@ -28,7 +26,6 @@ describe('Scroller', () => {
 	});
 
 	afterEach(() => {
-		clientSize = null;
 		contents = null;
 	});
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+    - "Scroller/EditableWrapper.js"


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Increased test coverage of Scroller component

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add `focusableScrollbar` TCs.
- Ignore EditableWrapper.js file. 
It was decided to skip the tests for EditableScroller by internal discussion.
Most of the EditableWrapper code is a scenario after selection using long press. So it is impossible to verify this in unit tests.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I wanted to verify the Scrolling operation, not simply verify the DOM structure after the render, but I failed.
I tried several things as shown below, but it doesn't seem to be rendered as a scrollable element (overflowed element).
```
	<Scroller
		style={{height: "720px", width: "1280px"}}
		clientSize={{clientWidth: 1280, clientHeight: 720}}
		data-testid={id}
		verticalScrollbar="visible"
		onScrollStart={spy}
		// scrollMode="translate"
	>
		<div style={{height: "30000px", width: "100px"}}>
			{contents}
			{contents}
			{contents}
			{contents}
			{contents}
			{contents}
		</div>
	</Scroller>
```
If I can verify the scrolling behavior, the unit test coverage will be greatly expanded, but I failed at the beginning stage, so I couldn't create more test cases.
`Scroller` and `VirtualList` have higher ui test coverage than other components, So I think it is okay to give up the unit test coverage of `Scroller` and `VirtualList`. There is obviously a limit to verifying the operation that engages with native events with unit tests.

### Links
[//]: # (Related issues, references)
WRP-857

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
