### PR TITLE
WRP-6257:Layout: add screenshot tests for `grow` prop

### DIFF
--- a/tests/screenshot/apps/components/Layout.js
+++ b/tests/screenshot/apps/components/Layout.js
@@ -41,7 +41,25 @@ const rowTestCases = [
 		<Cell className={css.blue} shrink>Layout menu</Cell>
 		<Cell className={css.red}>Layout Content</Cell>
 		<Cell className={css.blue} shrink>Layout Side</Cell>
-	</Layout>
+	</Layout>,
+
+	<Row>
+		<Cell className={css.red} grow>Layout Head</Cell>
+		<Cell className={css.blue} grow>Layout Content</Cell>
+		<Cell className={css.green} grow>Layout Tail</Cell>
+	</Row>,
+
+	<Row>
+		<Cell className={css.red} grow size={1000}>Layout Head</Cell>
+		<Cell className={css.blue} grow size={1000}>Layout Content</Cell>
+		<Cell className={css.green} grow size={1000}>Layout Tail</Cell>
+	</Row>,
+
+	<Row>
+		<Cell className={css.red} grow size={1500}>Layout Head</Cell>
+		<Cell className={css.blue} grow size={1500}>Layout Content</Cell>
+		<Cell className={css.green} grow size={1500}>Layout Tail</Cell>
+	</Row>
 ];
 
 const columnTestCases = [
@@ -76,6 +94,24 @@ const columnTestCases = [
 		<Cell className={css.blue} shrink>Column header5</Cell>
 		<Cell className={css.red}>Column Content5</Cell>
 		<Cell className={css.blue} size={500}>Column footer5</Cell>
+	</Column>,
+
+	<Column style={{height: "500px"}}>
+		<Cell className={css.red} grow>Column header6</Cell>
+		<Cell className={css.blue} grow>Column Content6</Cell>
+		<Cell className={css.green} grow>Column footer6</Cell>
+	</Column>,
+
+	<Column style={{height: "500px"}}>
+		<Cell className={css.red} grow size={100}>Column header7</Cell>
+		<Cell className={css.blue} grow size={100}>Column Content7</Cell>
+		<Cell className={css.green} grow size={100}>Column footer7</Cell>
+	</Column>,
+
+	<Column style={{height: "500px"}}>
+		<Cell className={css.red} grow size={500}>Column header8</Cell>
+		<Cell className={css.blue} grow size={500}>Column Content8</Cell>
+		<Cell className={css.green} grow size={500}>Column footer8</Cell>
 	</Column>
 ];
 
@@ -110,6 +146,30 @@ const layoutTestCases = [
 	<Layout align="center">
 		<Cell className={css.red} component="label" size="40%" shrink>Align center layout</Cell>
 		<Cell className={css.blue} component={Button} icon="home" />
+	</Layout>,
+
+	<Layout>
+		<Cell className={css.red}>
+			<Button>First</Button>
+		</Cell>
+		<Cell className={css.blue} shrink>
+			<div>A div with some long text in it</div>
+		</Cell>
+		<Cell className={css.green}>
+			<Button>Last</Button>
+		</Cell>
+	</Layout>,
+
+	<Layout>
+		<Cell className={css.red} grow size={1500}>
+			<Button>First</Button>
+		</Cell>
+		<Cell className={css.blue} grow size={1500}>
+			<div>A div with some long text in it</div>
+		</Cell>
+		<Cell className={css.green} grow size={1500}>
+			<Button>Last</Button>
+		</Cell>
 	</Layout>
 ];
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A follow-up PR to add qa-sampler and screenshot tests for `grow` prop in `Cell` (enactjs/enact#3138)
This PR is reopened (#1417) to fix a screenshot test failing on Item component in sandstone.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- ~~Added qa-sampler for `Layout`~~
- Added screenshot tests

~~qa-sampler~~
~~- One Column and Nested three Rows with a total of 9 Cells to control them at once.~~
~~- Three Cells in a Layout to control them individually.~~

~~In principle, this should be added to enact, but since enact does not have qa-sampler, it is added to sandstone instead.~~

screenshot tests

* Row
  - Simply set the `grow` prop to check if each cell occupies the same area.
  - Set `grow` and `size={1000} to make sure it fills the remaining area of the container.
  - by setting `grow` and `size={1500}`
     - Check that it does not shrink below the specified size
     - When `wrap` is activated, cells are listed in two lines and check if the last cell fills up the container.
    
* Column
  - Simply set the `grow` prop to check if each cell occupies the same area.
  - Set `grow` and `size={100}` to make sure it fills the remaining area of the container.
  - Set `grow` and `size={500}` to make sure it doesn't shrink below the
      specified size.

* Layout
  - by setting `grow` and `size={1500}`
     - Check that it does not shrink below the specified size.
     - When `wrap` is activated, check if cells are listed in two lines, and the last cell fills up the container.
 
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
enactjs/enact#3138 should be merged first.

### Links
[//]: # (Related issues, references)
WRP-6257
enactjs/enact#3138

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
