### PR TITLE
WRP-11620: Rearrange list by keyboard selection

### DIFF
--- a/TransferList/CustomDragImage.js
+++ b/TransferList/CustomDragImage.js
@@ -1,0 +1,84 @@
+import {forwardRef, useCallback, useImperativeHandle, useRef, useState} from 'react';
+import {flushSync} from 'react-dom';
+
+import css from './TransferList.module.less';
+import itemCss from '../Item/Item.module.less';
+
+const DragImage = forwardRef((props, ref) => {
+	const getCommonElementStyles = useCallback (() => {
+		const item = document.querySelectorAll(`.${css.draggableItem}`)[0];
+		if (!item) {
+			return {};
+		}
+
+		const baseStyles = {
+			left: '0px',
+			border: '1px solid black',
+			position: "absolute",
+			height: item.clientHeight + 'px',
+			width: item.clientWidth + 'px'
+		};
+
+		if (props.listComponent === 'VirtualList') {
+			const itemBg = item.querySelectorAll(`.${itemCss.bg}`)[0];
+
+			return {
+				...baseStyles,
+				backgroundColor: window.getComputedStyle(itemBg).backgroundColor,
+				borderRadius: window.getComputedStyle(itemBg).borderRadius
+			};
+		}
+
+		return {
+			...baseStyles,
+			backgroundColor: window.getComputedStyle(item, ':before').backgroundColor,
+			borderRadius: window.getComputedStyle(item, ':before').borderRadius
+		};
+	}, [props.listComponent]);
+
+	const generateMultiDragImage = useCallback(() => {
+		const item = document.querySelectorAll(`.${css.draggableItem}`)[0];
+		if (!item) {
+			return;
+		}
+
+		return <div style={{...getCommonElementStyles(), height: 1.6 * item.clientHeight + 'px', top: 0, zIndex: '-110'}}>
+			<div style={{...getCommonElementStyles(), top: 0, zIndex: '-100'}} />
+			<div style={{...getCommonElementStyles(), top: 0.3 * item.clientHeight + 'px', zIndex: '-90'}} />
+			<div style={{...getCommonElementStyles(), top: 0.6 * item.clientHeight + 'px', zIndex: '-80'}} />
+		</div>;
+	}, [getCommonElementStyles]);
+
+	let [content, setContent] = useState(null);
+	let domRef = useRef(null);
+
+	useImperativeHandle(ref, () => (isSingle, callback) => {
+		// This will be called during the dragStart event by handleScroll. We need to render the
+		// preview synchronously before this event returns so we can call event.dataTransfer.setDragImage.
+		flushSync(() => {
+			const singleDragImage = <div style={getCommonElementStyles()} />;
+			const multiDragImage = generateMultiDragImage();
+
+			setContent(isSingle ? singleDragImage : multiDragImage);
+		});
+
+		// Yield back to useDrag to set the drag image.
+		callback(domRef.current);
+
+		// Remove the preview from the DOM after a frame so the browser has time to paint.
+		requestAnimationFrame(() => {			// eslint-disable-line
+			setContent(null);
+		});
+	}, [setContent, generateMultiDragImage, getCommonElementStyles]);
+
+	if (!content) {
+		return null;
+	}
+
+	return (<div
+		style={{zIndex: -100, position: 'absolute', top: 0, left: -100000}}
+		ref={domRef}
+	>{content}</div>);
+});
+
+export default DragImage;

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -796,15 +796,15 @@ const TransferListBase = kind({
 		const moveInFirst = useCallback((ev) => {
 			if (selectedItems.findIndex(elm => elm.list === 'second') === -1 || !moveOnSpotlight) return;
 			moveIntoFirstSelected();
-			ev.preventDefault();
-			ev.stopPropagation();
+			ev?.preventDefault();
+			ev?.stopPropagation();
 		}, [moveIntoFirstSelected, moveOnSpotlight, selectedItems]);
 
 		const moveInSecond = useCallback((ev) => {
 			if (selectedItems.findIndex(elm => elm.list === 'first') === -1 || !moveOnSpotlight) return;
 			moveIntoSecondSelected();
-			ev.preventDefault();
-			ev.stopPropagation();
+			ev?.preventDefault();
+			ev?.stopPropagation();
 		}, [moveIntoSecondSelected, moveOnSpotlight, selectedItems]);
 
 		const firstListSpecs = {

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -374,6 +374,10 @@ const TransferListBase = kind({
 						reorderList(list, index, -2, element);
 					} else if (ev.key === 'ArrowRight') {
 						reorderList(list, index, 2, element);
+					} else if (ev.key === 'ArrowUp') {
+						reorderList(list, index, -1, element);
+					} else if (ev.key === 'ArrowDown') {
+						reorderList(list, index, 1, element);
 					}
 				}
 			};

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -231,7 +231,7 @@ const TransferListBase = kind({
 	},
 
 	computed: {
-		renderItem: ({disabled, itemSize, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, selectedItems, showSelectionOrder, reorderList, ...rest}) => (data) => {
+		renderItem: ({disabled, itemSize, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, reorderList, selectedItems, showSelectionOrder, ...rest}) => (data) => {
 			const {index, 'data-index': dataIndex} = data;
 			const element = elements[index];
 			const selectedIndex = selectedItems.findIndex((args) => args.element === element && args.list === list) + 1;

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -436,7 +436,7 @@ const TransferListBase = kind({
 		}, []);
 
 		const reorderList = (list, index, inc, element) => {
-			if (list === 'first') {
+			if (list === 'first' && moveOnSpotlight) {
 				if (index + inc < 0 || index + inc >= firstListLocal.length) return;
 
 				let firstListTemp = firstListLocal;
@@ -444,7 +444,7 @@ const TransferListBase = kind({
 				firstListTemp.splice(index + inc, 0, element);
 				setFirstListLocal(firstListTemp);
 				setSelectedItems([{element, index: index + inc, list}]);
-			} else {
+			} else if (list === 'second' && moveOnSpotlight) {
 				if (index + inc < 0 || index + inc >= secondListLocal.length) return;
 
 				let secondListTemp = secondListLocal;

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -231,7 +231,7 @@ const TransferListBase = kind({
 	},
 
 	computed: {
-		renderItem: ({disabled, itemSize, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, rearrangeList, selectedItems, showSelectionOrder, reorderList, ...rest}) => (data) => {
+		renderItem: ({disabled, itemSize, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, selectedItems, showSelectionOrder, reorderList, ...rest}) => (data) => {
 			const {index, 'data-index': dataIndex} = data;
 			const element = elements[index];
 			const selectedIndex = selectedItems.findIndex((args) => args.element === element && args.list === list) + 1;
@@ -279,14 +279,14 @@ const TransferListBase = kind({
 					} else if (ev.key === 'ArrowDown') {
 						reorderList(list, index, 1, element);
 					}
-				} else {
+				} else if (orientation !== 'horizontal') {
 					if (ev.key === 'ArrowLeft') {
 						reorderList(list, index, -1, element);
 					} else if (ev.key === 'ArrowRight') {
 						reorderList(list, index, 1, element);
 					}
 				}
-			}
+			};
 
 			return (
 				<CheckboxItem
@@ -298,7 +298,7 @@ const TransferListBase = kind({
 					id={`${index}-${list}`}
 					key={index + list}
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
-					onKeyDownCapture={handleKeyDownCapture}
+					onKeyDownCapture={handleKeyDownCapture}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightLeft={handleSpotlightLeft}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightRight={handleSpotlightRight}	// eslint-disable-line  react/jsx-no-bind
@@ -369,14 +369,14 @@ const TransferListBase = kind({
 					} else if (ev.key === 'ArrowDown') {
 						reorderList(list, index, 1, element);
 					}
-				} else {
+				} else if (orientation !== 'horizontal') {
 					if (ev.key === 'ArrowLeft') {
 						reorderList(list, index, -2, element);
 					} else if (ev.key === 'ArrowRight') {
 						reorderList(list, index, 2, element);
 					}
 				}
-			}
+			};
 
 			return (
 				<ImageItem
@@ -388,7 +388,7 @@ const TransferListBase = kind({
 					id={`${index}-${list}`}
 					key={index + list}
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
-					onKeyDownCapture={handleKeyDownCapture}
+					onKeyDownCapture={handleKeyDownCapture} // eslint-disable-line  react/jsx-no-bind
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightLeft={handleSpotlightLeft}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightRight={handleSpotlightRight}	// eslint-disable-line  react/jsx-no-bind
@@ -435,7 +435,7 @@ const TransferListBase = kind({
 				firstListTemp.splice(index, 1);
 				firstListTemp.splice(index + inc, 0, element);
 				setFirstListLocal(firstListTemp);
-				setSelectedItems([{element, index: index + inc, list}])
+				setSelectedItems([{element, index: index + inc, list}]);
 			} else {
 				if (index + inc < 0 || index + inc >= secondListLocal.length) return;
 
@@ -443,7 +443,7 @@ const TransferListBase = kind({
 				secondListTemp.splice(index, 1);
 				secondListTemp.splice(index + inc, 0, element);
 				setSecondListLocal(secondListTemp);
-				setSelectedItems([{element, index: index + inc, list}])
+				setSelectedItems([{element, index: index + inc, list}]);
 			}
 		};
 

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -231,7 +231,7 @@ const TransferListBase = kind({
 	},
 
 	computed: {
-		renderItem: ({disabled, itemSize, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, selectedItems, showSelectionOrder, ...rest}) => (data) => {
+		renderItem: ({disabled, itemSize, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, rearrangeList, selectedItems, showSelectionOrder, reorderList, ...rest}) => (data) => {
 			const {index, 'data-index': dataIndex} = data;
 			const element = elements[index];
 			const selectedIndex = selectedItems.findIndex((args) => args.element === element && args.list === list) + 1;
@@ -271,6 +271,23 @@ const TransferListBase = kind({
 				ev.stopPropagation();
 			};
 
+			const handleKeyDownCapture = (ev) => {
+				if (!selected || selectedItems.length > 1) return;
+				if (orientation !== 'vertical') {
+					if (ev.key === 'ArrowUp') {
+						reorderList(list, index, -1, element);
+					} else if (ev.key === 'ArrowDown') {
+						reorderList(list, index, 1, element);
+					}
+				} else {
+					if (ev.key === 'ArrowLeft') {
+						reorderList(list, index, -1, element);
+					} else if (ev.key === 'ArrowRight') {
+						reorderList(list, index, 1, element);
+					}
+				}
+			}
+
 			return (
 				<CheckboxItem
 					{...rest}
@@ -281,6 +298,7 @@ const TransferListBase = kind({
 					id={`${index}-${list}`}
 					key={index + list}
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
+					onKeyDownCapture={handleKeyDownCapture}
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightLeft={handleSpotlightLeft}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightRight={handleSpotlightRight}	// eslint-disable-line  react/jsx-no-bind
@@ -293,7 +311,7 @@ const TransferListBase = kind({
 				</CheckboxItem>
 			);
 		},
-		renderImageItem: ({disabled, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, selectedItems, showSelectionOrder, ...rest}) => (data) => {	// eslint-disable-line	enact/display-name
+		renderImageItem: ({disabled, orientation}) => ({elements, list, moveInFirst, moveInSecond, onSelect, reorderList, selectedItems, showSelectionOrder, ...rest}) => (data) => {	// eslint-disable-line	enact/display-name
 			const {index, 'data-index': dataIndex} = data;
 			const element = elements[index];
 			const selectedIndex = selectedItems.findIndex((args) => args.element === element && args.list === list) + 1;
@@ -343,6 +361,23 @@ const TransferListBase = kind({
 				ev.stopPropagation();
 			};
 
+			const handleKeyDownCapture = (ev) => {
+				if (!selected || selectedItems.length > 1) return;
+				if (orientation !== 'vertical') {
+					if (ev.key === 'ArrowUp') {
+						reorderList(list, index, -1, element);
+					} else if (ev.key === 'ArrowDown') {
+						reorderList(list, index, 1, element);
+					}
+				} else {
+					if (ev.key === 'ArrowLeft') {
+						reorderList(list, index, -2, element);
+					} else if (ev.key === 'ArrowRight') {
+						reorderList(list, index, 2, element);
+					}
+				}
+			}
+
 			return (
 				<ImageItem
 					{...rest}
@@ -353,6 +388,7 @@ const TransferListBase = kind({
 					id={`${index}-${list}`}
 					key={index + list}
 					onClick={handleClick}	// eslint-disable-line  react/jsx-no-bind
+					onKeyDownCapture={handleKeyDownCapture}
 					onSpotlightDown={handleSpotlightDown}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightLeft={handleSpotlightLeft}	// eslint-disable-line  react/jsx-no-bind
 					onSpotlightRight={handleSpotlightRight}	// eslint-disable-line  react/jsx-no-bind
@@ -390,6 +426,26 @@ const TransferListBase = kind({
 		const getScrollToSecond = useCallback((scrollTo) => {
 			scrollToRefSecond.current = scrollTo;
 		}, []);
+
+		const reorderList = (list, index, inc, element) => {
+			if (list === 'first') {
+				if (index + inc < 0 || index + inc >= firstListLocal.length) return;
+
+				let firstListTemp = firstListLocal;
+				firstListTemp.splice(index, 1);
+				firstListTemp.splice(index + inc, 0, element);
+				setFirstListLocal(firstListTemp);
+				setSelectedItems([{element, index: index + inc, list}])
+			} else {
+				if (index + inc < 0 || index + inc >= secondListLocal.length) return;
+
+				let secondListTemp = secondListLocal;
+				secondListTemp.splice(index, 1);
+				secondListTemp.splice(index + inc, 0, element);
+				setSecondListLocal(secondListTemp);
+				setSelectedItems([{element, index: index + inc, list}])
+			}
+		};
 
 		const setCommonElementStyles = (element) => {
 			const item = document.querySelectorAll(`.${css.draggableItem}`)[0];
@@ -795,6 +851,7 @@ const TransferListBase = kind({
 			elements: firstListLocal,
 			list: 'first',
 			onSelect: setSelected,
+			reorderList,
 			selectedItems,
 			moveInSecond,
 			showSelectionOrder
@@ -804,6 +861,7 @@ const TransferListBase = kind({
 			elements: secondListLocal,
 			list: 'second',
 			onSelect: setSelected,
+			reorderList,
 			selectedItems,
 			moveInFirst,
 			showSelectionOrder


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When an item is selected we want to move that item within its original list by using keyboard.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added functionality to reorder items in the same list by keyboard selection. Only 1 item can be moved at a time.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-11620

### Comments
