### PR TITLE
WRP-4228: Add `shadowed` prop to `Panels.Header` and `Button`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline false
-    - npm install -g enactjs/cli#develop
+    - npm install -g @enact/cli@5.1.1
     - npm install -g codecov
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline false
-    - npm install -g @enact/cli@5.1.1
+    - npm install -g @enact/cli
     - npm install -g codecov
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -167,10 +167,9 @@ const ButtonBase = kind({
 		minWidth: PropTypes.bool,
 
 		/**
-		 * Boolean controlling whether this component should add shadow to the text when button is transparent.
+		 * Adds shadow to the text when the button is transparent.
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 * @private
 		 */
 		shadowed: PropTypes.bool,
@@ -193,7 +192,6 @@ const ButtonBase = kind({
 		iconComponent: Icon,
 		iconOnly: false,
 		iconPosition: 'before',
-		shadowed: false,
 		size: 'large'
 	},
 

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -167,6 +167,15 @@ const ButtonBase = kind({
 		minWidth: PropTypes.bool,
 
 		/**
+		 * Boolean controlling whether this component should add shadow to the text when button is transparent.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @private
+		 */
+		shadowed: PropTypes.bool,
+
+		/**
 		 * The size of the button.
 		 *
 		 * @type {('large'|'small')}
@@ -184,6 +193,7 @@ const ButtonBase = kind({
 		iconComponent: Icon,
 		iconOnly: false,
 		iconPosition: 'before',
+		shadowed: false,
 		size: 'large'
 	},
 
@@ -193,12 +203,13 @@ const ButtonBase = kind({
 	},
 
 	computed: {
-		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, size, styler}) => styler.append(
+		className: ({backgroundOpacity, collapsable, collapsed, color, focusEffect, iconOnly, iconPosition, size, shadowed, styler}) => styler.append(
 			{
 				hasColor: color,
 				iconOnly,
 				collapsable,
-				collapsed
+				collapsed,
+				shadowed
 			},
 			backgroundOpacity || (iconOnly ? 'transparent' : 'opaque'), // Defaults to opaque, unless otherwise specified
 			color,
@@ -218,6 +229,7 @@ const ButtonBase = kind({
 		delete rest.iconOnly;
 		delete rest.iconPosition;
 		delete rest.focusEffect;
+		delete rest.shadowed;
 
 		return UiButtonBase.inline({
 			'data-webos-voice-intent': 'Select',

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -208,7 +208,7 @@ const ButtonBase = kind({
 				iconOnly,
 				collapsable,
 				collapsed,
-				shadowed
+				shadowed: shadowed && (backgroundOpacity ? backgroundOpacity === 'transparent' : iconOnly)
 			},
 			backgroundOpacity || (iconOnly ? 'transparent' : 'opaque'), // Defaults to opaque, unless otherwise specified
 			color,

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -167,10 +167,11 @@ const ButtonBase = kind({
 		minWidth: PropTypes.bool,
 
 		/**
-		 * Adds shadow to the text when the button is transparent.
+		 * Adds shadow to the text.
+		 * It is only applied when the background opacity of the button is `transparent`.
 		 *
 		 * @type {Boolean}
-		 * @private
+		 * @public
 		 */
 		shadowed: PropTypes.bool,
 

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -304,10 +304,8 @@
 			.bg {
 				opacity: @sand-button-transparent-bg-opacity;
 			}
-			&.shadowed {
-				.client {
-					text-shadow: @sand-button-text-shadow;
-				}
+			&.shadowed .client {
+				text-shadow: @sand-button-text-shadow;
 			}
 		}
 

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -304,6 +304,11 @@
 			.bg {
 				opacity: @sand-button-transparent-bg-opacity;
 			}
+			&.shadowed {
+				.client {
+					text-shadow: @sand-button-text-shadow;
+				}
+			}
 		}
 
 		&.red .client::before {
@@ -355,6 +360,10 @@
 
 			.bg {
 				.sand-button-focus-bg-colors();
+			}
+
+			.client {
+				text-shadow: none;
 			}
 
 			&.iconOnly {

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -304,6 +304,7 @@
 			.bg {
 				opacity: @sand-button-transparent-bg-opacity;
 			}
+
 			&.shadowed .client {
 				text-shadow: @sand-button-text-shadow;
 			}

--- a/Button/tests/Button-specs.js
+++ b/Button/tests/Button-specs.js
@@ -198,6 +198,17 @@ describe('Button', () => {
 		});
 	});
 
+	describe('with shadowed', () => {
+		test('should have shadowed class', () => {
+			render(<Button shadowed backgroundOpacity="transparent" />);
+			const button = screen.getByRole('button');
+
+			const expected = 'shadowed';
+
+			expect(button).toHaveClass(expected);
+		});
+	});
+
 	describe('events', () => {
 		test('should call onClick when not disabled', () => {
 			const handleClick = jest.fn();

--- a/Button/tests/Button-specs.js
+++ b/Button/tests/Button-specs.js
@@ -199,13 +199,31 @@ describe('Button', () => {
 	});
 
 	describe('with shadowed', () => {
-		test('should have shadowed class', () => {
+		test('should have shadowed class when the background is transparent', () => {
 			render(<Button shadowed backgroundOpacity="transparent" />);
 			const button = screen.getByRole('button');
 
 			const expected = 'shadowed';
 
 			expect(button).toHaveClass(expected);
+		});
+
+		test('should have shadowed class when the background is undefined and has icon only', () => {
+			render(<Button shadowed icon="check" />);
+			const button = screen.getByRole('button');
+
+			const expected = 'shadowed';
+
+			expect(button).toHaveClass(expected);
+		});
+
+		test('should not have shadowed class when the background is not transparent', () => {
+			render(<Button shadowed backgroundOpacity="opaque" />);
+			const button = screen.getByRole('button');
+
+			const expected = 'shadowed';
+
+			expect(button).not.toHaveClass(expected);
 		});
 	});
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Panels.Header` prop `shadowed` to add shadow to text and icon
+- `sandstone/Panels.Header` prop `shadowed` to add shadow to text and buttons
 
 ## [2.5.8] - 2023-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Added
 
-- `sandstone/Panels.Header` prop `shadowed` to add shadow to text and buttons
+- `sandstone/Button` and `sandstone/Panels.Header` prop `shadowed` to add shadow to text and buttons
 
 ## [2.5.8] - 2023-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Panels.Header` prop `shadowed` to add shadow to text and icon
+
 ## [2.5.8] - 2023-01-31
 
 ### Fixed

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -15,6 +15,7 @@ import {Children, useContext, useState} from 'react';
 import $L from '../internal/$L';
 import Button from '../Button';
 import Heading from '../Heading';
+import Skinnable from '../Skinnable';
 
 import {PanelsStateContext} from '../internal/Panels';
 import {useContextAsDefaults} from '../internal/Panels/util';
@@ -567,7 +568,8 @@ const HeaderDecorator = compose(
 	SpotlightContainerDecorator,
 	Slottable({slots: ['title', 'subtitle', 'slotAbove', 'slotAfter', 'slotBefore']}),
 	ContextAsDefaultsHeader,
-	HeaderMeasurementDecorator
+	HeaderMeasurementDecorator,
+	Skinnable
 );
 
 // Note that we only export this (even as HeaderBase). HeaderBase is not useful on its own.

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -182,6 +182,15 @@ const HeaderBase = kind({
 		onClose: PropTypes.func,
 
 		/**
+		 * Boolean controlling whether this component should add shadow to the text.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		shadowed: PropTypes.bool,
+
+		/**
 		 * A location for arbitrary elements to be placed above the title
 		 *
 		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
@@ -327,6 +336,7 @@ const HeaderBase = kind({
 	defaultProps: {
 		marqueeOn: 'render',
 		noSubtitle: false,
+		shadowed: false,
 		type: 'standard'
 	},
 
@@ -337,10 +347,11 @@ const HeaderBase = kind({
 	},
 
 	computed: {
-		className: ({centered, children, noSubtitle, type, styler, subtitle}) => styler.append(
+		className: ({centered, children, noSubtitle, type, shadowed, styler, subtitle}) => styler.append(
 			{
 				centered,
 				noSubtitle,
+				shadowed,
 				// This likely doesn't need to be as verbose as it is, with the first 2 conditionals
 				withChildren: hasChildren(children),
 				withSubtitle: subtitle
@@ -420,6 +431,7 @@ const HeaderBase = kind({
 		noCloseButton,
 		onBack,
 		onClose,
+		shadowed,
 		slotAbove,
 		slotAfter,
 		slotAfterRef,
@@ -447,6 +459,7 @@ const HeaderBase = kind({
 				icon="arrowhookleft"
 				iconFlip="auto"
 				onClick={onBack}
+				shadowed={shadowed}
 				size="small"
 			/>
 		) : null);
@@ -459,6 +472,7 @@ const HeaderBase = kind({
 				className={css.close}
 				icon="closex"
 				onClick={onClose}
+				shadowed={shadowed}
 				size="small"
 			/>
 		) : null);

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -182,10 +182,9 @@ const HeaderBase = kind({
 		onClose: PropTypes.func,
 
 		/**
-		 * Boolean controlling whether this component should add shadow to the text.
+		 * Adds shadow to the text contents.
 		 *
 		 * @type {Boolean}
-		 * @default false
 		 * @public
 		 */
 		shadowed: PropTypes.bool,
@@ -336,7 +335,6 @@ const HeaderBase = kind({
 	defaultProps: {
 		marqueeOn: 'render',
 		noSubtitle: false,
-		shadowed: false,
 		type: 'standard'
 	},
 

--- a/Panels/Header.module.less
+++ b/Panels/Header.module.less
@@ -1,7 +1,7 @@
 // Header.module.less
 //
-@import "../styles/colors.less";
 @import "../styles/mixins.less";
+@import "../styles/skin.less";
 @import "../styles/variables.less";
 
 .header {
@@ -91,13 +91,6 @@
 
 	.slotBelow {
 		margin: @sand-header-slotbelow-margin;
-	}
-
-	&.shadowed {	
-		.subtitle,
-		.title {
-			text-shadow: @sand-header-text-shadow;
-		}
 	}
 
 	///
@@ -214,4 +207,13 @@
 			padding-bottom: 0;
 		}
 	}
+
+	.applySkins({
+		&.shadowed {	
+			.subtitle,
+			.title {
+				text-shadow: @sand-header-text-shadow;
+			}
+		}
+	});
 }

--- a/Panels/Header.module.less
+++ b/Panels/Header.module.less
@@ -1,5 +1,6 @@
 // Header.module.less
 //
+@import "../styles/colors.less";
 @import "../styles/mixins.less";
 @import "../styles/variables.less";
 
@@ -90,6 +91,13 @@
 
 	.slotBelow {
 		margin: @sand-header-slotbelow-margin;
+	}
+
+	&.shadowed {	
+		.subtitle,
+		.title {
+			text-shadow: @sand-header-text-shadow;
+		}
 	}
 
 	///

--- a/Panels/tests/Header-specs.js
+++ b/Panels/tests/Header-specs.js
@@ -145,8 +145,10 @@ describe('Header Specs', () => {
 
 	test ('should set close button `shadowed` to true when `shadowed` is set to true', () => {
 		render(<Header shadowed><title>title</title></Header>);
+
 		const button = screen.getByRole('button');
 		const expected = 'button shadowed';
+
 		expect(button).toHaveClass(expected);
 	});
 });

--- a/Panels/tests/Header-specs.js
+++ b/Panels/tests/Header-specs.js
@@ -142,4 +142,11 @@ describe('Header Specs', () => {
 		expect(closeButtonAriaLabel).toBeInTheDocument();
 		expect(slotAfter).toHaveClass('slotAfter');
 	});
+
+	test ('should set close button `shadowed` to true when `shadowed` is set to true', () => {
+		render(<Header shadowed><title>title</title></Header>);
+		const button = screen.getByRole('button');
+		const expected = 'button shadowed';
+		expect(button).toHaveClass(expected);
+	});
 });

--- a/internal/DateTime/tests/DateTimeDecorator-specs.js
+++ b/internal/DateTime/tests/DateTimeDecorator-specs.js
@@ -5,9 +5,9 @@ import {DateTimeDecorator} from '../';
 
 describe('DateTimeDecorator', () => {
 	test('should accept an updated JavaScript Date for its value prop', () => {
-		const Picker = DateTimeDecorator({}, function PickerBase ({locale, title, value}) {
+		const Picker = DateTimeDecorator({}, function PickerBase ({title, value}) {
 			const minuteValue = value.getMinutes();
-			return <div locale={locale} title={title}>{minuteValue}</div>;
+			return <div title={title}>{minuteValue}</div>;
 		});
 
 		const {rerender} = render(

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -58,7 +58,8 @@ export const _Button = (args) => (
 			iconFlip={args['iconFlip']}
 			iconPosition={args['iconPosition']}
 			minWidth={threeWayBoolean(args['minWidth'])}
-			selected={args['selected']}
+			selected={args['selected']}			
+			shadowed={args['shadowed']}
 			size={args['size']}
 			tooltipText={args['tooltipText']}
 			tooltipType={args['tooltipType']}
@@ -76,6 +77,7 @@ select('iconFlip', _Button, prop.iconFlip, Config);
 select('iconPosition', _Button, prop.iconPosition, Config);
 select('minWidth', _Button, prop.minWidth, Config);
 boolean('selected', _Button, Config);
+boolean('shadowed', _Button, Config);
 select('size', _Button, prop.size, Config);
 text('tooltipText', _Button, Config);
 select('tooltipType', _Button, prop.tooltipType, Config);

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -58,7 +58,7 @@ export const _Button = (args) => (
 			iconFlip={args['iconFlip']}
 			iconPosition={args['iconPosition']}
 			minWidth={threeWayBoolean(args['minWidth'])}
-			selected={args['selected']}			
+			selected={args['selected']}
 			shadowed={args['shadowed']}
 			size={args['size']}
 			tooltipText={args['tooltipText']}

--- a/samples/sampler/stories/default/Header.js
+++ b/samples/sampler/stories/default/Header.js
@@ -62,6 +62,7 @@ export const PanelsHeader = (args) => {
 				noCloseButton={args['noCloseButton']}
 				noSubtitle={args['noSubtitle']}
 				onClose={action('onClose')}
+				shadowed={args['shadowed']}
 				slotAbove={slotAbove}
 				slotBefore={slotBefore}
 				slotAfter={slotAfter}
@@ -109,6 +110,7 @@ select(
 select('marqueeOn', PanelsHeader, prop.marqueeOn, Config);
 boolean('noCloseButton', PanelsHeader, Config);
 boolean('noSubtitle', PanelsHeader, Config);
+boolean('shadowed', PanelsHeader, Config);
 
 PanelsHeader.storyName = 'Panels.Header';
 PanelsHeader.parameters = {

--- a/samples/sampler/stories/qa/Slider.js
+++ b/samples/sampler/stories/qa/Slider.js
@@ -54,7 +54,7 @@ class SliderList extends Component {
 		this.fillItems(e.value);
 	};
 
-	renderItem = (size) => ({index, ...rest}) => {
+	renderItem = (size, items) => ({index, ...rest}) => {
 		const itemStyle = {
 			height: size + 'px',
 			borderBottom: ri.scaleToRem(6) + ' solid #202328',
@@ -63,7 +63,7 @@ class SliderList extends Component {
 
 		return (
 			<Item {...rest} style={itemStyle}>
-				{this.items[index].item + ': ' + this.items[index].count}
+				{items[index].item + ': ' + items[index].count}
 			</Item>
 		);
 	};
@@ -83,7 +83,7 @@ class SliderList extends Component {
 				/>
 				<VirtualList
 					dataSize={this.state.selectedItems.length}
-					itemRenderer={this.renderItem(this.props.itemSize)}
+					itemRenderer={this.renderItem(this.props.itemSize, this.items)}
 					itemSize={this.props.itemSize}
 					style={{
 						height: ri.scaleToRem(1104)

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -225,7 +225,7 @@
 
 // Header
 // ---------------------------------------
-@sand-header-text-shadow: 6px 12px 12px rgba(0, 0, 0, 0.3);
+@sand-header-text-shadow: 6px 12px 12px @sand-shadow-color;
 
 // Heading
 // ---------------------------------------

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -165,6 +165,7 @@
 @sand-button-selected-filter: none;
 @sand-button-transparent-text-color: @sand-text-color;
 @sand-button-focus-icononly-bg-color: '';
+@sand-button-text-shadow: @sand-header-text-shadow;
 
 // Checkbox
 // ---------------------------------------
@@ -221,6 +222,10 @@
 @sand-formcheckboxitem-focus-text-color: @sand-focus-text-color;
 @sand-formcheckboxitem-disabled-text-color: inherit;
 @sand-formcheckboxitem-disabled-focus-text-color: @sand-formcheckboxitem-disabled-text-color;
+
+// Header
+// ---------------------------------------
+@sand-header-text-shadow: 6px 12px 12px rgba(0, 0, 0, 0.3);
 
 // Heading
 // ---------------------------------------

--- a/tests/screenshot/apps/components/Button.js
+++ b/tests/screenshot/apps/components/Button.js
@@ -93,7 +93,8 @@ const ButtonTests = [
 
 	// shadowed
 	...withConfig({wrapper: {light: true, padded: true}}, [
-		<Button shadowed backgroundOpacity="transparent" icon="plus" minWidth={false} />
+		<Button shadowed icon="plus" minWidth={false} />,
+		<Button shadowed backgroundOpacity="transparent" minWidth={false}>click me</Button>
 	]),
 
 	// Focused with light wrapper
@@ -156,7 +157,8 @@ const ButtonTests = [
 		<Button icon="rotate">Focused button</Button>,
 
 		// shadowed + focused
-		<Button shadowed backgroundOpacity="transparent" icon="minus" minWidth={false} />
+		<Button shadowed icon="minus" minWidth={false} />,
+		<Button shadowed backgroundOpacity="transparent" minWidth={false}>Focused button</Button>
 	]),
 
 	// *************************************************************

--- a/tests/screenshot/apps/components/Button.js
+++ b/tests/screenshot/apps/components/Button.js
@@ -91,6 +91,11 @@ const ButtonTests = [
 	// [QWTC-1831]
 	<Button icon="rotate">click me</Button>,
 
+	// shadowed
+	...withConfig({wrapper: {light: true, padded: true}}, [
+		<Button shadowed backgroundOpacity="transparent" icon="plus" minWidth={false} />
+	]),
+
 	// Focused with light wrapper
 	...withConfig({focus: true, wrapper: {light: true, padded: true}}, [
 		<Button>Focused button</Button>,
@@ -148,7 +153,10 @@ const ButtonTests = [
 		<Button icon="arrowhookright" iconFlip="auto">Focused button</Button>,
 
 		// [QWTC-1831]
-		<Button icon="rotate">Focused button</Button>
+		<Button icon="rotate">Focused button</Button>,
+
+		// shadowed + focused
+		<Button shadowed backgroundOpacity="transparent" icon="minus" minWidth={false} />
 	]),
 
 	// *************************************************************

--- a/tests/screenshot/apps/components/Header.js
+++ b/tests/screenshot/apps/components/Header.js
@@ -69,7 +69,10 @@ const LtrTests = [
 	...withProps({type: 'standard', noSubtitle: true}, baseTests),
 	...withProps({type: 'compact', noSubtitle: true}, baseTests),
 	...withProps({type: 'wizard', noSubtitle: true}, baseTests),
-	...withProps({type: 'mini', noSubtitle: true}, baseTests)
+	...withProps({type: 'mini', noSubtitle: true}, baseTests),
+
+	// shadowed
+	...withProps({shadowed: true}, baseTests)
 ];
 
 const HeaderTests = [


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add prop to enable shadow effects on icons and text in ```Panels.Header```.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Use text-shadow CSS property to add shadow to text.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

The UX guide only mentioned close button. But for consistency, I also applied a shadow effect to the back button (In Panels/Header.js, line 462).

### Links
[//]: # (Related issues, references)
WRP-4228

### Comments