### PR TITLE
WRP-13858:Sampler: add hoverToScroll in bottomComponents of VideoPlayer

### DIFF
--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -195,6 +195,7 @@ export const _VideoPlayer = (args) => {
 							}}
 							itemRenderer={renderItem}
 							spacing={ri.scale(12)}
+							hoverToScroll
 						/>
 					</bottomComponents>
 					<Button size="small" icon="list" />


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There was a UX requirement to enable hoverToScroll in bottomComponents of videoPlayer.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In sampler (VideoPlayer), when we click the more button, virtualList appears. Make virtualList be able to scroll by hovering both edge sides.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-13858

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
