### PR TITLE
WRP-14562:WizardPanels: fix audio guidance for step when using `current`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` and `sandstone/VirtualList` to stop scrolling by `hoverToScroll` when the pointer disappears
 - `sandstone/VideoPlayer` to focus the play/pause button when the playback controls is shown using the 5-way down key
+- `sandstone/WizardPanels` to read out the correct step when using `current` prop
 
 ## [2.7.0] - 2023-04-25
 

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -332,10 +332,11 @@ const WizardPanelsBase = kind({
 	},
 
 	computed: {
-		'aria-label': ({'aria-label': label, index, noSteps, subtitle, title}) => {
+		'aria-label': ({'aria-label': label, current, index, noSteps, subtitle, title}) => {
 			if (label) return label;
 
-			const step = noSteps ? '' : new IString($L('step {num}')).format({num: index + 1}) + ' ';
+			const stepNum = (typeof current === 'number' && current > 0) ? current : (index + 1);
+			const step = noSteps ? '' : new IString($L('step {num}')).format({num: stepNum}) + ' ';
 			return `${step}${title} ${subtitle}`;
 		},
 		className: ({noSteps, noSubtitle, styler}) => styler.append(

--- a/WizardPanels/tests/WizardPanels-specs.js
+++ b/WizardPanels/tests/WizardPanels-specs.js
@@ -782,7 +782,7 @@ describe('WizardPanel Specs', () => {
 		'should reflect the aria-label when "current" is set',
 		async () => {
 			const current = 2;
-			const {container} = render(
+			render(
 				<WizardPanels current={current}>
 					<Panel />
 					<Panel />
@@ -790,7 +790,7 @@ describe('WizardPanel Specs', () => {
 				</WizardPanels>
 			);
 
-			const header = container.querySelector('header');
+			const header = screen.getByRole('region').children[0].children[0];
 			const expected = `step ${current}  `;
 
 			await waitFor(() => {

--- a/WizardPanels/tests/WizardPanels-specs.js
+++ b/WizardPanels/tests/WizardPanels-specs.js
@@ -779,6 +779,27 @@ describe('WizardPanel Specs', () => {
 	);
 
 	test(
+		'should reflect the aria-label when "current" is set',
+		async () => {
+			const current = 2;
+			const {container} = render(
+				<WizardPanels current={current}>
+					<Panel />
+					<Panel />
+					<Panel />
+				</WizardPanels>
+			);
+
+			const header = container.querySelector('header');
+			const expected = `step ${current}  `;
+
+			await waitFor(() => {
+				expect(header).toHaveAttribute('aria-label', expected);
+			});
+		}
+	);
+
+	test(
 		'should return a ref to the root Panel node',
 		() => {
 			const ref = jest.fn();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Even when WizardPanels passes value using the `current` prop, `aria-label` always reads "step 1".

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Depending on the value of the passed `current` prop, the value of `aria-label` is read correctly as `step ${current}`.
Please check the commit message for more details. [4ce0d6a9](https://github.com/enactjs/sandstone/commit/4ce0d6a94713bd526c35c7e5cdb8bd938cd9cd54)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
All unit tests must pass for `WizardPanels/tests/`
`npm run test WizardPanels/tests/`

### Links
[//]: # (Related issues, references)
WRP-14562

### Comments
Enact-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
