### PR TITLE
WRP-5352: Tuning a horizontal scrolling speed by hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/ActionGuide` to replace `Icon` with `Button`
 - `sandstone/VideoPlayer` to not expand video player using key down via 5way
+- `sandstone/Scroller` and `sandstone/VirtualList` scroll speed and hover area when `hoverToScroll` is `true` to match GUI
 
 ### Fixed
 

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -861,7 +861,7 @@
 @sand-scroll-fade-out-offset: 24px;
 @sand-scroll-vertical-fade-out-padding: @sand-scroll-fade-out-size 0;
 @sand-scroll-horizontal-fade-out-padding: 0 @sand-scroll-fade-out-size;
-@sand-scroll-hover-area-size: 288px;
+@sand-scroll-hover-area-size: 120px;
 @sand-scroll-focusablebody-padding: 72px 48px 72px 90px;
 @sand-scroll-focusablebody-padding-rtl: 72px 90px 72px 48px;
 @sand-scroll-focusablebody-focus-border-radius: 12px;

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -28,7 +28,10 @@ const getBoundsPropertyNames = (direction) => {
 		scrollPosition: 'scrollLeft'
 	};
 };
-const hoverToScrollMultiplier = 0.04;
+const hoverToScrollMultiplier = {
+	horizontal: 0.015,
+	vertical: 0.04
+};
 const directionToFocus = {
 	horizontal: {
 		before: 'right',
@@ -115,7 +118,7 @@ const HoverToScrollBase = (props) => {
 					const distance =
 						(position === 'before' ? -1 : 1) * // scroll direction
 						bounds[clientSize] * // scroll page size
-						hoverToScrollMultiplier; // a scrolling speed factor
+						hoverToScrollMultiplier[direction]; // a scrolling speed factor
 
 					mutableRef.current.hoveredPosition = position;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For better customer experience, we're going to tune hovering area and scroll speed by hovering in lists and scrollers.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Reduced hovering area and reduced scroll speed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-5352

### Comments
