### PR TITLE
WRP-4952: TransferListPOC - Added support for VirtualGridList

### DIFF
--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -290,6 +290,7 @@ const TransferListBase = kind({
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightUp={handleSpotlightUp}	// eslint-disable-line  react/jsx-no-bind
+					orientation="horizontal"
 					selected={selected}
 					showSelection
 					// slotAfter={(selected && showSelectionOrder) && selectedIndex}
@@ -715,7 +716,7 @@ const TransferListBase = kind({
 							horizontalScrollbar="hidden"
 							itemRenderer={renderImageItem(firstListSpecs)}
 							itemSize={{
-								minWidth: itemSize,
+								minWidth: 5*itemSize,
 								minHeight: itemSize
 							}}
 							onScrollStop={handleScroll}
@@ -756,7 +757,7 @@ const TransferListBase = kind({
 							horizontalScrollbar="hidden"
 							itemRenderer={renderImageItem(secondListSpecs)}
 							itemSize={{
-								minWidth: itemSize,
+								minWidth: 5*itemSize,
 								minHeight: itemSize
 							}}
 							onScrollStop={handleScroll}

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -116,10 +116,10 @@ const TransferListBase = kind({
 		itemSize: PropTypes.number,
 
 		/**
-		 * The type of component used to render the list of items
+		 * The type of component used to render the list of items.
 		 *
 		 * @type {Component}
-		 * @default sandstone/Icon.Icon
+		 * @default 'VirtualList'
 		 * @public
 		 */
 		listComponent: PropTypes.oneOf(['VirtualList', 'VirtualGridList']),
@@ -755,7 +755,6 @@ const TransferListBase = kind({
 							itemSize={itemSize}
 							onScrollStop={handleScroll}
 							style={{height: height}}
-							verticalScrollbar="hidden"
 						/> :
 						<VirtualGridList
 							cbScrollTo={getScrollToFirst}
@@ -768,7 +767,6 @@ const TransferListBase = kind({
 							}}
 							onScrollStop={handleScroll}
 							style={{height: height}}
-							verticalScrollbar="hidden"
 						/> }
 				</Cell>
 				<Cell className={componentCss.listButtons}>
@@ -798,7 +796,6 @@ const TransferListBase = kind({
 							itemRenderer={renderItem(secondListSpecs)}
 							itemSize={itemSize}
 							onScrollStop={handleScroll}
-							verticalScrollbar="hidden"
 						/> :
 						<VirtualGridList
 							cbScrollTo={getScrollToSecond}
@@ -810,7 +807,6 @@ const TransferListBase = kind({
 								minHeight: itemSize
 							}}
 							onScrollStop={handleScroll}
-							verticalScrollbar="hidden"
 						/> }
 				</Cell>
 			</Layout>

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -259,13 +259,13 @@ const TransferListBase = kind({
 			const selected = selectedIndex !== 0;
 
 			const source = {
-				hd: svgGenerator(200, 200,  `${element}`),
-				fhd: svgGenerator(300, 300, `${element}`),
-				uhd: svgGenerator(600, 600, `${element}`)
+				hd: svgGenerator(200, 200, ''),
+				fhd: svgGenerator(300, 300, ''),
+				uhd: svgGenerator(600, 600, '')
 			};
 
 			const selectionComponent = () => {
-				return <>{selected && <Icon className={imageItemCss.selectionIcon}>check</Icon>}{(selected && showSelectionOrder) && selectedIndex}</>;
+				return <div className={componentCss.selectionContainer}>{selected && <Icon className={imageItemCss.selectionIcon}>check</Icon>}{(selected && showSelectionOrder) && selectedIndex}</div>;
 			};
 
 			const handleClick = () => {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -236,10 +236,10 @@ const TransferListBase = kind({
 			return (
 				<CheckboxItem
 					{...rest}
+					className={componentCss.draggableItem}
 					data-index={dataIndex}
 					draggable={!disabled}
 					disabled={disabled}
-					className={componentCss.draggableItem}
 					id={`${index}-${list}`}
 					key={index + list}
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
@@ -287,10 +287,10 @@ const TransferListBase = kind({
 			return (
 				<ImageItem
 					{...rest}
-					data-index={dataIndex}
-					draggable={!disabled}
-					disabled={disabled}
 					className={componentCss.draggableItem}
+					data-index={dataIndex}
+					disabled={disabled}
+					draggable={!disabled}
 					id={`${index}-${list}`}
 					key={index + list}
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
@@ -756,7 +756,7 @@ const TransferListBase = kind({
 							onScrollStop={handleScroll}
 							style={{height: height}}
 							verticalScrollbar="hidden"
-						/>	:
+						/> :
 						<VirtualGridList
 							cbScrollTo={getScrollToFirst}
 							dataSize={firstListLocal.length}

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -19,11 +19,13 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 
 import Button from '../Button';
 import CheckboxItem from '../CheckboxItem';
+import Icon from '../Icon';
 import ImageItem from '../ImageItem';
 import Skinnable from '../Skinnable';
 import VirtualList, {VirtualGridList} from '../VirtualList';
 
 import componentCss from './TransferList.module.less';
+import imageItemCss from '../ImageItem/ImageItem.module.less';
 import itemCss from '../Item/Item.module.less';
 
 let multipleItemDragContainer, singleItemDragContainer;
@@ -262,6 +264,10 @@ const TransferListBase = kind({
 				uhd: svgGenerator(600, 600, `${element}`)
 			};
 
+			const selectionComponent = () => {
+				return <>{selected && <Icon className={imageItemCss.selectionIcon}>check</Icon>}{(selected && showSelectionOrder) && selectedIndex}</>;
+			};
+
 			const handleClick = () => {
 				onSelect(element, index, list);
 			};
@@ -292,8 +298,8 @@ const TransferListBase = kind({
 					onSpotlightUp={handleSpotlightUp}	// eslint-disable-line  react/jsx-no-bind
 					orientation="horizontal"
 					selected={selected}
+					selectionComponent={selectionComponent} // eslint-disable-line  react/jsx-no-bind
 					showSelection
-					// slotAfter={(selected && showSelectionOrder) && selectedIndex}
 					src={source}
 				>
 					{element}
@@ -463,7 +469,7 @@ const TransferListBase = kind({
 					}
 				});
 			});
-		}, [css.draggableItem, css.overAbove, css.overBelow, listComponent, noMultipleDrag, selectedItems]);
+		}, [css.draggableItem, css.overAbove, css.overBelow, noMultipleDrag, selectedItems]);
 
 		useEffect(() => {
 			const updateElements = setTimeout(() => {
@@ -549,7 +555,7 @@ const TransferListBase = kind({
 			setSelectedItems(tempSelected);
 
 			setPosition({index: tempSecond.length - 1, list: 'second'});
-		}, [firstListLocal, firstListMinCapacity, listComponent, secondListLocal, selectedItems, setFirstList, setSecondList, secondListMaxCapacity]);
+		}, [firstListLocal, firstListMinCapacity, secondListLocal, selectedItems, setFirstList, setSecondList, secondListMaxCapacity]);
 
 		const moveIntoSecondAll = useCallback(() => {
 			if (setFirstList !== null && setSecondList !== null) {
@@ -608,7 +614,7 @@ const TransferListBase = kind({
 			dragOverElement.current = null;
 			setSourceList(sourceList);
 			setDestinationList(destinationList);
-		}, [listComponent, noMultipleDrag, selectedItems]);
+		}, [noMultipleDrag, selectedItems]);
 
 		const getTransferData = (dataTransferObj) => {
 			if (dataTransferObj) {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -716,7 +716,7 @@ const TransferListBase = kind({
 							horizontalScrollbar="hidden"
 							itemRenderer={renderImageItem(firstListSpecs)}
 							itemSize={{
-								minWidth: 5*itemSize,
+								minWidth: 5 * itemSize,
 								minHeight: itemSize
 							}}
 							onScrollStop={handleScroll}
@@ -757,7 +757,7 @@ const TransferListBase = kind({
 							horizontalScrollbar="hidden"
 							itemRenderer={renderImageItem(secondListSpecs)}
 							itemSize={{
-								minWidth: 5*itemSize,
+								minWidth: 5 * itemSize,
 								minHeight: itemSize
 							}}
 							onScrollStop={handleScroll}

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -463,7 +463,7 @@ const TransferListBase = kind({
 					}
 				});
 			});
-		}, [css.draggableItem, css.overAbove, css.overBelow, noMultipleDrag, selectedItems]);
+		}, [css.draggableItem, css.overAbove, css.overBelow, listComponent, noMultipleDrag, selectedItems]);
 
 		useEffect(() => {
 			const updateElements = setTimeout(() => {
@@ -482,7 +482,7 @@ const TransferListBase = kind({
 			return () => {
 				clearTimeout(updateElements);
 			};
-		}, [dragOverElement, firstListLocal, position, secondListLocal, selectedItems, startDragElement]); // eslint-disable-line react-hooks/exhaustive-deps
+		}, [dragOverElement, firstListLocal, listComponent, position, secondListLocal, selectedItems, startDragElement]); // eslint-disable-line react-hooks/exhaustive-deps
 
 		const moveIntoFirstSelected = useCallback(() => {
 			let tempFirst = [...firstListLocal],
@@ -549,7 +549,7 @@ const TransferListBase = kind({
 			setSelectedItems(tempSelected);
 
 			setPosition({index: tempSecond.length - 1, list: 'second'});
-		}, [firstListLocal, firstListMinCapacity, secondListLocal, selectedItems, setFirstList, setSecondList, secondListMaxCapacity]);
+		}, [firstListLocal, firstListMinCapacity, listComponent, secondListLocal, selectedItems, setFirstList, setSecondList, secondListMaxCapacity]);
 
 		const moveIntoSecondAll = useCallback(() => {
 			if (setFirstList !== null && setSecondList !== null) {
@@ -608,7 +608,7 @@ const TransferListBase = kind({
 			dragOverElement.current = null;
 			setSourceList(sourceList);
 			setDestinationList(destinationList);
-		}, [noMultipleDrag, selectedItems]);
+		}, [listComponent, noMultipleDrag, selectedItems]);
 
 		const getTransferData = (dataTransferObj) => {
 			if (dataTransferObj) {
@@ -750,7 +750,7 @@ const TransferListBase = kind({
 							onScrollStop={handleScroll}
 							style={{height: height}}
 							verticalScrollbar="hidden"
-						/>					:
+						/>	:
 						<VirtualGridList
 							cbScrollTo={getScrollToFirst}
 							dataSize={firstListLocal.length}

--- a/TransferList/TransferList.module.less
+++ b/TransferList/TransferList.module.less
@@ -42,4 +42,11 @@
         transform: translate(0, 50px);
         color: #666565;
     }
+
+    .selectionContainer {
+        align-items: center;
+        display: flex;
+        justify-content: space-around;
+        width: 100%;
+    }
 }

--- a/samples/sampler/stories/default/TransferList.js
+++ b/samples/sampler/stories/default/TransferList.js
@@ -1,5 +1,5 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
-import {boolean, number} from '@enact/storybook-utils/addons/controls';
+import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
 
 import TransferList, {TransferListBase, TransferListDecorator} from '@enact/sandstone/TransferList';
 
@@ -19,6 +19,7 @@ export const _TransferList = (args) => (
 		firstListMaxCapacity={args['firstListMaximumCapacity']}
 		firstListMinCapacity={args['firstListMinCapacity']}
 		itemSize={args['itemSize']}
+		listComponent={args['listComponent']}
 		moveOnSpotlight={args['moveElementOnSpotlightDirections']}
 		noMultipleDrag={args['noMultipleDrag']}
 		secondList={['HBO', 'Comedy Central', 'HGTV', 'CBS', 'Cartoon Network', 'AXN', 'Disney Channel', 'BBC Food']}
@@ -32,8 +33,9 @@ boolean('disabled', _TransferList, Config, false);
 number('firstListMinCapacity', _TransferList, Config);
 number('firstListMaxCapacity', _TransferList, Config);
 number('itemSize', _TransferList, Config, 201);
-boolean('noMultipleDrag', _TransferList, Config, false);
+select('listComponent', _TransferList, ['VirtualList', 'VirtualGridList'], Config, 'VirtualList');
 boolean('moveElementOnSpotlightDirections', _TransferList, Config, false);
+boolean('noMultipleDrag', _TransferList, Config, false);
 number('secondListMinCapacity', _TransferList, Config);
 number('secondListMaxCapacity', _TransferList, Config);
 boolean('showSelectionOrder', _TransferList, Config, false);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
TransferList only supported VirtualList as component for source or destination list

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added support for VirtualGridList. Now there is a prop that can choose which component to use to render the lists

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
For the moment, the width of each ImageItem in the list is hardcoded as 5*height

### Links
[//]: # (Related issues, references)
WRP-4952

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)