### PR TITLE
WRP-11047:Picker: add `type` property to `onChange` event object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and page down at the last page
 - `sandstone/WizardPanels` to restore focus properly after a transition
-- `sandstone/Picker` prop `onChange` to include `type` in the event payload
+- `sandstone/Picker` to include `type` in the event payload for `onChange`
 
 ## [2.6.3] - 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and page down at the last page
 - `sandstone/WizardPanels` to restore focus properly after a transition
+- `sandstone/Picker` prop `onChange` to include `type` in the event payload
 
 ## [2.6.3] - 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Picker` to include `type` in the event payload for `onChange`
 - `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and page down at the last page
 - `sandstone/WizardPanels` to restore focus properly after a transition
-- `sandstone/Picker` to include `type` in the event payload for `onChange`
 
 ## [2.6.3] - 2023-03-17
 

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -149,11 +149,11 @@ const PickerBase = (props) => {
 		if (Number.isInteger(voiceIndex)) {
 			const voiceValue = min + voiceIndex;
 			if (onChange && voiceValue >= min && voiceValue <= max && voiceValue !== value) {
-				onChange({value: voiceValue});
+				forwardCustom('onChange', () => ({value: voiceValue}))(ev, props);
 				ev.preventDefault();
 			}
 		}
-	}, [max, min, onChange, value]);
+	}, [max, min, onChange, props, value]);
 
 	const computeNextValue = useCallback((delta) => {
 		const horizontalJoined = orientation === 'horizontal' && joined && changedBy === 'enter';
@@ -178,9 +178,9 @@ const PickerBase = (props) => {
 		setTransitionDirection(dir);
 		if (!disabled && onChange) {
 			const updatedValue = computeNextValue(dir * step);
-			onChange({value: updatedValue});
+			forwardCustom('onChange', () => ({value: updatedValue}))(null, props);
 		}
-	}, [adjustDirection, setTransitionDirection, disabled, onChange, computeNextValue, step]);
+	}, [adjustDirection, setTransitionDirection, disabled, onChange, computeNextValue, step, props]);
 
 	const setPressedState = useCallback((pressedValue) => {
 		if (joined) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`type: "onChange"` is missing in the object passed when `onChange` is called.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `type: "onChange"` in the event object.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`type: "onChange"` must be included in the sampler output in the Actions tab when clicking next or prev buttons.

### Links
[//]: # (Related issues, references)
WRP-11047

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
