### PR TITLE
WRP-14783: Apply touch events on TransferList

### DIFF
--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -453,7 +453,7 @@ const TransferListBase = kind({
 			scrollToRefSecond.current = scrollTo;
 		}, []);
 
-		const applyDropBorder = (element, ev, isAboveCurrentElement, isBelowCurrentElement) => {
+		const applyDropBorder = useCallback((element, ev, isAboveCurrentElement, isBelowCurrentElement) => {
 			if (startDragElement.current !== element && (!isVertical || !isDefaultListComponent)) {
 				if ((ev.offsetY < currentElement.current.offsetHeight / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
 					currentElement.current.classList.add(`${css.overAbove}`);
@@ -475,14 +475,14 @@ const TransferListBase = kind({
 					isAboveDropPosition.current = false;
 				}
 			}
-		};
+		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, isDefaultListComponent, isVertical]);
 
-		const removeDropBorder = (element) => {
+		const removeDropBorder = useCallback((element) => {
 			element.classList.remove(`${css.overAbove}`);
 			element.classList.remove(`${css.overBelow}`);
 			element.classList.remove(`${css.overLeft}`);
 			element.classList.remove(`${css.overRight}`);
-		};
+		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight]);
 
 		const rearrangeList = (dragOverElementIndex, itemIndex, list, listName, setNewList) => {
 			const draggedItem = list[itemIndex];
@@ -551,7 +551,7 @@ const TransferListBase = kind({
 			}
 
 			removeDropBorder(element);
-		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight]);
+		}, [removeDropBorder]);
 
 		const dragoverListenerFunction = useCallback((ev) => {
 			let element;
@@ -570,7 +570,7 @@ const TransferListBase = kind({
 			dragOverElement.current = parseInt(element.id.split('-')[0]);
 
 			applyDropBorder(element, ev, isAboveCurrentElement, isBelowCurrentElement);
-		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, isDefaultListComponent, isVertical]);
+		}, [applyDropBorder]);
 
 		const startListenerFunction = useCallback((ev) => {
 			const element = ev.target;
@@ -616,7 +616,7 @@ const TransferListBase = kind({
 					setTouchOverElement(element);
 				}
 			}
-		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, isDefaultListComponent, isVertical, touchOverElement]);
+		}, [applyDropBorder, removeDropBorder, touchOverElement]);
 
 		const handleTouchEndFirst = useCallback((ev) => {
 			let element = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY).closest('[draggable]');
@@ -661,7 +661,7 @@ const TransferListBase = kind({
 			rearrangeLists(firstListCopy, secondListCopy, startElementIndex, startElementList, dragOverElement.current, setFirstListLocal, setSecondListLocal);
 
 			removeDropBorder(element);
-		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, firstListLocal, firstListMaxCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMinCapacity, selectedItems]);
+		}, [removeDropBorder, firstListLocal, firstListMaxCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMinCapacity, selectedItems]);
 
 		const handleTouchEndSecond = useCallback((ev) => {
 			let element = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY).closest('[draggable]');
@@ -700,14 +700,14 @@ const TransferListBase = kind({
 					selectedListCopy.splice(potentialIndex, 1);
 				}
 				setSelectedItems(selectedListCopy);
-			};
+			}
 
 			setPosition({index: ((selectedItems.length / 2) + parseInt(dragOverElement.current)) - 2, list: 'second'});
 
 			rearrangeLists(secondListCopy, firstListCopy, startElementIndex, startElementList, dragOverElement.current, setSecondListLocal, setFirstListLocal);
 
 			removeDropBorder(element);
