### PR TITLE
WRP-12378: Fixed `Scroller` and `VirtualList` to focus Spottable container items properly via page up/down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and via page down at the last page
 - `sandstone/WizardPanels` to restore focus properly after a transition
 
 ## [2.6.3] - 2023-03-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and via page down at the last page
+- `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and page down at the last page
 - `sandstone/WizardPanels` to restore focus properly after a transition
 
 ## [2.6.3] - 2023-03-17

--- a/tests/ui/specs/Scroller/EditableScroller/Scroller-QWTC-569-specs.js
+++ b/tests/ui/specs/Scroller/EditableScroller/Scroller-QWTC-569-specs.js
@@ -17,7 +17,7 @@ describe.skip('Editable Scroller', function () {
 
 		// Step 4: 5-way Right.
 		await ScrollerPage.spotlightRight();
-		// STep 4 Verify: Position of Image 0 and Image 1 are switched.
+		// Step 4 Verify: Position of Image 0 and Image 1 are switched.
 		await ScrollerPage.spotlightSelect();
 		await expectFocusedItem(0);
 		await ScrollerPage.spotlightLeft();

--- a/tests/ui/specs/TabLayout/VerticalTabsWithoutIcons/VerticalTabsWithoutIcons-specs.js
+++ b/tests/ui/specs/TabLayout/VerticalTabsWithoutIcons/VerticalTabsWithoutIcons-specs.js
@@ -64,7 +64,7 @@ describe('TabLayout', function () {
 					await Page.delay(500);
 					// Step 4-3: Click on Home tab.
 					await $$('.TabLayout_TabLayout_tabGroup')[1].click();
-					// STep 4-4: Hover on ImageItem 1 again.
+					// Step 4-4: Hover on ImageItem 1 again.
 					await $('#button1').moveTo();
 					// step 4 Verify: Spotlight is on ImageItem 1.
 					expect(await $('#button1').isFocused()).to.be.true();

--- a/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWTC-11715-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWTC-11715-specs.js
@@ -1,0 +1,43 @@
+const Page = require('../VirtualListPage');
+
+describe('VirtualList with multiple spottables in an item', function () {
+	beforeEach(async function () {
+		await Page.open('WithMultipleSpottables');
+	});
+
+	it('should navigates between the same spottable controls of items with Channel Up/Down [QWTC-11715]', async function () {
+		// Set the number of items to 20 for easy test
+		await Page.spotlightSelect();
+		await Page.backSpace();
+		await Page.backSpace();
+		await Page.backSpace();
+		await Page.numPad(2);
+		await Page.numPad(0);
+		// 5-way Spot a star icon (★) of the first ('Item 00')
+		await Page.spotlightDown();
+		await Page.spotlightRight();
+		await Page.spotlightRight();
+		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
+		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(0);
+		// normal scroll down with channel down
+		await Page.pageDown();
+		await Page.delay(1000);
+		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
+		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(6);
+		// scroll to the bottom with channel down
+		await Page.pageDown();
+		await Page.delay(1000);
+		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
+		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(19);
+		// normal scroll up with channel up
+		await Page.pageUp();
+		await Page.delay(1000);
+		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
+		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(13);
+		// scroll to the top with channel up
+		await Page.pageUp();
+		await Page.delay(1000);
+		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
+		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(0);
+	});
+});

--- a/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWTC-11715-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWTC-11715-specs.js
@@ -6,14 +6,14 @@ describe('VirtualList with multiple spottables in an item', function () {
 	});
 
 	it('should navigates between the same spottable controls of items with Channel Up/Down [QWTC-11715]', async function () {
-		// Set the number of items to 20 for easy test
+		// Step 3: Set the number of items to 20 for easy test
 		await Page.spotlightSelect();
 		await Page.backSpace();
 		await Page.backSpace();
 		await Page.backSpace();
 		await Page.numPad(2);
 		await Page.numPad(0);
-		// 5-way Spot a star icon (★) of the first ('Item 00')
+		// Step 5: 5-way Spot a star icon (★) of the first ('Item 00')
 		await Page.spotlightDown();
 		await Page.spotlightRight();
 		await Page.spotlightRight();
@@ -24,7 +24,7 @@ describe('VirtualList with multiple spottables in an item', function () {
 		await Page.delay(1000);
 		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
 		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(6);
-		// scroll to the bottom with channel down
+		// Step 6: scroll to the bottom with channel down
 		await Page.pageDown();
 		await Page.delay(1000);
 		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
@@ -34,7 +34,7 @@ describe('VirtualList with multiple spottables in an item', function () {
 		await Page.delay(1000);
 		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
 		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(13);
-		// scroll to the top with channel up
+		// Step 7: scroll to the top with channel up
 		await Page.pageUp();
 		await Page.delay(1000);
 		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');

--- a/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWTC-2260-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualList/WithMultipleSpottables/VirtualList-QWTC-2260-specs.js
@@ -10,7 +10,7 @@ describe('VirtualList with multiple spottables in an item', function () {
 		await Page.spotlightDown();
 		await Page.spotlightRight();
 		await Page.spotlightRight();
-		// STep 1 Verify: Spotlight displays on a star icon(★) of the first item ('item 000').
+		// Step 1 Verify: Spotlight displays on a star icon(★) of the first item ('item 000').
 		expect((await Page.getElementAttribute('id')).slice(0, 8)).to.equal('starIcon');
 		expect(Number(await Page.getElementAttribute('data-index'))).to.equal(0);
 		// 5-way Down hold for 1 second.

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -57,7 +57,7 @@ const dataIndexAttribute = 'data-index';
 const isIntersecting = (elem, container) => elem && intersects(getRect(container), getRect(elem));
 const getIntersectingElement = (elem, container) => isIntersecting(elem, container) && elem;
 const getTargetInViewByDirectionFromPosition = (direction, position, container) => {
-	const target = getTargetByDirectionFromPosition(direction, position, Spotlight.getActiveContainer());
+	const target = getTargetByDirectionFromPosition(direction, position, container);
 	return getIntersectingElement(target, container);
 };
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When a page up/down key is pressed on items in a scroller or a list, an expected behavior is to scroll a page and focus an item at the same visual position normally.

And, if page up is pressed at the first page or page down is pressed at the last page, an expected behavior is to scroll to the edge then focus the first (for page up) or the last (for page down) item.

The reported issue is that, the focus disappears on page down key at the last page when the last item is spotlight container that has a spottable node not attached to the bottom of the item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

`useScroll` has a logic to find an item to focus and it was working well _for items that are not Spotlight containers_ as it searches candidates from the last active Spotlight container. To fix this, I changed the starting node from the last active Spotlight container to a scroll container.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-12378

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)