### PR TITLE
WRP-10826: Fix `WizardPanels` to restore focus properly after a transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/WizardPanels` to restore focus properly after a transtion
+- `sandstone/WizardPanels` to restore focus properly after a transition
 
 ## [2.6.3] - 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/WizardPanels` to handle focus properly when switching views in Chrome version 104 or higher
+- `sandstone/WizardPanels` to restore focus properly after a transtion
 
 ## [2.6.3] - 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/WizardPanels` to handle focus properly when switching views in Chrome version 104 or higher
+
 ## [2.6.3] - 2023-03-17
 
 ### Added

--- a/WizardPanels/useFocusOnTransition.js
+++ b/WizardPanels/useFocusOnTransition.js
@@ -12,7 +12,7 @@ const transitionHandlers = {
 				if (spotlightId && !currentSpotlight) {
 					Spotlight.focus(spotlightId);
 				}
-			});
+			}, 40);
 		}
 	),
 	onWillTransition: handle(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Until 2.5.8, the focus always exists on the screen in 5-way mode when the next/prev button of the WizardPanels sample is selected. From 2.6.0, focus disappears when moving from view 3 to view 4 via the next button and from view 2 to view 1 via the prev button.

This behavior is observed on PC, and the ui-test on the local machine may fail. The failed test case is described as "should select buttons over header - [QWTC-2390]" in WizardPanels specs. Note that we have yet to get this issue on TV and Jenkins tests.

This problem is observed in Chrome version 104 or higher but not in Chrome version 103 or lower.

The observed problems are as follows: Spotlight refocuses on the item previously focused on in the previous view.
- When transitioning from View 3 to View 4, the focus remains on Item (Hello Item) in View 3.
- When transitioning from View 2 to View 1, the focus remains on Button A in View 2.

The problem goes away if adding some delay in `setTimeout()` in the `onTransition` Handler. There is a race condition between view transition and rendering.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add 40ms delay to setTimeout in onTranstion
The delay of "40ms" ensures that the timer handler is called after two rendering cycles (60HZ).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
It should be checked to see if the problem is resolved in the sampler and ui-test on local machine with Chrome version 104 or higher.

### Links
[//]: # (Related issues, references)
WRP-10826
QWTC-2390

### Comments
Enact-1.0-DCO-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>

