### PR TITLE
WRP-6275: Incorrect drag image when showSelection={true}

### DIFF
--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -397,25 +397,8 @@ const TransferListBase = kind({
 
 			selectCheckboxItem.forEach(element => {
 				const [index, list] = element.id.split('-');
-				let potentialIndex;
 				element.setAttribute('order', orderCounter + 1);
 				orderCounter++;
-
-				if (listComponent === 'VirtualGridList' && showSelectionOrder) {
-					potentialIndex = selectedItems.findIndex((pair) => {
-						const textContent = element.textContent.substring(2);
-
-						return pair.element === textContent && pair.list === list;
-					});
-				} else if (listComponent === 'VirtualList' && showSelectionOrder) {
-					selectedItems.findIndex((pair) => {
-						const textContent = element.textContent.slice(0, -1);
-
-						return '✓' + pair.element === textContent && pair.list === list;
-					});
-				} else {
-					selectedItems.findIndex((pair) => '✓' + pair.element === element.textContent && pair.list === list);
-				}
 
 				const eventListeners = ['dragstart', 'dragover', 'dragenter', 'dragleave', 'drop'];
 				eventListeners.forEach(event => {
@@ -425,7 +408,7 @@ const TransferListBase = kind({
 							ev.dataTransfer.setData('text/plain', `${index}-${list}`);
 							ev.dataTransfer.effectAllowed = 'move';
 
-							if (!noMultipleDrag && potentialIndex === -1 ? selectedItems.length + 1 > 1 : selectedItems.length > 1) {
+							if (selectedItems.length > 1) {
 								ev.dataTransfer.setDragImage(multipleItemDragContainer, 0, 0);
 							} else {
 								ev.dataTransfer.setDragImage(singleItemDragContainer, 0, 0);

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -397,18 +397,25 @@ const TransferListBase = kind({
 
 			selectCheckboxItem.forEach(element => {
 				const [index, list] = element.id.split('-');
+				let potentialIndex;
 				element.setAttribute('order', orderCounter + 1);
 				orderCounter++;
 
-				const potentialIndex = () => {
-					if (listComponent === 'VirtualGridList' && showSelectionOrder) {
-						selectedItems.findIndex((pair) => '✓' + index + pair.element === element.textContent && pair.list === list);
-					} else if (listComponent === 'VirtualList' && showSelectionOrder) {
-						selectedItems.findIndex((pair) => '✓' + pair.element + index === element.textContent && pair.list === list);
-					} else {
-						selectedItems.findIndex((pair) => '✓' + pair.element === element.textContent && pair.list === list);
-					}
-				};
+				if (listComponent === 'VirtualGridList' && showSelectionOrder) {
+					potentialIndex = selectedItems.findIndex((pair) => {
+						const textContent = element.textContent.substring(2);
+
+						return pair.element === textContent && pair.list === list;
+					});
+				} else if (listComponent === 'VirtualList' && showSelectionOrder) {
+					selectedItems.findIndex((pair) => {
+						const textContent = element.textContent.slice(0, -1);
+
+						return '✓' + pair.element === textContent && pair.list === list;
+					});
+				} else {
+					selectedItems.findIndex((pair) => '✓' + pair.element === element.textContent && pair.list === list);
+				}
 
 				const eventListeners = ['dragstart', 'dragover', 'dragenter', 'dragleave', 'drop'];
 				eventListeners.forEach(event => {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -467,7 +467,7 @@ const TransferListBase = kind({
 					}
 				});
 			});
-		}, [css.draggableItem, css.overAbove, css.overBelow, listComponent, noMultipleDrag, selectedItems, showSelectionOrder]);
+		}, [css.draggableItem, css.overAbove, css.overBelow, selectedItems]);
 
 		useEffect(() => {
 			const updateElements = setTimeout(() => {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -400,7 +400,15 @@ const TransferListBase = kind({
 				element.setAttribute('order', orderCounter + 1);
 				orderCounter++;
 
-				const potentialIndex = selectedItems.findIndex((pair) => '✓' + pair.element === element.textContent && pair.list === list);
+				const potentialIndex = () => {
+					if (listComponent === 'VirtualGridList' && showSelectionOrder) {
+						selectedItems.findIndex((pair) => '✓' + index + pair.element === element.textContent && pair.list === list);
+					} else if (listComponent === 'VirtualList' && showSelectionOrder) {
+						selectedItems.findIndex((pair) => '✓' + pair.element + index === element.textContent && pair.list === list);
+					} else {
+						selectedItems.findIndex((pair) => '✓' + pair.element === element.textContent && pair.list === list);
+					}
+				};
 
 				const eventListeners = ['dragstart', 'dragover', 'dragenter', 'dragleave', 'drop'];
 				eventListeners.forEach(event => {
@@ -469,7 +477,7 @@ const TransferListBase = kind({
 					}
 				});
 			});
-		}, [css.draggableItem, css.overAbove, css.overBelow, noMultipleDrag, selectedItems]);
+		}, [css.draggableItem, css.overAbove, css.overBelow, listComponent, noMultipleDrag, selectedItems, showSelectionOrder]);
 
 		useEffect(() => {
 			const updateElements = setTimeout(() => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When 'showSelectionOrder' is set to 'true' the wrong drag image is being displayed

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed drag image for 'showSelectionOrder' by adding an if else statement to 'potentialIndex' that checks for 'showSelectionOrder'.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6275

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com