-		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, firstListLocal, firstListMinCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMaxCapacity, selectedItems]);
+		}, [removeDropBorder, firstListLocal, firstListMinCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMaxCapacity, selectedItems]);
 
 		const handleScroll = useCallback(() => {
 			const selectCheckboxItem = document.querySelectorAll(`.${css.draggableItem}`);

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -453,6 +453,37 @@ const TransferListBase = kind({
 			scrollToRefSecond.current = scrollTo;
 		}, []);
 
+		const applyDropBorder = (element, ev, isAboveCurrentElement, isBelowCurrentElement) => {
+			if (startDragElement.current !== element && (!isVertical || !isDefaultListComponent)) {
+				if ((ev.offsetY < currentElement.current.offsetHeight / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
+					currentElement.current.classList.add(`${css.overAbove}`);
+					currentElement.current.classList.remove(`${css.overBelow}`);
+					isAboveDropPosition.current = true;
+				} else {
+					currentElement.current.classList.add(`${css.overBelow}`);
+					currentElement.current.classList.remove(`${css.overAbove}`);
+					isAboveDropPosition.current = false;
+				}
+			} else if (startDragElement.current !== element) {
+				if ((ev.offsetX < currentElement.current.offsetWidth / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
+					currentElement.current.classList.add(`${css.overLeft}`);
+					currentElement.current.classList.remove(`${css.overRight}`);
+					isAboveDropPosition.current = true;
+				} else {
+					currentElement.current.classList.add(`${css.overRight}`);
+					currentElement.current.classList.remove(`${css.overLeft}`);
+					isAboveDropPosition.current = false;
+				}
+			}
+		};
+
+		const removeDropBorder = (element) => {
+			element.classList.remove(`${css.overAbove}`);
+			element.classList.remove(`${css.overBelow}`);
+			element.classList.remove(`${css.overLeft}`);
+			element.classList.remove(`${css.overRight}`);
+		};
+
 		const rearrangeList = (dragOverElementIndex, itemIndex, list, listName, setNewList) => {
 			const draggedItem = list[itemIndex];
 			list.splice(itemIndex, 1);
@@ -519,10 +550,7 @@ const TransferListBase = kind({
 				element = ev.currentTarget;
 			}
 
-			element.classList.remove(`${css.overAbove}`);
-			element.classList.remove(`${css.overBelow}`);
-			element.classList.remove(`${css.overLeft}`);
-			element.classList.remove(`${css.overRight}`);
+			removeDropBorder(element);
 		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight]);
 
 		const dragoverListenerFunction = useCallback((ev) => {
@@ -541,27 +569,7 @@ const TransferListBase = kind({
 			currentElement.current = dragOverOrder > 0 ? element : currentElement.current;
 			dragOverElement.current = parseInt(element.id.split('-')[0]);
 
-			if (startDragElement.current !== element && (!isVertical || !isDefaultListComponent)) {
-				if ((ev.offsetY < currentElement.current.offsetHeight / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
-					currentElement.current.classList.add(`${css.overAbove}`);
-					currentElement.current.classList.remove(`${css.overBelow}`);
-					isAboveDropPosition.current = true;
-				} else {
-					currentElement.current.classList.add(`${css.overBelow}`);
-					currentElement.current.classList.remove(`${css.overAbove}`);
-					isAboveDropPosition.current = false;
-				}
-			} else if (startDragElement.current !== element) {
-				if ((ev.offsetX < currentElement.current.offsetWidth / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
-					currentElement.current.classList.add(`${css.overLeft}`);
-					currentElement.current.classList.remove(`${css.overRight}`);
-					isAboveDropPosition.current = true;
-				} else {
-					currentElement.current.classList.add(`${css.overRight}`);
-					currentElement.current.classList.remove(`${css.overLeft}`);
-					isAboveDropPosition.current = false;
-				}
-			}
+			applyDropBorder(element, ev, isAboveCurrentElement, isBelowCurrentElement);
 		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, isDefaultListComponent, isVertical]);
 
 		const startListenerFunction = useCallback((ev) => {
@@ -596,57 +604,14 @@ const TransferListBase = kind({
 				dragOverElement.current = parseInt(element.id.split('-')[0]);
 
 				if (touchOverElement && touchOverElement !== element) {
-					touchOverElement.classList.remove(`${css.overAbove}`);
-					touchOverElement.classList.remove(`${css.overBelow}`);
-					touchOverElement.classList.remove(`${css.overLeft}`);
-					touchOverElement.classList.remove(`${css.overRight}`);
+					removeDropBorder(touchOverElement);
 
-					if (startDragElement.current !== element && (!isVertical || !isDefaultListComponent)) {
-						if ((ev.offsetY < currentElement.current.offsetHeight / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
-							currentElement.current.classList.add(`${css.overAbove}`);
-							currentElement.current.classList.remove(`${css.overBelow}`);
-							isAboveDropPosition.current = true;
-						} else {
-							currentElement.current.classList.add(`${css.overBelow}`);
-							currentElement.current.classList.remove(`${css.overAbove}`);
-							isAboveDropPosition.current = false;
-						}
-					} else if (startDragElement.current !== element) {
-						if ((ev.offsetX < currentElement.current.offsetWidth / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
-							currentElement.current.classList.add(`${css.overLeft}`);
-							currentElement.current.classList.remove(`${css.overRight}`);
-							isAboveDropPosition.current = true;
-						} else {
-							currentElement.current.classList.add(`${css.overRight}`);
-							currentElement.current.classList.remove(`${css.overLeft}`);
-							isAboveDropPosition.current = false;
-						}
-					}
+					applyDropBorder(element, ev, isAboveCurrentElement, isBelowCurrentElement);
 
 					setTouchOverElement(element);
 
 				} else {
-					if (startDragElement.current !== element && (!isVertical || !isDefaultListComponent)) {
-						if ((ev.offsetY < currentElement.current.offsetHeight / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
-							currentElement.current.classList.add(`${css.overAbove}`);
-							currentElement.current.classList.remove(`${css.overBelow}`);
-							isAboveDropPosition.current = true;
-						} else {
-							currentElement.current.classList.add(`${css.overBelow}`);
-							currentElement.current.classList.remove(`${css.overAbove}`);
-							isAboveDropPosition.current = false;
-						}
-					} else if (startDragElement.current !== element) {
-						if ((ev.offsetX < currentElement.current.offsetWidth / 3 || isAboveCurrentElement) && !isBelowCurrentElement) {
-							currentElement.current.classList.add(`${css.overLeft}`);
-							currentElement.current.classList.remove(`${css.overRight}`);
-							isAboveDropPosition.current = true;
-						} else {
-							currentElement.current.classList.add(`${css.overRight}`);
-							currentElement.current.classList.remove(`${css.overLeft}`);
-							isAboveDropPosition.current = false;
-						}
-					}
+					applyDropBorder(element, ev, isAboveCurrentElement, isBelowCurrentElement);
 
 					setTouchOverElement(element);
 				}
@@ -672,10 +637,7 @@ const TransferListBase = kind({
 
 				rearrangeList(dragOverElement.current, startElementIndex, firstListCopy, list, setFirstListLocal);
 
-				element.classList.remove(`${css.overAbove}`);
-				element.classList.remove(`${css.overBelow}`);
-				element.classList.remove(`${css.overLeft}`);
-				element.classList.remove(`${css.overRight}`);
+				removeDropBorder(element);
 
 				return;
 			}
@@ -698,10 +660,7 @@ const TransferListBase = kind({
 
 			rearrangeLists(firstListCopy, secondListCopy, startElementIndex, startElementList, dragOverElement.current, setFirstListLocal, setSecondListLocal);
 
-			element.classList.remove(`${css.overAbove}`);
-			element.classList.remove(`${css.overBelow}`);
-			element.classList.remove(`${css.overLeft}`);
-			element.classList.remove(`${css.overRight}`);
+			removeDropBorder(element);
 		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, firstListLocal, firstListMaxCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMinCapacity, selectedItems]);
 
 		const handleTouchEndSecond = useCallback((ev) => {
@@ -724,10 +683,7 @@ const TransferListBase = kind({
 
 				rearrangeList(dragOverElement.current, startElementIndex, secondListCopy, list, setSecondListLocal);
 
-				element.classList.remove(`${css.overAbove}`);
-				element.classList.remove(`${css.overBelow}`);
-				element.classList.remove(`${css.overLeft}`);
-				element.classList.remove(`${css.overRight}`);
+				removeDropBorder(element);
 
 				return;
 			}
@@ -750,10 +706,7 @@ const TransferListBase = kind({
 
 			rearrangeLists(secondListCopy, firstListCopy, startElementIndex, startElementList, dragOverElement.current, setSecondListLocal, setFirstListLocal);
 
-			element.classList.remove(`${css.overAbove}`);
-			element.classList.remove(`${css.overBelow}`);
-			element.classList.remove(`${css.overLeft}`);
-			element.classList.remove(`${css.overRight}`);
+			removeDropBorder(element);
 		}, [css.overAbove, css.overBelow, css.overLeft, css.overRight, firstListLocal, firstListMinCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMaxCapacity, selectedItems]);
 
 		const handleScroll = useCallback(() => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
TransferList uses the drag and drop API which does not work on webOS TV. We need to adapt it to work on webOS by using touch events. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added touch events for TransferList to work on webOS.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-14783

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop (stanca.pop@lgepartner.com)