### PR TITLE
WRP-13074: call getLastInputType method only when it's available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Picker` to include `type` in the event payload for `onChange`
 - `sandstone/Scroller` and `sandstone/VirtualList` to handle focus properly via page up at the first page and page down at the last page
+- `sandstone/ThemeDecorator` to call the API checking the last input type only when it's available
 - `sandstone/WizardPanels` to restore focus properly after a transition
 
 ## [2.6.3] - 2023-03-17

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -179,6 +179,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	});
 
 	let requestInputType = null;
+	let getLastInputTypeApiAvailable = false;
 
 	let App = Wrapped;
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
@@ -256,8 +257,22 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			skin: PropTypes.string
 		};
 
+		constructor (props) {
+			super(props);
+
+			if (platform.webos) {
+				new LS2Request().send({
+					service: 'luna://com.webos.surfacemanager',
+					method: 'com/palm/luna/private/introspection',
+					onSuccess: function ({'/': apiList}) {
+						getLastInputTypeApiAvailable = Object.prototype.hasOwnProperty.call(apiList, 'getLastInputType');
+					}
+				});
+			}
+		}
+
 		componentDidMount () {
-			if (spotlight && platform.webos) {
+			if (spotlight && platform.webos && getLastInputTypeApiAvailable) {
 				activateInputType(true);
 				requestInputType = new LS2Request().send({
 					service: 'luna://com.webos.surfacemanager',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This issue was raised because we unconditionally execute `getLastInputType` LS call without checking for the existence of the function. So, `surface-manager` reports an `LS_NO_METH` error on RP-based platforms.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The `getLastInputType` method only exists on TV platforms, not RP or OSE. So we need to check the function's existence first before calling the function.

We can query the API method list using a special method.
- `com/palm/luna/private/introspection`

Using this API, ThemeDecorator checks the existence of `getLastInputType` function in `constructor` and calls the function only when it is available in `componentDidMount`.

Please take a look at the commit message for more details. [9d35bbb](https://github.com/enactjs/sandstone/commit/9d35bbb7c03a078b96c8491cfe556a5edef667db)
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
`surface-manager` should not report an `LS_NO_METH` error anymore on RP-based platforms.

### Links
[//]: # (Related issues, references)
WRP-13074

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
