### PR TITLE
WRP-4977: Fixed MediaControls to disable buttons properly when buttons are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/MediaPlayer.MediaControls` to disable buttons when hidden
+
 ## [2.5.6] - 2022-12-13
 
 ### Added

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -335,6 +335,7 @@ const MediaControlsBase = kind({
 		actionGuideShowing: ({bottomComponents, children}) => countReactChildren(children) || bottomComponents,
 		className: ({visible, styler}) => styler.append({hidden: !visible}),
 		moreButtonsClassName: ({styler}) => styler.join('mediaControls', 'moreButtonsComponents'),
+		moreComponentsClassName: ({styler, showMoreComponents}) => styler.join({hidden: !showMoreComponents}, 'moreComponents'),
 		moreComponentsRendered: ({showMoreComponents, moreComponentsRendered}) => showMoreComponents || moreComponentsRendered
 	},
 
@@ -366,6 +367,7 @@ const MediaControlsBase = kind({
 		showMoreComponents,
 		moreComponentsRendered,
 		moreButtonsClassName,
+		moreComponentsClassName,
 		actionGuideClassName,
 		spotlightDisabled,
 		spotlightId,
@@ -385,7 +387,7 @@ const MediaControlsBase = kind({
 					null
 				}
 				{moreComponentsRendered ?
-					<Container spotlightId={moreComponentsSpotlightId} className={css.moreComponents} spotlightDisabled={!showMoreComponents || spotlightDisabled}>
+					<Container spotlightId={moreComponentsSpotlightId} className={moreComponentsClassName} spotlightDisabled={!showMoreComponents || spotlightDisabled}>
 						<Container className={moreButtonsClassName} >
 							{children}
 						</Container>

--- a/MediaPlayer/MediaControls.module.less
+++ b/MediaPlayer/MediaControls.module.less
@@ -24,8 +24,10 @@
 	.actionGuide {
 		padding-top: @sand-mediaplayer-controls-actionguide-padding-top;
 		transition: opacity @sand-mediaplayer-controls-actionguide-time linear;
+
 		&.hidden {
 			opacity: 0;
+			visibility: hidden;
 		}
 	}
 
@@ -35,6 +37,10 @@
 		right: 0;
 		height: 0px;
 		opacity: 0;
+
+		&.hidden {
+			visibility: hidden;
+		}
 
 		.moreButtonsComponents {
 			> * {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Buttons in the MediaControls were focusable and clickable even though when they are hidden.
They need to be disabled when they are hidden.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `visibility:hidden` css property to the related elements(moreComponents, actionGuide)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-4977

### Comments
