### PR TITLE
WRP-5920: Fixed hoverToScroll not to invoke stopRaf when scrollContainer is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/MediaPlayer.MediaControls` to disable buttons when hidden
-- `sandstone/Scroller` to not stop unexpectedly when `hoverToScroll` is `true`
+- `sandstone/Scroller` to not stop scrolling by hover unexpectedly when `hoverToScroll` is `true`
 
 ## [2.5.6] - 2022-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/MediaPlayer.MediaControls` to disable buttons when hidden
+- `sandstone/Scroller` to not stop unexpectedly when `hoverToScroll` is `true`
 
 ## [2.5.6] - 2022-12-13
 

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -185,12 +185,6 @@ const HoverToScrollBase = (props) => {
 		}
 	}, [update, direction, scrollContainer, props]);
 
-	useLayoutEffect(() => {
-		return () => {
-			stopRaf(); // for hoverToScroll prop change during hovering
-		};
-	}, [stopRaf]);
-
 	// Render
 
 	const renderHoverArea = useCallback((position) => {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The issue was reported that when the pointer is in the hover area it scrolls for a while and then stopped in some cases.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We found that scrolls stopped because of stopRaf function in hoverToScroll.js invoked unintentionally. 
stopRaf function is invoked when scrollContainer is updated.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We removed the code that the stopRaf function is called because of scrollerContainer update.
We found in hoverToScroll.js line 159 covers the edge case which needs to call the stopRaf function. 
So we decided to remove codes that call stopRaf function in a wide range of cases.
Later, we need to investigate whether scrollContainer is updated in unnecessary cases.

### Links
[//]: # (Related issues, references)
WRP-5920

### Comments
