### PR TITLE
WRP-6259:qa-sampler:Touchable: change min/maxZoom to min/maxScale

### DIFF
--- a/samples/sampler/stories/qa/Touchable.js
+++ b/samples/sampler/stories/qa/Touchable.js
@@ -223,8 +223,8 @@ export const WithPinchHandlers = (args) => {
 		<TouchableDiv
 			pinchConfig={{
 				global: args['pinchConfig global'] || false,
-				maxZoom: args['pinchConfig maxZoom'],
-				minZoom: args['pinchConfig minZoom'],
+				maxScale: args['pinchConfig maxScale'],
+				minScale: args['pinchConfig minScale'],
 				moveTolerance: args['pinchConfig moveTolerance']
 			}}
 			onPinchStart={action('onPinchStart')}
@@ -244,8 +244,8 @@ export const WithPinchHandlers = (args) => {
 };
 
 boolean('pinchConfig global', WithPinchHandlers, TouchableDiv, false);
-number('pinchConfig maxZoom', WithPinchHandlers, TouchableDiv, 4);
-number('pinchConfig minZoom', WithPinchHandlers, TouchableDiv, 0.5);
+number('pinchConfig maxScale', WithPinchHandlers, TouchableDiv, 4);
+number('pinchConfig minScale', WithPinchHandlers, TouchableDiv, 0.5);
 number('pinchConfig moveTolerance', WithPinchHandlers, TouchableDiv, 16);
 
 WithPinchHandlers.storyName = 'with onPinch handlers';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
PR enactjs/enact#3114 on enact repo "WRP-6259:ui:Touchable: add scale payload to pinch event doc" changes the names of pinchConfig.min/maxZoom to min/maxScale. So this fix is the follow-up.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
change the use of min/maxZoom to min/maxScale

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6259
enactjs/enact#3114

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>