### PR TITLE
WRP-8540: Fix typo of `onComplete` event payload of DatePicker and TimePicker

### DIFF
--- a/DatePicker/tests/DatePicker-specs.js
+++ b/DatePicker/tests/DatePicker-specs.js
@@ -16,7 +16,7 @@ describe('DatePicker', () => {
 		userEvent.click(dayPickerUp);
 
 		const expected = 1;
-		const expectedType = {type: 'onChange'};
+		const expectedType = {type: 'onChange', value: new Date(2000, 6, 16)};
 		const actual = handleChange.mock.calls.length && handleChange.mock.calls[0][0];
 
 		expect(handleChange).toBeCalledTimes(expected);
@@ -31,7 +31,7 @@ describe('DatePicker', () => {
 		userEvent.click(monthPickerUp);
 
 		const expected = 1;
-		const expectedType = {type: 'onChange'};
+		const expectedType = {type: 'onChange', value: new Date(2000, 7, 15)};
 		const actual = handleChange.mock.calls.length && handleChange.mock.calls[0][0];
 
 		expect(handleChange).toBeCalledTimes(expected);
@@ -46,7 +46,7 @@ describe('DatePicker', () => {
 		userEvent.click(yearPickerUp);
 
 		const expected = 1;
-		const expectedType = {type: 'onChange'};
+		const expectedType = {type: 'onChange', value: new Date(2001, 6, 15)};
 		const actual = handleChange.mock.calls.length && handleChange.mock.calls[0][0];
 
 		expect(handleChange).toBeCalledTimes(expected);
@@ -61,7 +61,7 @@ describe('DatePicker', () => {
 		act(() => year.focus());
 		fireEvent.keyDown(year, {which: 13, keyCode: 13, code: 13});
 
-		const expected = {type: 'onComplete'};
+		const expected = {type: 'onComplete', value: new Date(2000, 6, 15)};
 		const actual = handleComplete.mock.calls.length && handleComplete.mock.calls[0][0];
 
 		expect(actual).toMatchObject(expected);

--- a/TimePicker/tests/TimePicker-specs.js
+++ b/TimePicker/tests/TimePicker-specs.js
@@ -21,7 +21,7 @@ describe('TimePicker', () => {
 		userEvent.click(hourPicker);
 
 		const expected = 1;
-		const expectedType = {type: 'onChange'};
+		const expectedType = {type: 'onChange', value: new Date(2000, 6, 15, 4, 30)};
 		const actual = handleChange.mock.calls.length && handleChange.mock.calls[0][0];
 
 		expect(handleChange).toBeCalledTimes(expected);
@@ -38,7 +38,7 @@ describe('TimePicker', () => {
 		userEvent.click(minutePicker);
 
 		const expected = 1;
-		const expectedType = {type: 'onChange'};
+		const expectedType = {type: 'onChange', value: new Date(2000, 6, 15, 3, 31)};
 		const actual = handleChange.mock.calls.length && handleChange.mock.calls[0][0];
 
 		expect(handleChange).toBeCalledTimes(expected);
@@ -55,7 +55,7 @@ describe('TimePicker', () => {
 		userEvent.click(meridiemPicker);
 
 		const expected = 1;
-		const expectedType = {type: 'onChange'};
+		const expectedType = {type: 'onChange', value: new Date(2000, 6, 15, 15, 30)};
 		const actual = handleChange.mock.calls.length && handleChange.mock.calls[0][0];
 
 		expect(handleChange).toBeCalledTimes(expected);
@@ -70,7 +70,7 @@ describe('TimePicker', () => {
 		act(() => meridiemPicker.focus());
 		fireEvent.keyDown(meridiemPicker, {which: 13, keyCode: 13, code: 13});
 
-		const expected = {type: 'onComplete'};
+		const expected = {type: 'onComplete', value: new Date(2000, 6, 15, 3, 30)};
 		const actual = handleComplete.mock.calls.length && handleComplete.mock.calls[0][0];
 
 		expect(actual).toMatchObject(expected);

--- a/internal/DateTime/DateTimeDecorator.js
+++ b/internal/DateTime/DateTimeDecorator.js
@@ -218,7 +218,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 			if (ev.target && ev.target.dataset.lastElement === 'true') {
 				const value = this.state.value ? this.toIDate(this.state.value) : null;
 
-				forward('onComplete', {type: 'onComplete', alue: value ? value.getJSDate() : null}, this.props);
+				forward('onComplete', {type: 'onComplete', value: value ? value.getJSDate() : null}, this.props);
 			} else {
 				Spotlight.move(this.props.rtl ? 'left' : 'right');
 			}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
DatePicker and TimePicker's `onComplete` event payload does not have 'value' property due to a typo.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix typo of `onComplete` event payload.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-8540

### Comments
