### PR TITLE
WRP-8078:Button: Add roundBorder prop making both sides of button fully round

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -167,6 +167,15 @@ const ButtonBase = kind({
 		minWidth: PropTypes.bool,
 
 		/**
+		 * True if both sides of button are fully rounded.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		roundBorder: PropTypes.bool,
+
+		/**
 		 * The size of the button.
 		 *
 		 * @type {('large'|'small')}
@@ -184,6 +193,7 @@ const ButtonBase = kind({
 		iconComponent: Icon,
 		iconOnly: false,
 		iconPosition: 'before',
+		roundBorder: false,
 		size: 'large'
 	},
 
@@ -193,12 +203,13 @@ const ButtonBase = kind({
 	},
 
 	computed: {
-		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, size, styler}) => styler.append(
+		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, roundBorder, size, styler}) => styler.append(
 			{
 				hasColor: color,
 				iconOnly,
 				collapsable,
-				collapsed
+				collapsed,
+				roundBorder
 			},
 			backgroundOpacity || (iconOnly ? 'transparent' : 'opaque'), // Defaults to opaque, unless otherwise specified
 			color,
@@ -218,6 +229,7 @@ const ButtonBase = kind({
 		delete rest.iconOnly;
 		delete rest.iconPosition;
 		delete rest.focusEffect;
+		delete rest.roundBorder;
 
 		return UiButtonBase.inline({
 			'data-webos-voice-intent': 'Select',

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -330,6 +330,18 @@
 			}
 		}
 
+		&.roundBorder {
+			.bg {
+				// https://w3c.github.io/csswg-drafts/css-backgrounds/#corner-overlap
+				//
+				// Corner curves must not overlap: When the sum of any two
+				// adjacent border radii exceeds the size of the border box,
+				// UAs must proportionally reduce the used values of all border
+				// radii until none of them overlap.
+				border-radius: 9999px;
+			}
+		}
+
 		&.selected {
 			color: @sand-button-selected-text-color;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+- `sandstone/Button` prop `roundBorder`, to make both sides of button fully rounded.
+
 ### Fixed
 - `sandstone/DayPicker` to handle number typed `selected` prop properly in es-ES locale
 

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -58,6 +58,7 @@ export const _Button = (args) => (
 			iconFlip={args['iconFlip']}
 			iconPosition={args['iconPosition']}
 			minWidth={threeWayBoolean(args['minWidth'])}
+			roundBorder={args['roundBorder']}
 			selected={args['selected']}
 			size={args['size']}
 			tooltipText={args['tooltipText']}
@@ -75,6 +76,7 @@ select('icon', _Button, prop.icons, Config);
 select('iconFlip', _Button, prop.iconFlip, Config);
 select('iconPosition', _Button, prop.iconPosition, Config);
 select('minWidth', _Button, prop.minWidth, Config);
+boolean('roundBorder', _Button, Config);
 boolean('selected', _Button, Config);
 select('size', _Button, prop.size, Config);
 text('tooltipText', _Button, Config);

--- a/samples/sampler/stories/qa/Button.js
+++ b/samples/sampler/stories/qa/Button.js
@@ -209,6 +209,9 @@ export const KitchenSink = () => (
 				<Button size="small" alt="With Icon" icon="home">
 					Button
 				</Button>
+				<Button roundBorder size="small" alt="Round Border">
+					Button
+				</Button>
 			</Section>
 
 			<Section title="Large Buttons" size="50%">
@@ -227,18 +230,23 @@ export const KitchenSink = () => (
 				<Button size="large" alt="With Icon" icon="home">
 					Button
 				</Button>
+				<Button roundBorder size="large" alt="Round Border">
+					Button
+				</Button>
 			</Section>
 
 			<Section title="Small Icon Button" size="50%">
 				<Button size="small" icon="play" alt="Normal" />
 				<Button size="small" icon="play" alt="Selected" selected />
 				<Button size="small" icon="play" alt="Disabled" disabled />
+				<Button roundBorder size="small" icon="play" alt="Round Border" disabled />
 			</Section>
 
 			<Section title="Large Icon Button" size="50%">
 				<Button size="large" icon="play" alt="Normal" />
 				<Button size="large" icon="play" alt="Selected" selected />
 				<Button size="large" icon="play" alt="Disabled" disabled />
+				<Button roundBorder size="large" icon="play" alt="Round Border" disabled />
 			</Section>
 
 			<Section title="Small Transparent Buttons" size="50%">
@@ -255,6 +263,9 @@ export const KitchenSink = () => (
 					Super-duper long text string inside a button
 				</Button>
 				<Button backgroundOpacity="transparent" size="small" alt="With Icon" icon="home">
+					Button
+				</Button>
+				<Button backgroundOpacity="transparent" roundBorder size="small" alt="Round Border">
 					Button
 				</Button>
 			</Section>
@@ -275,13 +286,22 @@ export const KitchenSink = () => (
 				<Button backgroundOpacity="transparent" size="large" alt="With Icon" icon="home">
 					Button
 				</Button>
+				<Button backgroundOpacity="transparent" roundBorder size="large" alt="Round Border">
+					Button
+				</Button>
 			</Section>
 
 			<Section title="Static Focus Effect Text" size="50%">
 				<Button focusEffect="static" size="small" alt="Small">
 					Button
 				</Button>
+				<Button focusEffect="static" roundBorder size="small" alt=" Small Round Border">
+					Button
+				</Button>
 				<Button focusEffect="static" size="large" alt="Large">
+					Button
+				</Button>
+				<Button focusEffect="static" roundBorder size="large" alt="Large Round Border">
 					Button
 				</Button>
 				<Button
@@ -295,8 +315,26 @@ export const KitchenSink = () => (
 				<Button
 					focusEffect="static"
 					backgroundOpacity="transparent"
+					roundBorder
+					size="small"
+					alt="Small Transparent Round Border"
+				>
+					Button
+				</Button>
+				<Button
+					focusEffect="static"
+					backgroundOpacity="transparent"
 					size="large"
 					alt="Large Transparent"
+				>
+					Button
+				</Button>
+				<Button
+					focusEffect="static"
+					backgroundOpacity="transparent"
+					roundBorder
+					size="large"
+					alt="Large Transparent Round Border"
 				>
 					Button
 				</Button>
@@ -304,7 +342,10 @@ export const KitchenSink = () => (
 
 			<Section title="Static Focus Effect Icon" size="50%">
 				<Button focusEffect="static" size="small" icon="play" alt="Small" />
+				<Button focusEffect="static" roundBorder size="small" icon="play" alt="Small Round Border" />
 				<Button focusEffect="static" size="large" icon="play" alt="Large" />
+				<Button focusEffect="static" roundBorder size="large" icon="play" alt="Large Round Border" />
+
 			</Section>
 		</Row>
 	</Scroller>

--- a/tests/screenshot/apps/components/Button.js
+++ b/tests/screenshot/apps/components/Button.js
@@ -93,6 +93,21 @@ const ButtonTests = [
 	// [QWTC-1831]
 	<Button icon="rotate">click me</Button>,
 
+	// roundBorder
+	<Button >click me</Button>,
+	{
+		textSize: 'large',
+		component: <Button roundBorder>click me</Button>
+	},
+	<Button roundBorder size="small">click me</Button>,
+	<Button roundBorder size="large">click me</Button>,
+	<Button backgroundOpacity="transparent" roundBorder>click me</Button>,
+	<Button backgroundOpacity="opaque" roundBorder>click me</Button>,
+	<Button icon="minus" iconPosition="after" roundBorder />,
+	<Button icon="minus" iconPosition="after" roundBorder size="large" />,
+	<Button icon="plus" iconPosition="before" roundBorder />,
+	<Button icon="plus" iconPosition="before" roundBorder size="large" />,
+
 	// Focused with light wrapper
 	...withConfig({focus: true, wrapper: {light: true, padded: true}}, [
 		<Button>Focused button</Button>,
@@ -150,7 +165,22 @@ const ButtonTests = [
 		<Button icon="arrowhookright" iconFlip="auto">Focused button</Button>,
 
 		// [QWTC-1831]
-		<Button icon="rotate">Focused button</Button>
+		<Button icon="rotate">Focused button</Button>,
+
+		// roundBorder
+		<Button >Focused button</Button>,
+		{
+			textSize: 'large',
+			component: <Button roundBorder>Focused button</Button>
+		},
+		<Button roundBorder size="small">Focused button</Button>,
+		<Button roundBorder size="large">Focused button</Button>,
+		<Button backgroundOpacity="transparent" roundBorder>Focused button</Button>,
+		<Button backgroundOpacity="opaque" roundBorder>Focused button</Button>,
+		<Button icon="minus" iconPosition="after" roundBorder />,
+		<Button icon="minus" iconPosition="after" roundBorder size="large" />,
+		<Button icon="plus" iconPosition="before" roundBorder />,
+		<Button icon="plus" iconPosition="before" roundBorder size="large" />
 	]),
 
 	// *************************************************************


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As a result of a discussion with the GUI team, it was decided to provide a boolean prop to have both the left and right sides of the button completely round. Therefore, a `roundBorder` boolean prop is added to achieve that.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use `border-radius: 9999px`.
    
* https://w3c.github.io/csswg-drafts/css-backgrounds/#corner-overlap
    
Corner curves must not overlap: When the sum of any two adjacent border radii exceeds the size of the border box, UAs must proportionally reduce the used values of all border radii until none of them overlap.
    
You can also use `border-radius: calc($height / 2)` for the exact height, but that will require a .sand-custom-text mixin nested inside .applySkins mixin for the "large text" environment.

    .sand-custom-text({
        &.roundBorder {
            .bg {
                 border-radius: calc(@sand-button-height-large / 2);
            }
        }
    });
    
To avoid this, we use the property of CSS specification that corner curves do not overlap when the border-radius is set to a tremendous value.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-8078

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>