### PR TITLE
WRP-6648:DayPicker: fix TypeError when passing prop 'selected' as a number type

### DIFF
--- a/DayPicker/DaySelectorDecorator.js
+++ b/DayPicker/DaySelectorDecorator.js
@@ -35,10 +35,15 @@ function generalizeSelected (selected, state) {
 	return selected.map(v => generalizeDay(v, state.firstDayOfWeek)).sort();
 }
 
-// Accepts a localized selected array and returns a "Sunday at index 0" array
+// Accepts a "Sunday at index 0" selected array or number and returns a
+// localized array or number.
 function localizeSelected (selected, state) {
-	if (state.firstDayOfWeek === 0 || !selected) {
+	if (selected === undefined || selected === null) {
 		return selected;
+	}
+
+	if (typeof selected === 'number') {
+		return localizeDay(selected, state.firstDayOfWeek);
 	}
 
 	return selected.map(v => localizeDay(v, state.firstDayOfWeek));

--- a/DayPicker/tests/DayPicker-specs.js
+++ b/DayPicker/tests/DayPicker-specs.js
@@ -25,6 +25,15 @@ describe('DayPicker', () => {
 		expect(selectedDay).toHaveClass(expected);
 	});
 
+	test('should select day when passed prop \'selected\' as a number', () => {
+		render(<DayPicker selected={0} />);
+		const selectedDay = screen.getAllByRole('checkbox')[1];
+
+		const expected = 'selected';
+
+		expect(selectedDay).toHaveClass(expected);
+	});
+
 	test('should emit an onSelect event with \'onSelect\' type when selecting days', () => {
 		const handleSelect = jest.fn();
 		render(<DayPicker onSelect={handleSelect} />);

--- a/tests/screenshot/apps/components/DayPicker.js
+++ b/tests/screenshot/apps/components/DayPicker.js
@@ -26,6 +26,25 @@ const DayPickerTests = [
 		component: <DayPicker disabled selected={1} />
 	},
 
+	// *************************************************************
+	// locale = 'es-ES', [QWTC-637]
+	{
+		locale: 'es-ES',
+		component: <DayPicker />
+	},
+	{
+		locale: 'es-ES',
+		component: <DayPicker selected={1} />
+	},
+	{
+		locale: 'es-ES',
+		component: <DayPicker disabled />
+	},
+	{
+		locale: 'es-ES',
+		component: <DayPicker disabled selected={1} />
+	},
+
 	...withConfig({focus: true}, [
 		<DayPicker selected={2} />,
 		<DayPicker disabled selected={2} />


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
DayPicker accepts a number or an array of numbers in "selected" prop.
But TypeError exception occurs in localizedSelected() function when passing a number (not 0).

localizedSelected() function also accepts a number or an array of numbers as a "selected" argument.
The problem is this.
 1. the function doesn't differentiate between number 0 and undefined/null.
 2. treats unconditionally the "selected" argument as an array.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The fix is this.
 1. differentiate between 0 and undefined/null
 2. check type of "selected" argument and if it's a number, then returns a localized number.
 3. leave the selected.map() for arrays as a fallback.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Unit/Screenshot test has been added.

### Links
[//]: # (Related issues, references)
WRP-6648
QWTC-637

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
