### PR TITLE
WRP-15428: Add hiding element feature to EditableScroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/Scroller` to support hiding items when `editable` is given
+
 ### Fixed
 
 - `sandstone/Scroller` and `sandstone/VirtualList` to stop scrolling by `hoverToScroll` when the pointer disappears

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -394,6 +394,7 @@ const EditableWrapper = (props) => {
 		const {prevToIndex, selectedItem} = mutableRef.current;
 
 		if (selectedItem) {
+			// rearrangedItems need for the case when removing item while moving selected item
 			const rearrangedItems = mutableRef.current.rearrangedItems;
 			const selectedItemRect = selectedItem && selectedItem.getBoundingClientRect();
 			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
@@ -414,15 +415,16 @@ const EditableWrapper = (props) => {
 		const {selectedItem} = mutableRef.current;
 
 		if (selectedItem) {
-			const ordernum = Number(selectedItem.style.order);
+			// rearrangedItems need for the case when hiding item while moving selected item
 			const rearrangedItems = mutableRef.current.rearrangedItems;
+			const selectedItemOrder = Number(selectedItem.style.order);
 			const selectedItemRect = selectedItem && selectedItem.getBoundingClientRect();
 			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
 			mutableRef.current.hideIndex -= 1;
 
 			const orders = finalizeOrders();
-			orders.splice(orders.indexOf(ordernum), 1);
-			orders.push(ordernum);
+			orders.splice(orders.indexOf(selectedItemOrder), 1);
+			orders.push(selectedItemOrder);
 			rearrangedItems.forEach(item => {
 				item.style.order -= 1;
 			});
@@ -435,14 +437,15 @@ const EditableWrapper = (props) => {
 
 	const showItem = useCallback(() => {
 		const {selectedItem} = mutableRef.current;
+
 		if (selectedItem) {
+			const selectedItemOrder = Number(selectedItem.style.order);
 			const selectedItemRect = selectedItem && selectedItem.getBoundingClientRect();
 			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
 
 			const orders = Array.from({length: dataSize}, (_, i) => i + 1);
-			const selectedItemOrder = selectedItem.style.order;
 			orders.splice(selectedItemOrder - 1, 1);
-			orders.splice(mutableRef.current.hideIndex, 0, Number(selectedItemOrder));
+			orders.splice(mutableRef.current.hideIndex, 0, selectedItemOrder);
 
 			mutableRef.current.hideIndex += 1;
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -67,7 +67,7 @@ const holdConfig = {
 const EditableWrapper = (props) => {
 	const {children, editable, scrollContainerHandle, scrollContainerRef, scrollContentRef} = props;
 	const centered = editable?.centered != null ? editable.centered : true;
-	const selectItemBy = editable?.selectItemBy || 'press';
+	const selectItemBy = editable?.selectItemBy || 'longPress';
 	const customCss = editable?.css || {};
 	const removeItemFuncRef = editable?.removeItemFuncRef;
 	const hideItemFuncRef = editable?.hideItemFuncRef;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -432,12 +432,13 @@ const EditableWrapper = (props) => {
 		if (selectedItem) {
 			const selectedItemRect = selectedItem && selectedItem.getBoundingClientRect();
 			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
-			mutableRef.current.hideIndex += 1;
 
 			const orders = Array.from({length: dataSize}, (_, i) => i + 1);
 			const selectedItemOrder = selectedItem.style.order;
 			orders.splice(selectedItemOrder - 1, 1);
 			orders.splice(mutableRef.current.hideIndex, 0, Number(selectedItemOrder));
+
+			mutableRef.current.hideIndex += 1;
 
 			forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
 			reset();

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -41,8 +41,8 @@ const EditableShape = PropTypes.shape({
 	centered: PropTypes.bool,
 	css: PropTypes.object,
 	hideItemFuncRef: EnactPropTypes.ref,
-	longPressMode: PropTypes.bool,
 	removeItemFuncRef: EnactPropTypes.ref,
+	selectItemBy: PropTypes.string,
 	showItemFuncRef: EnactPropTypes.ref
 });
 
@@ -67,7 +67,7 @@ const holdConfig = {
 const EditableWrapper = (props) => {
 	const {children, editable, scrollContainerHandle, scrollContainerRef, scrollContentRef} = props;
 	const centered = editable?.centered != null ? editable.centered : true;
-	const longPressMode = editable?.longPressMode;
+	const selectItemBy = editable?.selectItemBy || 'press';
 	const customCss = editable?.css || {};
 	const removeItemFuncRef = editable?.removeItemFuncRef;
 	const hideItemFuncRef = editable?.hideItemFuncRef;
@@ -224,7 +224,7 @@ const EditableWrapper = (props) => {
 			mutableRef.current.needToPreventEvent = true;
 		} else {
 			const targetItemNode = findItemNode(ev.target);
-			if (!longPressMode) {
+			if (selectItemBy === 'press') {
 				if (targetItemNode && targetItemNode.dataset.index) {
 					// Start editing by adding selected transition to selected item
 					mutableRef.current.targetItemNode = targetItemNode;
@@ -235,7 +235,7 @@ const EditableWrapper = (props) => {
 			}
 			mutableRef.current.needToPreventEvent = false;
 		}
-	}, [editable, finalizeOrders, findItemNode, longPressMode, reset, startEditing]);
+	}, [editable, finalizeOrders, findItemNode, reset, selectItemBy, startEditing]);
 
 	const handleHoldStart = useCallback(() => {
 		const {targetItemNode} = mutableRef.current;
@@ -521,7 +521,7 @@ const EditableWrapper = (props) => {
 							true
 						);
 					}, completeAnnounceDelay);
-				} else if (!longPressMode) {
+				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
 				}
 			} else if (repeat && targetItemNode && !mutableRef.current.timer) {
@@ -542,7 +542,7 @@ const EditableWrapper = (props) => {
 				ev.stopPropagation();
 			}
 		}
-	}, [editable, finalizeOrders, findItemNode, longPressMode, moveItemsByKeyDown, reset, startEditing]);
+	}, [editable, finalizeOrders, findItemNode, moveItemsByKeyDown, reset, selectItemBy, startEditing]);
 
 	const handleKeyUpCapture = useCallback((ev) => {
 		mutableRef.current.lastKeyEventTargetElement = ev.target;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -41,6 +41,7 @@ const EditableShape = PropTypes.shape({
 	centered: PropTypes.bool,
 	css: PropTypes.object,
 	hideItemFuncRef: EnactPropTypes.ref,
+	longPressMode: PropTypes.bool,
 	removeItemFuncRef: EnactPropTypes.ref,
 	showItemFuncRef: EnactPropTypes.ref
 });
@@ -66,6 +67,7 @@ const holdConfig = {
 const EditableWrapper = (props) => {
 	const {children, editable, scrollContainerHandle, scrollContainerRef, scrollContentRef} = props;
 	const centered = editable?.centered != null ? editable.centered : true;
+	const longPressMode = editable?.longPressMode;
 	const customCss = editable?.css || {};
 	const removeItemFuncRef = editable?.removeItemFuncRef;
 	const hideItemFuncRef = editable?.hideItemFuncRef;
@@ -222,14 +224,18 @@ const EditableWrapper = (props) => {
 			mutableRef.current.needToPreventEvent = true;
 		} else {
 			const targetItemNode = findItemNode(ev.target);
-			if (targetItemNode && targetItemNode.dataset.index) {
-				// Start editing by adding selected transition to selected item
+			if (!longPressMode) {
+				if (targetItemNode && targetItemNode.dataset.index) {
+					// Start editing by adding selected transition to selected item
+					mutableRef.current.targetItemNode = targetItemNode;
+					startEditing(targetItemNode);
+				}
+			} else {
 				mutableRef.current.targetItemNode = targetItemNode;
-				startEditing(targetItemNode);
 			}
 			mutableRef.current.needToPreventEvent = false;
 		}
-	}, [editable, finalizeOrders, findItemNode, reset, startEditing]);
+	}, [editable, finalizeOrders, findItemNode, longPressMode, reset, startEditing]);
 
 	const handleHoldStart = useCallback(() => {
 		const {targetItemNode} = mutableRef.current;
@@ -512,7 +518,7 @@ const EditableWrapper = (props) => {
 							true
 						);
 					}, completeAnnounceDelay);
-				} else {
+				} else if (!longPressMode) {
 					startEditing(targetItemNode);
 				}
 			} else if (repeat && targetItemNode && !mutableRef.current.timer) {
@@ -533,7 +539,7 @@ const EditableWrapper = (props) => {
 				ev.stopPropagation();
 			}
 		}
-	}, [editable, finalizeOrders, findItemNode, moveItemsByKeyDown, reset, startEditing]);
+	}, [editable, finalizeOrders, findItemNode, longPressMode, moveItemsByKeyDown, reset, startEditing]);
 
 	const handleKeyUpCapture = useCallback((ev) => {
 		mutableRef.current.lastKeyEventTargetElement = ev.target;

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -288,7 +288,7 @@ export const EditableIconWithLongPress = (args) => {
 				css,
 				hideIndex: mutableRef.current.hideIndex,
 				onComplete: handleComplete,
-				removeItemFuncRef: removeItem,
+				removeItemFuncRef: removeItem
 			}}
 			focusableScrollbar={args['focusableScrollbar']}
 			horizontalScrollbar={args['horizontalScrollbar']}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -164,7 +164,8 @@ export const EditableIcon = (args) => {
 							onComplete: handleComplete,
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
-							showItemFuncRef: showItem
+							showItemFuncRef: showItem,
+							selectItemBy: 'press'
 						}}
 						focusableScrollbar={args['focusableScrollbar']}
 						horizontalScrollbar={args['horizontalScrollbar']}
@@ -288,7 +289,6 @@ export const EditableIconWithLongPress = (args) => {
 				hideIndex: mutableRef.current.hideIndex,
 				onComplete: handleComplete,
 				removeItemFuncRef: removeItem,
-				selectItemBy: 'longPress'
 			}}
 			focusableScrollbar={args['focusableScrollbar']}
 			horizontalScrollbar={args['horizontalScrollbar']}

--- a/samples/sampler/stories/qa/IconItem.module.less
+++ b/samples/sampler/stories/qa/IconItem.module.less
@@ -6,6 +6,22 @@
 	}
 }
 
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hideItem {
+		display: none;
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
 .wrapper { // public class for editable wrapper
 	padding-left: 36px;
 	padding-right: 36px;
@@ -21,10 +37,11 @@
 	.itemWrapper {
 		text-align: center;
 
-		.iconItem {
+		.iconItem,
+		.hideItem {
 			width: 312px;
 			height: 240px;
-			margin: 24px;
+			margin: 60px;
 		}
 	}
 
@@ -42,13 +59,13 @@
 			opacity: 1;
 		}
 
-		&::before {
+		&:has(> .iconItem)::before{
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&::after {
+		&:has(> .iconItem)::after{
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -439,7 +439,7 @@ export const EditableListWithLongPress = (args) => {
 				css,
 				hideIndex: mutableRef.current.hideIndex,
 				onComplete: handleComplete,
-				removeItemFuncRef: removeItem,
+				removeItemFuncRef: removeItem
 			}}
 			focusableScrollbar={args['focusableScrollbar']}
 			horizontalScrollbar={args['horizontalScrollbar']}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -291,10 +291,10 @@ export const EditableList = (args) => {
 	useEffect(() => {
 		divRef.current.addEventListener('keydown', (ev) => {
 			const {keyCode} = ev;
-			if(isCancel(keyCode)) {
+			if (isCancel(keyCode)) {
 				setEditMode(false);
 			}
-		})
+		});
 	}, [divRef]);
 
 	return (
@@ -395,7 +395,103 @@ select('scrollMode', EditableList, prop.scrollModeOption, Config);
 boolean('spotlightDisabled', EditableList, Config, false);
 select('verticalScrollbar', EditableList, prop.scrollbarOption, Config);
 
-EditableList.storyName = 'with editable items';
+EditableList.storyName = 'With Editable Items';
+
+export const EditableListWithLongPress = (args) => {
+	const dataSize = args['editableDataSize'];
+	const [items, setItems] = useState(itemsArr);
+	const removeItem = useRef();
+	const mutableRef = useRef({
+		hideIndex: null
+	});
+
+	useLayoutEffect(() => {
+		itemsArr = [];
+		for (let i = 0; i < dataSize; i++) {
+			itemsArr.push(populateItems({index: i}));
+		}
+		setItems(itemsArr);
+		mutableRef.current.hideIndex = dataSize;
+	}, [dataSize]);
+
+	const onClickRemoveButton = useCallback((ev) => {
+		if (removeItem.current) {
+			removeItem.current();
+		}
+		ev.preventDefault();
+		ev.stopPropagation();
+	}, []);
+
+	const handleComplete = useCallback((ev) => {
+		const {orders} = ev;
+		// change data from the new orders
+		const newItems = [];
+
+		orders.forEach(order => {
+			newItems.push(items[order - 1]);
+		});
+
+		setItems(newItems);
+	}, [items]);
+
+	return (
+		<Scroller
+			direction="horizontal"
+			editable={{
+				centered: args['editableCentered'],
+				css,
+				hideIndex: mutableRef.current.hideIndex,
+				onComplete: handleComplete,
+				removeItemFuncRef: removeItem,
+				longPressMode: true
+			}}
+			focusableScrollbar={args['focusableScrollbar']}
+			horizontalScrollbar={args['horizontalScrollbar']}
+			hoverToScroll={args['hoverToScroll']}
+			key={args['scrollMode']}
+			noScrollByWheel={args['noScrollByWheel']}
+			onClick={action('onClickScroller')}
+			onKeyDown={action('onKeyDown')}
+			onScrollStart={action('onScrollStart')}
+			onScrollStop={action('onScrollStop')}
+			scrollMode={args['scrollMode']}
+			spotlightDisabled={args['spotlightDisabled']}
+			verticalScrollbar={args['verticalScrollbar']}
+		>
+			{
+				items.map((item, index) => {
+					return (
+						<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+							<div className={css.removeButtonContainer}>
+								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
+							</div>
+							<ImageItem
+								aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
+								src={item.src}
+								className={css.imageItem}
+								onClick={action('onClickItem')}
+							>
+								{`Image ${item.index}`}
+							</ImageItem>
+						</div>
+					);
+				})
+			}
+		</Scroller>
+	);
+};
+
+boolean('editableCentered', EditableListWithLongPress, Config, true);
+number('editableDataSize', EditableListWithLongPress, Config, 20);
+select('focusableScrollbar', EditableListWithLongPress, prop.focusableScrollbarOption, Config);
+select('horizontalScrollbar', EditableListWithLongPress, prop.scrollbarOption, Config);
+boolean('hoverToScroll', EditableListWithLongPress, Config, true);
+boolean('noScrollByWheel', EditableListWithLongPress, Config);
+select('scrollMode', EditableListWithLongPress, prop.scrollModeOption, Config);
+boolean('spotlightDisabled', EditableListWithLongPress, Config, false);
+select('verticalScrollbar', EditableListWithLongPress, prop.scrollbarOption, Config);
+
+EditableListWithLongPress.storyName = 'With Editable Items Trigger By Long Press';
 
 export const ListOfThingsInFixedPopupPanels = (args) => (
 	<FixedPopupPanels

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -312,7 +312,8 @@ export const EditableList = (args) => {
 							onComplete: handleComplete,
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
-							showItemFuncRef: showItem
+							showItemFuncRef: showItem,
+							selectItemBy: 'press'
 						}}
 						focusableScrollbar={args['focusableScrollbar']}
 						horizontalScrollbar={args['horizontalScrollbar']}
@@ -439,7 +440,6 @@ export const EditableListWithLongPress = (args) => {
 				hideIndex: mutableRef.current.hideIndex,
 				onComplete: handleComplete,
 				removeItemFuncRef: removeItem,
-				selectItemBy: 'longPress'
 			}}
 			focusableScrollbar={args['focusableScrollbar']}
 			horizontalScrollbar={args['horizontalScrollbar']}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -281,6 +281,7 @@ export const EditableList = (args) => {
 		orders.forEach(order => {
 			newItems.push(items[order - 1]);
 		});
+
 		for (let i = 0; i < orders.length; i++) {
 			newItems[i].disabled = (i >= hideIndex);
 		}
@@ -360,11 +361,7 @@ export const EditableList = (args) => {
 							items.map((item, index) => {
 								return (
 									<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
-										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
-											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-											{item.disabled ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
-										</ContainerDivWithLeaveForConfig>
+										<div className={css.removeButtonContainer} />
 										<ImageItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
 											src={item.src}
@@ -419,7 +416,6 @@ export const EditableListWithLongPress = (args) => {
 			removeItem.current();
 		}
 		ev.preventDefault();
-		ev.stopPropagation();
 	}, []);
 
 	const handleComplete = useCallback((ev) => {
@@ -443,7 +439,7 @@ export const EditableListWithLongPress = (args) => {
 				hideIndex: mutableRef.current.hideIndex,
 				onComplete: handleComplete,
 				removeItemFuncRef: removeItem,
-				longPressMode: true
+				selectItemBy: 'longPress'
 			}}
 			focusableScrollbar={args['focusableScrollbar']}
 			horizontalScrollbar={args['horizontalScrollbar']}

--- a/samples/sampler/stories/qa/Scroller.module.less
+++ b/samples/sampler/stories/qa/Scroller.module.less
@@ -6,6 +6,22 @@
 	}
 }
 
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hideItem {
+		display: none;
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
 .wrapper { // public class for editable wrapper
 	padding-left: 36px;
 	padding-right: 36px;
@@ -21,7 +37,8 @@
 	.itemWrapper {
 		text-align: center;
 
-		.imageItem {
+		.imageItem,
+		.hideItem {
 			width: 768px;
 			height: 588px;
 		}
@@ -41,13 +58,13 @@
 			opacity: 1;
 		}
 
-		&::before {
+		&:has(> .imageItem)::before{
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&::after {
+		&:has(> .imageItem)::after{
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add hiding/showing element feature when scroller is in edit mode(when `editable` is given)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Item will be selected by single tap/click
- The selected item can be hidden and also hidden items can be shown
- Added `longPresMode` feature to `editable` object, allowing long-press or single tap to select an item.
- Fixed a bug where removing a selected item while moving was not working properly.
- Added qa-sampler 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-15428

### Comments
