### PR TITLE
WRP-11626: Move custom drag image into own component

### DIFF
--- a/TransferList/CustomDragImage.js
+++ b/TransferList/CustomDragImage.js
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import css from './TransferList.module.less';
+import itemCss from '../Item/Item.module.less';
+
+const DragImage = (listComponent, item, itemBg) => {
+	let singleItemDragContainer, multipleItemDragContainer;
+	console.log(itemBg)
+	const setCommonElementStyles = (element) => {
+		if (item) {
+			if (listComponent === 'VirtualList' && itemBg) {
+				element.style.backgroundColor = window.getComputedStyle(itemBg).backgroundColor;
+				element.style.borderRadius = window.getComputedStyle(itemBg).borderRadius;
+			} else {
+				element.style.backgroundColor = window.getComputedStyle(item, ':before').backgroundColor;
+				element.style.borderRadius = window.getComputedStyle(item, ':before').borderRadius;
+			}
+
+			element.style.border = '1px solid black';
+			element.style.height = item.clientHeight + 'px';
+			element.style.left = "0px";
+			element.style.position = "absolute";
+			element.style.width = item.clientWidth + 'px';
+		}
+	};
+
+	return () => {
+		if (item) {
+			singleItemDragContainer = document.createElement("div");
+			setCommonElementStyles(singleItemDragContainer);
+			singleItemDragContainer.style.bottom = "0px";
+			singleItemDragContainer.style.left = "0px";
+			singleItemDragContainer.style.zIndex = '-100';
+			document.body.appendChild(singleItemDragContainer);
+
+			multipleItemDragContainer = document.createElement("div");
+			setCommonElementStyles(multipleItemDragContainer);
+			multipleItemDragContainer.style.height = 1.6 * item.clientHeight + 'px';
+			multipleItemDragContainer.style.top = "0px";
+			multipleItemDragContainer.style.zIndex = '-110';
+			document.body.appendChild(multipleItemDragContainer);
+
+			let div2 = document.createElement("div");
+			setCommonElementStyles(div2);
+			div2.style.top = "0px";
+			div2.style.zIndex = '-100';
+
+			let div3 = document.createElement("div");
+			setCommonElementStyles(div3);
+			div3.style.top = 0.3 * item.clientHeight + 'px';
+			div3.style.zIndex = '-90';
+
+			let div4 = document.createElement("div");
+			setCommonElementStyles(div4);
+			div4.style.top = 0.6 * item.clientHeight + 'px';
+			div4.style.zIndex = '-80';
+
+			multipleItemDragContainer.appendChild(div2);
+			multipleItemDragContainer.appendChild(div3);
+			multipleItemDragContainer.appendChild(div4);
+		}
+		return {singleItemDragContainer, multipleItemDragContainer};
+	};
+}
+
+
+export default DragImage;

--- a/TransferList/CustomDragImage.js
+++ b/TransferList/CustomDragImage.js
@@ -1,10 +1,10 @@
-import React, {useCallback, useState} from 'react';
+import React, {forwardRef, useCallback, useImperativeHandle, useState} from 'react';
 import {flushSync} from 'react-dom';
 
 import css from './TransferList.module.less';
 import itemCss from '../Item/Item.module.less';
 
-const DragImage = React.forwardRef((props, ref) => {
+const DragImage = forwardRef((props, ref) => {
 	const getCommonElementStyles = useCallback (() => {
 		const item = document.querySelectorAll(`.${css.draggableItem}`)[0];
 		if (!item) {
@@ -52,7 +52,7 @@ const DragImage = React.forwardRef((props, ref) => {
 	let [content, setContent] = useState(null);
 	let domRef = React.useRef(null);
 
-	React.useImperativeHandle(ref, () => (isSingle, callback) => {
+	useImperativeHandle(ref, () => (isSingle, callback) => {
 		// This will be called during the dragStart event by handleScroll. We need to render the
 		// preview synchronously before this event returns so we can call event.dataTransfer.setDragImage.
 		flushSync(() => {
@@ -71,11 +71,9 @@ const DragImage = React.forwardRef((props, ref) => {
 		});
 	}, [setContent, generateMultiDragImage, getCommonElementStyles]);
 
-
 	if (!content) {
 		return null;
 	}
-
 
 	return (<div
 		style={{zIndex: -100, position: 'absolute', top: 0, left: -100000}}

--- a/TransferList/CustomDragImage.js
+++ b/TransferList/CustomDragImage.js
@@ -1,4 +1,4 @@
-import React, {forwardRef, useCallback, useImperativeHandle, useRef, useState} from 'react';
+import {forwardRef, useCallback, useImperativeHandle, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 
 import css from './TransferList.module.less';

--- a/TransferList/CustomDragImage.js
+++ b/TransferList/CustomDragImage.js
@@ -1,4 +1,4 @@
-import React, {forwardRef, useCallback, useImperativeHandle, useState} from 'react';
+import React, {forwardRef, useCallback, useImperativeHandle, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 
 import css from './TransferList.module.less';
@@ -50,7 +50,7 @@ const DragImage = forwardRef((props, ref) => {
 	}, [getCommonElementStyles]);
 
 	let [content, setContent] = useState(null);
-	let domRef = React.useRef(null);
+	let domRef = useRef(null);
 
 	useImperativeHandle(ref, () => (isSingle, callback) => {
 		// This will be called during the dragStart event by handleScroll. We need to render the


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Refactored the code by creating a new component called CustomDragImage and moving all the functionality related to DragImage into this component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We're now using a custom component to generate the DragImage.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-11626

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com