### PR TITLE
WRP-13634: Fixed `VideoPlayer` to read out 'time' on a slider

### DIFF
--- a/MediaPlayer/MediaSliderDecorator.js
+++ b/MediaPlayer/MediaSliderDecorator.js
@@ -105,7 +105,7 @@ const MediaSliderDecorator = hoc((config, Wrapped) => {
 
 		componentDidUpdate (prevProps, prevState) {
 			if (prevState.x !== this.state.x) {
-				forwardCustom('onKnobMove')(this.getEventPayload(), this.props);
+				forwardCustom('onKnobMove', ev => ev)(this.getEventPayload(), this.props);
 			}
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`VideoPlayer` does not read out 'time' when the focus is moving on a slider.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The root cause is a missing adapter function for `forwardCustom` when a internal module passes 'time' information for `VideoPlayer`.
To fix this issue, I added an adapter function.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
No changelog as this bug occurs after the latest release.

### Links
[//]: # (Related issues, references)
WRP-13634

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)