### PR TITLE
WRP-11279: Fix broken links referencing other props in documentation

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -61,7 +61,7 @@ const ButtonBase = kind({
 		/**
 		 * Enables the `collapsed` feature.
 		 *
-		 * This requires that both the text and {@link ui/Button.ButtonBase.Icon|icon} are
+		 * This requires that both the text and {@link ui/Button.ButtonBase.icon|icon} are
 		 * defined.
 		 *
 		 * Use {@link sandstone/Button.ButtonBase.collapsed|collapsed} to toggle the collapsed state.

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -61,14 +61,14 @@ const ButtonBase = kind({
 		/**
 		 * Enables the `collapsed` feature.
 		 *
-		 * This requires that both the text and {@link sandstone/Button.Button#icon|icon} are
+		 * This requires that both the text and {@link ui/Button.ButtonBase.Icon|icon} are
 		 * defined.
 		 *
-		 * Use {@link sandstone/Button.Button#collapsed|collapsed} to toggle the collapsed state.
+		 * Use {@link sandstone/Button.ButtonBase.collapsed|collapsed} to toggle the collapsed state.
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @see {@link sandstone/Button.Button#collapsed}
+		 * @see {@link sandstone/Button.ButtonBase.collapsed}
 		 * @private
 		 */
 		collapsable: PropTypes.bool,
@@ -76,12 +76,12 @@ const ButtonBase = kind({
 		/**
 		 * Toggles the collapsed state of this button, down to just its icon.
 		 *
-		 * This requires that {@link sandstone/Button.Button#collapsable|collapsable} is enabled
-		 * and both the text and {@link sandstone/Button.Button#icon|icon} are defined.
+		 * This requires that {@link sandstone/Button.ButtonBase.collapsable|collapsable} is enabled
+		 * and both the text and {@link ui/Button.ButtonBase.icon|icon} are defined.
 		 *
 		 * @type {Boolean}
 		 * @default false
-		 * @see {@link sandstone/Button.Button#collapsable}
+		 * @see {@link sandstone/Button.ButtonBase.collapsable}
 		 * @private
 		 */
 		collapsed: PropTypes.bool,

--- a/Checkbox/Checkbox.js
+++ b/Checkbox/Checkbox.js
@@ -47,7 +47,7 @@ const CheckboxBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the {@link sandstone/Icon.Icon.iconList|iconList},
+		 * * A string that represents an icon from the {@link sandstone/Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})

--- a/CheckboxItem/CheckboxItem.js
+++ b/CheckboxItem/CheckboxItem.js
@@ -76,7 +76,7 @@ const CheckboxItemBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the {@link sandstone/Icon.Icon.iconList|iconList},
+		 * * A string that represents an icon from the {@link sandstone/Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -105,7 +105,7 @@ const CheckboxItemBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the {@link sandstone/Icon.Icon.iconList|iconList},
+		 * * A string that represents an icon from the {@link sandstone/Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})

--- a/FlexiblePopupPanels/Panel.js
+++ b/FlexiblePopupPanels/Panel.js
@@ -38,7 +38,7 @@ const PanelBase = kind({
 		 *
 		 * If `false`, the button will not show. If set to a component, or `true`, the button will
 		 * show. This will override the setting of
-		 * {@link sandstone/FlexiblePopupPanels.FlexiblePopupPanels#nextButtonVisibility|nextButtonVisibility}.
+		 * {@link sandstone/FlexiblePopupPanels.FlexiblePopupPanels.nextButtonVisibility|nextButtonVisibility}.
 		 *
 		 * Example:
 		 * ```
@@ -102,7 +102,7 @@ const PanelBase = kind({
 		 *
 		 * If `false`, the button will not show. If set to a component, or `true`, the button will
 		 * show. This will override the setting of
-		 * {@link sandstone/FlexiblePopupPanels.FlexiblePopupPanels#prevButtonVisibility|prevButtonVisibility}.
+		 * {@link sandstone/FlexiblePopupPanels.FlexiblePopupPanels.prevButtonVisibility|prevButtonVisibility}.
 		 *
 		 * Example:
 		 * ```

--- a/FormCheckboxItem/FormCheckboxItem.js
+++ b/FormCheckboxItem/FormCheckboxItem.js
@@ -63,7 +63,7 @@ const FormCheckboxItemBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the {@link sandstone/Icon.Icon.iconList|iconList},
+		 * * A string that represents an icon from the {@link sandstone/Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -92,7 +92,7 @@ const FormCheckboxItemBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the {@link sandstone/Icon.Icon.iconList|iconList},
+		 * * A string that represents an icon from the {@link sandstone/Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})

--- a/Icon/Icon.js
+++ b/Icon/Icon.js
@@ -41,7 +41,7 @@ const IconBase = kind({
 		/**
 		 * The icon content.
 		 *
-		 * @see {@link ui/Icon.Icon.children}
+		 * @see {@link ui/Icon.IconBase.children}
 		 * @type {String|Object}
 		 * @public
 		 */

--- a/ImageItem/ImageItem.js
+++ b/ImageItem/ImageItem.js
@@ -155,7 +155,7 @@ const ImageItemBase = kind({
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 
 		/**
-		 * Placeholder image used while {@link sandstone/ImageItem.ImageItem#src|src}
+		 * Placeholder image used while {@link sandstone/ImageItem.ImageItemBase.src|src}
 		 * is loaded.
 		 *
 		 * @type {String}

--- a/Input/InputFieldDecoratorIcon.js
+++ b/Input/InputFieldDecoratorIcon.js
@@ -27,7 +27,7 @@ const InputDecoratorIconBase = kind({
 		/**
 		 * Icon to be displayed.
 		 *
-		 * @see {@link sandstone/Icon.Icon#children}
+		 * @see {@link sandstone/Icon.IconBase.children}
 		 * @type {String|Object}
 		 */
 		children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -127,7 +127,7 @@ const PickerBase = kind({
 		 *
 		 * All strings supported by {@link sandstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * {@link sandstone/Picker.Picker#orientation|orientation} is changed.
+		 * {@link sandstone/Picker.PickerBase.orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -67,8 +67,8 @@ const PickerBase = kind({
 		 *  * `'arrow'` allows the user to use the left or right keys to adjust the picker's value.
 		 *
 		 * The default value for joined horizontal picker is `'enter'`.
-		 * If {@link sandstone/Picker.Picker#orientation|orientation} is `'vertical'` or
-		 * {@link sandstone/Picker.Picker#joined|joined} is undefined or is `false`, this prop is ignored.
+		 * If {@link sandstone/Picker.PickerBase.orientation|orientation} is `'vertical'` or
+		 * {@link sandstone/Picker.PickerBase.joined|joined} is undefined or is `false`, this prop is ignored.
 		 *
 		 * @type {('enter'|'arrow')}
 		 * @public
@@ -107,7 +107,7 @@ const PickerBase = kind({
 		 *
 		 * All strings supported by {@link sandstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * {@link sandstone/Picker.Picker#orientation|orientation} is changed.
+		 * {@link sandstone/Picker.PickerBase.orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -349,7 +349,7 @@ class Popup extends Component {
 		 * Called after show transition has completed, and immediately with no transition.
 		 *
 		 * Note: The function does not run if Popup is initially opened and
-		 * {@link sandstone/Popup.PopupBase#noAnimation|noAnimation} is `true`.
+		 * {@link sandstone/Popup.PopupBase.noAnimation|noAnimation} is `true`.
 		 *
 		 * @type {Function}
 		 * @public

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -93,8 +93,8 @@ const RangePickerBase = kind({
 		 *  * `'arrow'` allows the user to use the left or right keys to adjust the picker's value.
 		 *
 		 * The default value for joined horizontal picker is `'enter'`.
-		 * If {@link sandstone/RangePicker.RangePicker#orientation|orientation} is `'vertical'` or
-		 * {@link sandstone/RangePicker.RangePicker#joined|joined} is undefined or is `false`, this prop is ignored.
+		 * If {@link sandstone/RangePicker.RangePickerBase.orientation|orientation} is `'vertical'` or
+		 * {@link sandstone/RangePicker.RangePickerBase.joined|joined} is undefined or is `false`, this prop is ignored.
 		 *
 		 * @type {('enter'|'arrow')}
 		 * @public
@@ -136,7 +136,7 @@ const RangePickerBase = kind({
 		 *
 		 * All strings supported by {@link sandstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * {@link sandstone/RangePicker.RangePicker#orientation|orientation} is changed.
+		 * {@link sandstone/RangePicker.RangePickerBase.orientation|orientation} is changed.
 		 *
 		 * @type {string}
 		 * @public
@@ -156,7 +156,7 @@ const RangePickerBase = kind({
 		 *
 		 * All strings supported by {@link sandstone/Icon.Icon|Icon} are supported. Without a
 		 * custom icon, the default is used, and is automatically changed when the
-		 * {@link sandstone/RangePicker.RangePicker#orientation|orientation} is changed.
+		 * {@link sandstone/RangePicker.RangePickerBase.orientation|orientation} is changed.
 		 *
 		 * @type {String}
 		 * @public

--- a/Sprite/Sprite.js
+++ b/Sprite/Sprite.js
@@ -174,7 +174,7 @@ const SpriteBase = kind({
 		/**
 		 * The sprite-sheet image with all of the cells on it.
 		 *
-		 * @see {@link ui/Image.Image.src}
+		 * @see {@link ui/Image.ImageBase.src}
 		 * @type {String|Object}
 		 * @public
 		 */

--- a/TabLayout/Tab.js
+++ b/TabLayout/Tab.js
@@ -35,7 +35,7 @@ const Tab = kind({
 		/**
 		 * The icon content of the tab.
 		 *
-		 * @see {@link ui/Icon.Icon.children}
+		 * @see {@link ui/Icon.IconBase.children}
 		 * @type {String|Object}
 		 * @public
 		 */

--- a/TimePicker/TimePicker.js
+++ b/TimePicker/TimePicker.js
@@ -198,7 +198,7 @@ const dateTimeConfig = {
 /**
  * A component that allows displaying or selecting time.
  *
- * Set the {@link sandstone/TimePicker.TimePicker#value|value} property to a standard JavaScript
+ * Set the {@link sandstone/TimePicker.TimePicker.value|value} property to a standard JavaScript
  *  {@link /docs/developer-guide/glossary/#date|Date} object to initialize the picker.
  *
  * By default, `TimePicker` maintains the state of its `value` property. Supply the

--- a/TooltipDecorator/Tooltip.js
+++ b/TooltipDecorator/Tooltip.js
@@ -97,7 +97,7 @@ const TooltipBase = kind({
 		/**
 		 * Allows the tooltip to marquee.
 		 *
-		 * Specifying a {@link sandstone/TooltipDecorator.TooltipBase#width|width} restrects
+		 * Specifying a {@link sandstone/TooltipDecorator.TooltipBase.width|width} restrects
 		 * the marquee to that size.
 		 *
 		 * @type {Boolean}

--- a/TooltipDecorator/TooltipDecorator.js
+++ b/TooltipDecorator/TooltipDecorator.js
@@ -115,7 +115,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		/**
 		 * Allows the tooltip to marquee.
 		 *
-		 * Specifying a {@link sandstone/TooltipDecorator.TooltipDecorator#tooltipWidth|tooltipWidth}
+		 * Specifying a {@link sandstone/TooltipDecorator.TooltipDecorator.tooltipWidth|tooltipWidth}
 		 * restrects the marquee to that size.
 		 *
 		 * @type {Boolean}

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -1658,8 +1658,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Changes {@link sandstone/VideoPlayer.VideoPlayer#playbackRate|playbackRate} to a valid value
-	 * when initiating fast forward or rewind.
+	 * Changes playbackRate to a valid value when initiating fast forward or rewind.
 	 *
 	 * @param {Number} idx - The index of the desired playback rate.
 	 * @private
@@ -1684,7 +1683,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Sets {@link sandstone/VideoPlayer.VideoPlayer#playbackRate|playbackRate}.
+	 * Sets playbackRate.
 	 *
 	 * @param {Number|String} rate - The desired playback rate.
 	 * @private

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -1648,7 +1648,7 @@ const VideoPlayerBase = class extends Component {
 	};
 
 	/**
-	 * Sets the playback rate type (from the keys of {@link sandstone/VideoPlayer.VideoPlayer#playbackRateHash|playbackRateHash}).
+	 * Sets the playback rate type (from the keys of {@link sandstone/VideoPlayer.VideoPlayer.playbackRateHash|playbackRateHash}).
 	 *
 	 * @param {String} cmd - Key of the playback rate type.
 	 * @private

--- a/WizardPanels/Panel.js
+++ b/WizardPanels/Panel.js
@@ -70,7 +70,7 @@ const Panel = Slottable(
  *
  * If `false`, the button will not show. If set to a component, or `true`, the button will
  * show. This will override the setting of
- * {@link sandstone/WizardPanels.WizardPanels#nextButtonVisibility|nextButtonVisibility}.
+ * {@link sandstone/WizardPanels.WizardPanelsBase.nextButtonVisibility|nextButtonVisibility}.
  *
  * Example:
  * ```
@@ -90,7 +90,7 @@ const Panel = Slottable(
  *
  * If `false`, the button will not show. If set to a component, or `true`, the button will
  * show. This will override the setting of
- * {@link sandstone/WizardPanels.WizardPanels#prevButtonVisibility|prevButtonVisibility}.
+ * {@link sandstone/WizardPanels.WizardPanelsBase.prevButtonVisibility|prevButtonVisibility}.
  *
  * Example:
  * ```

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -795,7 +795,7 @@ PickerBase.propTypes = /** @lends sandstone/internal/Picker.Picker.prototype */ 
 	/**
 	 * Assign a custom icon for the decrementer. All strings supported by {@link sandstone/Icon.Icon|Icon} are
 	 * supported. Without a custom icon, the default is used, and is automatically changed when
-	 * the {@link sandstone/Icon.Icon#orientation|orientation} is changed.
+	 * the {@link sandstone/internal/Picker.PickerBase.orientation|orientation} is changed.
 	 *
 	 * @type {String}
 	 * @public
@@ -831,7 +831,7 @@ PickerBase.propTypes = /** @lends sandstone/internal/Picker.Picker.prototype */ 
 	/**
 	 * Assign a custom icon for the incrementer. All strings supported by {@link sandstone/Icon.Icon|Icon} are
 	 * supported. Without a custom icon, the default is used, and is automatically changed when
-	 * the {@link sandstone/Icon.Icon#orientation|orientation} is changed.
+	 * the {@link sandstone/internal/Picker.PickerBase.orientation|orientation} is changed.
 	 *
 	 * @type {String}
 	 * @public

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -732,8 +732,8 @@ PickerBase.propTypes = /** @lends sandstone/internal/Picker.Picker.prototype */ 
 	 *  * `'arrow'` allows the user to use the left or right keys to adjust the picker's value.
 	 *
 	 * The default value for joined horizontal picker is `'enter'`.
-	 * If {@link sandstone/internal/Picker.PickerBase#orientation|orientation} is `'vertical'` or
-	 * {@link sandstone/internal/Picker.PickerBase#joined|joined} is undefined or is `false`, this prop is ignored.
+	 * If {@link sandstone/internal/Picker.PickerBase.orientation|orientation} is `'vertical'` or
+	 * {@link sandstone/internal/Picker.PickerBase.joined|joined} is undefined or is `false`, this prop is ignored.
 	 *
 	 * @type {('enter'|'arrow')}
 	 * @default 'enter'


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There are broken links that refer to other `prop`s in the documentation.
Broken links
- https://enactjs.com/docs/modules/sandstone/Checkbox/#CheckboxBase.children
- https://enactjs.com/docs/modules/sandstone/CheckboxItem/#CheckboxItemBase.icon
- https://enactjs.com/docs/modules/sandstone/CheckboxItem/#CheckboxItemBase.indeterminateIcon
- https://enactjs.com/docs/modules/sandstone/FlexiblePopupPanels/#Panel.nextButton
- https://enactjs.com/docs/modules/sandstone/FlexiblePopupPanels/#Panel.prevButton
- https://enactjs.com/docs/modules/sandstone/FormCheckboxItem/#FormCheckboxItemBase.icon
- https://enactjs.com/docs/modules/sandstone/FormCheckboxItem/#FormCheckboxItemBase.indeterminateIcon
- https://enactjs.com/docs/modules/sandstone/Icon/#IconBase.children
- https://enactjs.com/docs/modules/sandstone/ImageItem/#ImageItemBase.placeholder
- https://enactjs.com/docs/modules/sandstone/Picker/#PickerBase.changedBy
- https://enactjs.com/docs/modules/sandstone/Picker/#PickerBase.decrementIcon
- https://enactjs.com/docs/modules/sandstone/Picker/#PickerBase.incrementIcon
- https://enactjs.com/docs/modules/sandstone/Popup/#Popup.onShow
- https://enactjs.com/docs/modules/sandstone/RangePicker/#RangePickerBase.changedBy
- https://enactjs.com/docs/modules/sandstone/RangePicker/#RangePickerBase.decrementIcon
- https://enactjs.com/docs/modules/sandstone/RangePicker/#RangePickerBase.incrementIcon
- https://enactjs.com/docs/modules/sandstone/Sprite/#Sprite.src
- https://enactjs.com/docs/modules/sandstone/TabLayout/#Tab.icon
- https://enactjs.com/docs/modules/sandstone/TimePicker/#TimePicker
- https://enactjs.com/docs/modules/sandstone/TooltipDecorator/#TooltipDecorator.tooltipMarquee
- https://enactjs.com/docs/modules/sandstone/TooltipDecorator/#TooltipBase.marquee
- https://enactjs.com/docs/modules/sandstone/WizardPanels/#Panel.PrevButton
- https://enactjs.com/docs/modules/sandstone/WizardPanels/#Panel.nextButton

Private broken links
- sandstone\Button\Button.js
  - 64,44
  - 67,11
  - 71,12
  - 79,26
  - 80,29
  - 84,12
- sandstone\Input\InputFieldDecoratorIcon.js 30,12
- sandstone\internal\Picker\Picker.js
  - 735,9
  - 736,6
- sandstone\VideoPlayer\VideoPlayer.js 1655,52

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix links to broken `prop`s in the documentation

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-11279

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
