### PR TITLE
WRP-12759:  Replace `noMultipleDrag` with `noMultipleSelect` and enhance functionality

### DIFF
--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -145,7 +145,7 @@ const TransferListBase = kind({
 		 * @type {Boolean}
 		 * @public
 		 */
-		noMultipleDrag: PropTypes.bool,
+		noMultipleSelect: PropTypes.bool,
 
 		/**
 		 * The orientation for the transfer list.
@@ -231,7 +231,7 @@ const TransferListBase = kind({
 		itemSize: 201,
 		listComponent: 'VirtualList',
 		moveOnSpotlight: false,
-		noMultipleDrag: false,
+		noMultipleSelect: false,
 		orientation: 'horizontal',
 		secondList: {},
 		setFirstList: null,
@@ -425,7 +425,7 @@ const TransferListBase = kind({
 		}
 	},
 
-	render: ({css, disabled, firstList, firstListMaxCapacity, firstListMinCapacity, firstListOperation, height: defaultHeight, itemSize: defaultItemSize, listComponent, moveOnSpotlight, noMultipleDrag, orientation, renderImageItem, renderItem, secondList, secondListMaxCapacity, secondListMinCapacity, secondListOperation, setFirstList, setSecondList, showSelectionOrder, verticalHeight}) => {
+	render: ({css, disabled, firstList, firstListMaxCapacity, firstListMinCapacity, firstListOperation, height: defaultHeight, itemSize: defaultItemSize, listComponent, moveOnSpotlight, noMultipleSelect, orientation, renderImageItem, renderItem, secondList, secondListMaxCapacity, secondListMinCapacity, secondListOperation, setFirstList, setSecondList, showSelectionOrder, verticalHeight}) => {
 		const [firstListLocal, setFirstListLocal] = useState(firstList);
 		const [position, setPosition] = useState(null);
 		const [secondListLocal, setSecondListLocal] = useState(secondList);
@@ -676,16 +676,20 @@ const TransferListBase = kind({
 
 		const setSelected = useCallback((element, index, list) => {
 			if (selectedItems.findIndex((newElement) => newElement.list === list) === -1 && selectedItems.length) return;
-			const potentialIndex = selectedItems.findIndex((pair) => pair.element === element && pair.list === list);
-			if (potentialIndex !== -1) {
-				setSelectedItems(items => {
-					items.splice(potentialIndex, 1);
-					return [...items];
-				});
+			if (noMultipleSelect) {
+				setSelectedItems([{element, index, list}]);
 			} else {
-				setSelectedItems(items => ([...items, {element, index, list}]));
+				const potentialIndex = selectedItems.findIndex((pair) => pair.element === element && pair.list === list);
+				if (potentialIndex !== -1) {
+					setSelectedItems(items => {
+						items.splice(potentialIndex, 1);
+						return [...items];
+					});
+				} else {
+					setSelectedItems(items => ([...items, {element, index, list}]));
+				}
 			}
-		}, [selectedItems]);
+		}, [selectedItems, noMultipleSelect]);
 
 		const reorderList = (list, index, inc, element) => {
 			if (list === 'first' && moveOnSpotlight) {
@@ -718,7 +722,7 @@ const TransferListBase = kind({
 			const draggedItem = sourceList[draggedElementIndex];
 			const elementPosition = isAboveDropPosition.current ? dragOverElementIndex : dragOverElementIndex + 1;
 
-			if (!noMultipleDrag) {
+			if (!noMultipleSelect) {
 				const potentialIndex = selectedItems.findIndex((pair) => pair.element === draggedItem);
 
 				if (potentialIndex === -1) {
@@ -763,7 +767,7 @@ const TransferListBase = kind({
 			dragOverElement.current = null;
 			setSourceList(sourceList);
 			setDestinationList(destinationList);
-		}, [firstListOperation, noMultipleDrag, secondListOperation, selectedItems]);
+		}, [firstListOperation, noMultipleSelect, secondListOperation, selectedItems]);
 
 		const getTransferData = (dataTransferObj) => {
 			if (dataTransferObj) {
@@ -794,7 +798,7 @@ const TransferListBase = kind({
 			const potentialIndex = selectedItems.findIndex((pair) => pair.element === firstListCopy[index] && pair.list === list);
 
 			const selectedListCopy = [...selectedItems];
-			if (!noMultipleDrag) {
+			if (!noMultipleSelect) {
 				selectedItems.map((item) => {
 					selectedListCopy.splice(selectedListCopy.findIndex((pair) => pair.element === item.element && pair.list === item.list), 1);
 				});
@@ -806,7 +810,7 @@ const TransferListBase = kind({
 			setPosition({index: ((selectedItems.length / 2) + parseInt(dragOverElement.current)) - 2, list: 'second'});
 
 			rearrangeLists(firstListCopy, secondListCopy, index, list, dragOverElement.current, setFirstListLocal, setSecondListLocal);
-		}, [firstListLocal, firstListMinCapacity, noMultipleDrag, rearrangeLists, secondListLocal, selectedItems, secondListMaxCapacity]);
+		}, [firstListLocal, firstListMinCapacity, noMultipleSelect, rearrangeLists, secondListLocal, selectedItems, secondListMaxCapacity]);
 
 		const onDropFirstHandler = useCallback((ev) => {
 			const {index, list} = getTransferData(ev.dataTransfer);
@@ -829,7 +833,7 @@ const TransferListBase = kind({
 
 			if (potentialIndex !== -1) {
 				const selectedListCopy = [...selectedItems];
-				if (!noMultipleDrag) {
+				if (!noMultipleSelect) {
 					selectedItems.map((item) => {
 						selectedListCopy.splice(selectedListCopy.findIndex((pair) => pair.element === item.element && pair.list === item.list), 1);
 					});
@@ -842,7 +846,7 @@ const TransferListBase = kind({
 			setPosition({index: ((selectedItems.length / 2) + parseInt(dragOverElement.current)) - 2, list: 'first'});
 
 			rearrangeLists(secondListCopy, firstListCopy, index, list, dragOverElement.current, setSecondListLocal, setFirstListLocal);
-		}, [firstListLocal, firstListMaxCapacity, noMultipleDrag, rearrangeLists, secondListLocal, selectedItems, secondListMinCapacity]);
+		}, [firstListLocal, firstListMaxCapacity, noMultipleSelect, rearrangeLists, secondListLocal, selectedItems, secondListMinCapacity]);
 
 		const handlePreventDefault = useCallback(ev => ev.preventDefault(), []);
 

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -676,18 +676,19 @@ const TransferListBase = kind({
 
 		const setSelected = useCallback((element, index, list) => {
 			if (selectedItems.findIndex((newElement) => newElement.list === list) === -1 && selectedItems.length) return;
-			if (noMultipleSelect) {
-				setSelectedItems([{element, index, list}]);
+			const potentialIndex = selectedItems.findIndex((pair) => pair.element === element && pair.list === list);
+			if (potentialIndex !== -1) {
+				setSelectedItems(items => {
+					items.splice(potentialIndex, 1);
+					return [...items];
+				});
 			} else {
-				const potentialIndex = selectedItems.findIndex((pair) => pair.element === element && pair.list === list);
-				if (potentialIndex !== -1) {
-					setSelectedItems(items => {
-						items.splice(potentialIndex, 1);
-						return [...items];
-					});
-				} else {
-					setSelectedItems(items => ([...items, {element, index, list}]));
-				}
+				setSelectedItems(items => {
+					if (noMultipleSelect) {
+						return [{element, index, list}];
+					}
+					return [...items, {element, index, list}];
+				});
 			}
 		}, [selectedItems, noMultipleSelect]);
 

--- a/samples/sampler/stories/default/TransferList.js
+++ b/samples/sampler/stories/default/TransferList.js
@@ -22,7 +22,7 @@ export const _TransferList = (args) => (
 		itemSize={args['itemSize']}
 		listComponent={args['listComponent']}
 		moveOnSpotlight={args['moveElementOnSpotlightDirections']}
-		noMultipleDrag={args['noMultipleDrag']}
+		noMultipleSelect={args['noMultipleSelect']}
 		orientation={args['orientation']}
 		secondList={['HBO', 'Comedy Central', 'HGTV', 'CBS', 'Cartoon Network', 'AXN', 'Disney Channel', 'BBC Food']}
 		secondListMaxCapacity={args['secondListMaxCapacity']}
@@ -39,7 +39,7 @@ select('firstListOperation', _TransferList, ['move', 'copy', 'delete'], Config, 
 number('itemSize', _TransferList, Config, 201);
 select('listComponent', _TransferList, ['VirtualList', 'VirtualGridList'], Config, 'VirtualList');
 boolean('moveElementOnSpotlightDirections', _TransferList, Config, false);
-boolean('noMultipleDrag', _TransferList, Config, false);
+boolean('noMultipleSelect', _TransferList, Config, false);
 select('orientation', _TransferList, ['horizontal', 'vertical'], Config, 'horizontal');
 number('secondListMinCapacity', _TransferList, Config);
 number('secondListMaxCapacity', _TransferList, Config);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Replace 'noMultipleDrag' prop with 'noMultipleSelect' and modify the behaviour to disallow selecting multiple items while 'noMultipleSelect' prop is true.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
 If an item is already selected while the 'noMultipleSelect' prop is true, selecting a new item should automatically deselect the previously selected one.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-12759

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com