### PR TITLE
WRP-6648:DayPicker: restore locale to previous locale in unit test

### DIFF
--- a/DayPicker/tests/DayPicker-specs.js
+++ b/DayPicker/tests/DayPicker-specs.js
@@ -111,6 +111,8 @@ describe('DayPicker', () => {
 
 	describe('with alternate first day of week', () => {
 		test('should accept and emit a generalized selected array', () => {
+			const prevLocale = ilib.getLocale();
+
 			ilib.setLocale('es-ES');
 
 			const handleSelect = jest.fn();
@@ -127,6 +129,8 @@ describe('DayPicker', () => {
 			const actual = handleSelect.mock.calls[0][0];
 
 			expect(actual).toMatchObject(expected);
+
+			ilib.setLocale(prevLocale);
 		});
 	});
 });

--- a/DayPicker/tests/DayPicker-specs.js
+++ b/DayPicker/tests/DayPicker-specs.js
@@ -30,6 +30,8 @@ describe('DayPicker', () => {
 		// If firstDayOfWeek === 0, the number type check conditional statement
 		// is skipped due to the fast execution path of localizeSelected(), which
 		// reduces code coverage..
+		const prevLocale = ilib.getLocale();
+
 		ilib.setLocale('es-ES');
 
 		render(<DayPicker locale="es-ES" selected={1} />);
@@ -38,6 +40,8 @@ describe('DayPicker', () => {
 		const expected = 'selected';
 
 		expect(selectedDay).toHaveClass(expected);
+
+		ilib.setLocale(prevLocale);
 	});
 
 	test('should emit an onSelect event with \'onSelect\' type when selecting days', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unit Test failed in enact-cli-test of jenkins. The unit test failed right after the selected prop unit test that receives the number type as a parameter. Looking at the failure log, the unit test was run on es-ES, not en-US. In the selected prop unit test that receives the number type as an argument, it is not restored after changing locale to es-ES.

Here is a snippet of jenkins console failure output:

    FAIL DayPicker/tests/DayPicker-specs.js

    DayPicker › should emit an onSelect event with 'onSelect' type when selecting days

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    - Expected
    + Received

      Object {
    -   "content": "Mon",
    +   "content": "lun",
        "selected": Array [
          1,
        ],
        "type": "onSelect",
      },

    Number of calls: 1

      48 | 		userEvent.click(item);
      49 |
    > 50 | 		expect(handleSelect).toHaveBeenCalledWith({content: 'Mon', selected: [1], type: 'onSelect'});
         | 		                     ^
      51 | 	});
      52 |
      53 | 	test('should include \'content\' in onSelect event payload which respects dayNameLength', () => {

      at Object.<anonymous> (DayPicker/tests/DayPicker-specs.js:50:24)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

In the unit test for the es-ES locale, add the missing code to restore the original locale before starting the next unit test.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6648
#1389

### Comments

Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
