### PR TITLE
WRP-12385:TooltipDecorator: add unit-test for useTooltip

### DIFF
--- a/TooltipDecorator/tests/useTooltip-specs.js
+++ b/TooltipDecorator/tests/useTooltip-specs.js
@@ -1,0 +1,255 @@
+import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
+import '@testing-library/jest-dom';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+
+import Button from '../../Button';
+
+import {defaultScreenEdgeKeepout, useTooltip} from "../useTooltip";
+
+const FloatingLayerController = FloatingLayerDecorator('div');
+
+describe('useTooltip', () => {
+	const TooltipButton = ({
+		screenEdgeKeepout = defaultScreenEdgeKeepout,
+		tooltipDestinationProp = 'children',
+		children,
+		...rest
+	}) => {
+		const {tooltip, handlers, restProps} = useTooltip({screenEdgeKeepout, ...rest});
+
+		if (tooltip) {
+			if (tooltipDestinationProp === 'children') {
+				restProps.children = [children, tooltip];
+			} else {
+				restProps[tooltipDestinationProp] = tooltip;
+			}
+		}
+
+		return <Button {...restProps} {...handlers} />;
+	};
+
+	describe('Tooltip', () => {
+		beforeEach(() => {
+			global.Element.prototype.getBoundingClientRect = jest.fn(() => {
+				return {
+					width: 501,
+					height: 501,
+					top: 99,
+					left: 99,
+					bottom: 0,
+					right: 0
+				};
+			});
+		});
+
+		test('should render a tooltip if hovered', async () => {
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+		});
+
+		test('should hide tooltip if not hovered', async () => {
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+
+			act(() => button.blur());
+			fireEvent.mouseOut(button);
+
+			await waitFor(() => {
+				expect(screen.queryByText('Tooltip')).not.toBeInTheDocument();
+			});
+		});
+
+		test('should hide tooltip if not hovered (disabled)', async () => {
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipText={tooltipText} disabled>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+
+			expect(button).toHaveAttribute('disabled');
+
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+
+			act(() => button.blur());
+			fireEvent.mouseOut(button);
+
+			await waitFor(() => {
+				expect(screen.queryByText('Tooltip')).not.toBeInTheDocument();
+			});
+		});
+
+		test('should render a tooltip if keydown', async () => {
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.keyDown(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+		});
+
+		test('should render a tooltip if hovered for \'tooltipRelative\'', async () => {
+			console.error = jest.fn();	// eslint-disable-line no-console
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipRelative tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+		});
+
+		describe('Tooltip position', () => {
+			test('should have \'above\' className when tooltipPosition is set to \'above\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="above" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+
+				button.getBoundingClientRect = jest.fn(() => {
+					return {
+						width: 300,
+						height: 300,
+						top: 600,
+						left: 600,
+						bottom: 0,
+						right: 0
+					};
+				});
+
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip above';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have \'below\' className when tooltipPosition is set to \'below\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="below" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+
+				button.getBoundingClientRect = jest.fn(() => {
+					return {
+						width: 300,
+						height: 300,
+						top: 600,
+						left: 600,
+						bottom: 0,
+						right: 0
+					};
+				});
+
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+
+					const expected = 'tooltip below';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have \'left middle\' className when tooltipPosition is set to \'left middle\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="left middle" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip left middleArrow';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have \'right middle\' className when tooltipPosition is set to \'right middle\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="right middle" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip right middleArrow';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+		});
+	});
+});

--- a/TooltipDecorator/tests/useTooltip-specs.js
+++ b/TooltipDecorator/tests/useTooltip-specs.js
@@ -11,18 +11,13 @@ const FloatingLayerController = FloatingLayerDecorator('div');
 describe('useTooltip', () => {
 	const TooltipButton = ({
 		screenEdgeKeepout = defaultScreenEdgeKeepout,
-		tooltipDestinationProp = 'children',
 		children,
 		...rest
 	}) => {
 		const {tooltip, handlers, restProps} = useTooltip({screenEdgeKeepout, ...rest});
 
 		if (tooltip) {
-			if (tooltipDestinationProp === 'children') {
-				restProps.children = [children, tooltip];
-			} else {
-				restProps[tooltipDestinationProp] = tooltip;
-			}
+			restProps.children = [children, tooltip];
 		}
 
 		return <Button {...restProps} {...handlers} />;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As for the following PR for #1401, we'd like to add unit tests for useTooltip component which was missing.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add unit tests for useTooltip.
The below unit tests are derived from TooltipDecorator-specs.js, and two more unit tests (+) are added to increase code covarage.

Unit Tests
- render a tooltip if hovered
- hide tooltip if not hovered
- (+) hide tooltip if not hovered (disabled)
- (+) render a tooltip if keydown
- render a tooltip if hovered for 'tooltipRelative'
- Tooltip position
  - tooltipPosition is set to 'above'
  - tooltipPosition is set to 'below'
  - tooltipPosition is set to 'left middle'
  - tooltipPosition is set to 'right middle'

Code Coverage
| File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
| -------------- | --------- | ---------- | ---------- | -------- | -------------------- |
|  useTooltip.js |     96.49 |        88.33 |           95 |     96.49 |    140,172,190,222 |

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-12385
#1401

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
