### PR TITLE
WRP-7056: Fix `MediaControls` to show round buttons correctly in high-contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Input` to read out properly after closing it in a `sandstone/PopupTabLayout`
 - `sandstone/MediaPlayer.MediaControls` to disable buttons when hidden
+- `sandstone/MediaPlayer.MediaControls` to show round buttons correctly in high-contrast mode
 
 ## [2.6.0] - 2022-12-05
 

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -19,6 +19,7 @@ import ActionGuide from '../ActionGuide';
 import Button from '../Button';
 import $L from '../internal/$L';
 import {compareChildren, onlyUpdateForProps} from '../internal/util';
+import Skinnable from '../Skinnable';
 
 import {countReactChildren} from './util';
 
@@ -893,6 +894,7 @@ const handleCancel = (ev, {onClose}) => {
  * @class MediaControls
  * @memberof sandstone/MediaPlayer
  * @mixes ui/Cancelable.Cancelable
+ * @mixes sandstone/Skinnable.Skinnable
  * @ui
  * @public
  */
@@ -904,7 +906,9 @@ const MediaControls = ApiDecorator(
 	]},
 	MediaControlsDecorator(
 		Cancelable({modal: true, onCancel: handleCancel},
-			MediaControlsBase
+			Skinnable(
+				MediaControlsBase
+			)
 		)
 	)
 );

--- a/MediaPlayer/MediaControls.module.less
+++ b/MediaPlayer/MediaControls.module.less
@@ -67,9 +67,14 @@
 		.client {
 			padding: @sand-mediaplayer-button-client-padding;
 		}
-
-		.bg {
-			border-radius: @sand-mediaplayer-button-border-radius;
-		}
 	}
+
+	// Skin colors
+	.applySkins({
+		.button {
+			.bg {
+				border-radius: @sand-mediaplayer-button-border-radius;
+			}
+		}
+	});
 }


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`MediaControls`' buttons should have a round shape but a rounded-square shape when `highContrast` skin variant is applied.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Made `MediaControls` skinnable.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-7056

### Comments
