### PR TITLE
WRP-12301: Changed `Alert` alignment of text content to be left for fullscreen type

### DIFF
--- a/Alert/Alert.js
+++ b/Alert/Alert.js
@@ -25,8 +25,7 @@ import AlertImage from './AlertImage';
 
 import css from './Alert.module.less';
 
-// when Alert type is "fullscreen", the body content for string children should be centered
-const CenteredBodyText = (props) => <BodyText {...props} centered />;
+const CenteredBodyText = (props) => <BodyText {...props} />;
 
 /**
  * A modal Alert component.

--- a/Alert/Alert.js
+++ b/Alert/Alert.js
@@ -25,8 +25,6 @@ import AlertImage from './AlertImage';
 
 import css from './Alert.module.less';
 
-const CenteredBodyText = (props) => <BodyText {...props} />;
-
 /**
  * A modal Alert component.
  *
@@ -154,11 +152,11 @@ const AlertBase = kind({
 				</Cell>
 			)) || null;
 		},
-		contentComponent: ({children, type}) => {
+		contentComponent: ({children}) => {
 			if (typeof children === 'string' ||
 				Array.isArray(children) && children.every(child => (child == null || typeof child === 'string'))
 			) {
-				return (type === 'fullscreen' ? CenteredBodyText : BodyText);
+				return BodyText;
 			}
 		},
 		className: ({buttons, image, title, type, styler}) => styler.append(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `sandstone/Alert` alignment of text content to be left for fullscreen type
+
 ### Fixed
 
 - `sandstone/WizardPanels` to restore focus properly after a transition


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`sandstone/Alert` alignment of text content to be left for fullscreen type.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed alignment to be left.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-12301

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)