### PR TITLE
WRP-8078:Button: Add roundBorder prop making both sides of button fully round

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -170,7 +170,6 @@ const ButtonBase = kind({
 		 * True if both sides of button are fully rounded.
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 * @public
 		 */
 		roundBorder: PropTypes.bool,

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -167,6 +167,15 @@ const ButtonBase = kind({
 		minWidth: PropTypes.bool,
 
 		/**
+		 * True if both sides of button are fully rounded.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		roundBorder: PropTypes.bool,
+
+		/**
 		 * The size of the button.
 		 *
 		 * @type {('large'|'small')}
@@ -184,6 +193,7 @@ const ButtonBase = kind({
 		iconComponent: Icon,
 		iconOnly: false,
 		iconPosition: 'before',
+		roundBorder: false,
 		size: 'large'
 	},
 
@@ -193,12 +203,13 @@ const ButtonBase = kind({
 	},
 
 	computed: {
-		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, size, styler}) => styler.append(
+		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, roundBorder, size, styler}) => styler.append(
 			{
 				hasColor: color,
 				iconOnly,
 				collapsable,
-				collapsed
+				collapsed,
+				roundBorder
 			},
 			backgroundOpacity || (iconOnly ? 'transparent' : 'opaque'), // Defaults to opaque, unless otherwise specified
 			color,
@@ -218,6 +229,7 @@ const ButtonBase = kind({
 		delete rest.iconOnly;
 		delete rest.iconPosition;
 		delete rest.focusEffect;
+		delete rest.roundBorder;
 
 		return UiButtonBase.inline({
 			'data-webos-voice-intent': 'Select',

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -15,12 +15,14 @@
 	margin: @sand-button-margin;
 	text-align: center;
 	vertical-align: middle;
+	--button-height: $height;
 
 	.sand-custom-text({
 		font-size: @sand-button-font-size-large;
 		height: @sand-button-height-large;
 		min-width: @sand-button-height-large;
 		line-height: (@sand-button-height-large - (2 * @sand-button-border-width));
+		--button-height: $height;
 	});
 
 	&.focusStatic {
@@ -126,6 +128,7 @@
 		margin: @sand-button-small-margin;
 		padding-left: @sand-button-small-h-padding;
 		padding-right: @sand-button-small-h-padding;
+		--button-height: $height;
 
 		&.focusExpand {
 			margin: @sand-button-small-focusexpand-margin;
@@ -188,6 +191,7 @@
 			height: @sand-button-small-height-large;
 			min-width: @sand-button-small-height-large;
 			line-height: (@sand-button-small-height-large - (2 * @sand-button-border-width));
+			--button-height: $height;
 
 			&.minWidth {
 				min-width: @sand-button-small-min-width;
@@ -327,6 +331,12 @@
 			.bg {
 				border: @sand-button-icononly-bg-border;
 				border-radius: @sand-button-icononly-border-radius;
+			}
+		}
+
+		&.roundBorder {
+			.bg {
+				border-radius: calc(var(--button-height) / 2);
 			}
 		}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ## [unreleased]
 
 ### Added
-- `sandstone/Button` prop `roundBorder`, to make both sides of button fully rounded.
+
+- `sandstone/Button` prop `roundBorder`, to make both sides of button fully rounded
 
 ### Fixed
 - `sandstone/DayPicker` to handle number typed `selected` prop properly in es-ES locale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+- `sandstone/Button` prop `roundBorder`, to make both sides of button fully rounded.
+
 ### Fixed
 - `sandstone/DayPicker` to handle number typed `selected` prop properly in es-ES locale
 

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -58,6 +58,7 @@ export const _Button = (args) => (
 			iconFlip={args['iconFlip']}
 			iconPosition={args['iconPosition']}
 			minWidth={threeWayBoolean(args['minWidth'])}
+			roundBorder={args['roundBorder']}
 			selected={args['selected']}
 			size={args['size']}
 			tooltipText={args['tooltipText']}
@@ -75,6 +76,7 @@ select('icon', _Button, prop.icons, Config);
 select('iconFlip', _Button, prop.iconFlip, Config);
 select('iconPosition', _Button, prop.iconPosition, Config);
 select('minWidth', _Button, prop.minWidth, Config);
+boolean('roundBorder', _Button, Config);
 boolean('selected', _Button, Config);
 select('size', _Button, prop.size, Config);
 text('tooltipText', _Button, Config);

--- a/samples/sampler/stories/qa/Button.js
+++ b/samples/sampler/stories/qa/Button.js
@@ -345,7 +345,6 @@ export const KitchenSink = () => (
 				<Button focusEffect="static" roundBorder size="small" icon="play" alt="Small Round Border" />
 				<Button focusEffect="static" size="large" icon="play" alt="Large" />
 				<Button focusEffect="static" roundBorder size="large" icon="play" alt="Large Round Border" />
-
 			</Section>
 		</Row>
 	</Scroller>

--- a/samples/sampler/stories/qa/Button.js
+++ b/samples/sampler/stories/qa/Button.js
@@ -209,6 +209,9 @@ export const KitchenSink = () => (
 				<Button size="small" alt="With Icon" icon="home">
 					Button
 				</Button>
+				<Button roundBorder size="small" alt="Round Border">
+					Button
+				</Button>
 			</Section>
 
 			<Section title="Large Buttons" size="50%">
@@ -227,18 +230,23 @@ export const KitchenSink = () => (
 				<Button size="large" alt="With Icon" icon="home">
 					Button
 				</Button>
+				<Button roundBorder size="large" alt="Round Border">
+					Button
+				</Button>
 			</Section>
 
 			<Section title="Small Icon Button" size="50%">
 				<Button size="small" icon="play" alt="Normal" />
 				<Button size="small" icon="play" alt="Selected" selected />
 				<Button size="small" icon="play" alt="Disabled" disabled />
+				<Button roundBorder size="small" icon="play" alt="Round Border" disabled />
 			</Section>
 
 			<Section title="Large Icon Button" size="50%">
 				<Button size="large" icon="play" alt="Normal" />
 				<Button size="large" icon="play" alt="Selected" selected />
 				<Button size="large" icon="play" alt="Disabled" disabled />
+				<Button roundBorder size="large" icon="play" alt="Round Border" disabled />
 			</Section>
 
 			<Section title="Small Transparent Buttons" size="50%">
@@ -255,6 +263,9 @@ export const KitchenSink = () => (
 					Super-duper long text string inside a button
 				</Button>
 				<Button backgroundOpacity="transparent" size="small" alt="With Icon" icon="home">
+					Button
+				</Button>
+				<Button backgroundOpacity="transparent" roundBorder size="small" alt="Round Border">
 					Button
 				</Button>
 			</Section>
@@ -275,13 +286,22 @@ export const KitchenSink = () => (
 				<Button backgroundOpacity="transparent" size="large" alt="With Icon" icon="home">
 					Button
 				</Button>
+				<Button backgroundOpacity="transparent" roundBorder size="large" alt="Round Border">
+					Button
+				</Button>
 			</Section>
 
 			<Section title="Static Focus Effect Text" size="50%">
 				<Button focusEffect="static" size="small" alt="Small">
 					Button
 				</Button>
+				<Button focusEffect="static" roundBorder size="small" alt=" Small Round Border">
+					Button
+				</Button>
 				<Button focusEffect="static" size="large" alt="Large">
+					Button
+				</Button>
+				<Button focusEffect="static" roundBorder size="large" alt="Large Round Border">
 					Button
 				</Button>
 				<Button
@@ -295,8 +315,26 @@ export const KitchenSink = () => (
 				<Button
 					focusEffect="static"
 					backgroundOpacity="transparent"
+					roundBorder
+					size="small"
+					alt="Small Transparent Round Border"
+				>
+					Button
+				</Button>
+				<Button
+					focusEffect="static"
+					backgroundOpacity="transparent"
 					size="large"
 					alt="Large Transparent"
+				>
+					Button
+				</Button>
+				<Button
+					focusEffect="static"
+					backgroundOpacity="transparent"
+					roundBorder
+					size="large"
+					alt="Large Transparent Round Border"
 				>
 					Button
 				</Button>
@@ -304,7 +342,10 @@ export const KitchenSink = () => (
 
 			<Section title="Static Focus Effect Icon" size="50%">
 				<Button focusEffect="static" size="small" icon="play" alt="Small" />
+				<Button focusEffect="static" roundBorder size="small" icon="play" alt="Small Round Border" />
 				<Button focusEffect="static" size="large" icon="play" alt="Large" />
+				<Button focusEffect="static" roundBorder size="large" icon="play" alt="Large Round Border" />
+
 			</Section>
 		</Row>
 	</Scroller>

--- a/tests/screenshot/apps/components/Button.js
+++ b/tests/screenshot/apps/components/Button.js
@@ -93,6 +93,53 @@ const ButtonTests = [
 	// [QWTC-1831]
 	<Button icon="rotate">click me</Button>,
 
+	// roundBorder
+	<Button roundBorder>click me</Button>,
+	<Button roundBorder size="small">click me</Button>,
+	<Button roundBorder size="large">click me</Button>,
+	<Button backgroundOpacity="transparent" roundBorder>click me</Button>,
+	<Button backgroundOpacity="opaque" roundBorder>click me</Button>,
+	<Button icon="minus" iconPosition="after" roundBorder />,
+	<Button icon="minus" iconPosition="after" roundBorder size="large" />,
+	<Button icon="plus" iconPosition="before" roundBorder />,
+	<Button icon="plus" iconPosition="before" roundBorder size="large" />,
+	{
+		textSize: 'large',
+		component: <Button roundBorder>click me</Button>
+	},
+	{
+		textSize: 'large',
+		component: <Button roundBorder size="small">click me</Button>
+	},
+	{
+		textSize: 'large',
+		component: <Button roundBorder size="large">click me</Button>
+	},
+	{
+		textSize: 'large',
+		component: <Button backgroundOpacity="transparent" roundBorder>click me</Button>
+	},
+	{
+		textSize: 'large',
+		component: <Button backgroundOpacity="opaque" roundBorder>click me</Button>
+	},
+	{
+		textSize: 'large',
+		component: <Button icon="minus" iconPosition="after" roundBorder />
+	},
+	{
+		textSize: 'large',
+		component: <Button icon="minus" iconPosition="after" roundBorder size="large" />
+	},
+	{
+		textSize: 'large',
+		component: <Button icon="plus" iconPosition="before" roundBorder />
+	},
+	{
+		textSize: 'large',
+		component: <Button icon="plus" iconPosition="before" roundBorder size="large" />
+	},
+
 	// Focused with light wrapper
 	...withConfig({focus: true, wrapper: {light: true, padded: true}}, [
 		<Button>Focused button</Button>,
@@ -150,7 +197,54 @@ const ButtonTests = [
 		<Button icon="arrowhookright" iconFlip="auto">Focused button</Button>,
 
 		// [QWTC-1831]
-		<Button icon="rotate">Focused button</Button>
+		<Button icon="rotate">Focused button</Button>,
+
+		// roundBorder
+		<Button roundBorder>Focused button</Button>,
+		<Button roundBorder size="small">Focused button</Button>,
+		<Button roundBorder size="large">Focused button</Button>,
+		<Button backgroundOpacity="transparent" roundBorder>Focused button</Button>,
+		<Button backgroundOpacity="opaque" roundBorder>Focused button</Button>,
+		<Button icon="minus" iconPosition="after" roundBorder />,
+		<Button icon="minus" iconPosition="after" roundBorder size="large" />,
+		<Button icon="plus" iconPosition="before" roundBorder />,
+		<Button icon="plus" iconPosition="before" roundBorder size="large" />,
+		{
+			textSize: 'large',
+			component: <Button roundBorder>Focused button</Button>
+		},
+		{
+			textSize: 'large',
+			component: <Button roundBorder size="small">Focused button</Button>
+		},
+		{
+			textSize: 'large',
+			component: <Button roundBorder size="large">Focused button</Button>
+		},
+		{
+			textSize: 'large',
+			component: <Button backgroundOpacity="transparent" roundBorder>Focused button</Button>
+		},
+		{
+			textSize: 'large',
+			component: <Button backgroundOpacity="opaque" roundBorder>Focused button</Button>
+		},
+		{
+			textSize: 'large',
+			component: <Button icon="minus" iconPosition="after" roundBorder />
+		},
+		{
+			textSize: 'large',
+			component: <Button icon="minus" iconPosition="after" roundBorder size="large" />
+		},
+		{
+			textSize: 'large',
+			component: <Button icon="plus" iconPosition="before" roundBorder />
+		},
+		{
+			textSize: 'large',
+			component: <Button icon="plus" iconPosition="before" roundBorder size="large" />
+		},
 	]),
 
 	// *************************************************************

--- a/tests/screenshot/apps/components/Button.js
+++ b/tests/screenshot/apps/components/Button.js
@@ -244,7 +244,7 @@ const ButtonTests = [
 		{
 			textSize: 'large',
 			component: <Button icon="plus" iconPosition="before" roundBorder size="large" />
-		},
+		}
 	]),
 
 	// *************************************************************


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As a result of a discussion with the GUI team, it was decided to provide a boolean prop to have both the left and right sides of the button completely round. Therefore, a `roundBorder` boolean prop is added to achieve that.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use
- `--button-height: $height`
- `border-radius: calc(--button-height / 2)`.
    
Use CSS custom property `--button-height` and LESS property as variable `$height`. CSS custom property `--button-height` is overridden wherever CSS property `height` is defined.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
add sampler/qa-sampler and screenshot tests for roundBorder prop

- sampler
  - add roundBorder prop in controls
- qa-sampler
  - add roundBorder variants in each `<Section>`s of `KitchenSink`
- screenshot tests
  - add roundBorder variants for the following
    - size
    - backgroundOpacity
    - icon
    - large text size


### Links
[//]: # (Related issues, references)
WRP-8078

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>