### PR TITLE
WRP-15824: Fixed to keep showing media controls while the user is wheeling in VideoPlayer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,15 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - "18"
 sudo: false
 before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline false
-    - npm install -g @enact/cli
+    - npm install -g @enact/cli@5.1.3
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=release/4.5.x.develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/VideoPlayer` to continue to display controls when user activity including rotating a wheel button is detected
+- `sandstone/VideoPlayer` to keep showing media controls while a user is wheeling
 
 ## [2.5.10] - 2023-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/VideoPlayer` to continue to display controls when user activity including rotating a wheel button is detected
+
 ## [2.5.10] - 2023-04-13
 
 ### Fixed

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -849,6 +849,7 @@ const VideoPlayerBase = class extends Component {
 			on('touchmove', this.activityDetected);
 		}
 		document.addEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
+		document.addEventListener('wheel', this.handleWheel, {capture: true});
 		this.startDelayedFeedbackHide();
 		if (this.context && typeof this.context === 'function') {
 			this.floatingLayerController = this.context(() => {});
@@ -946,6 +947,7 @@ const VideoPlayerBase = class extends Component {
 			off('touchmove', this.activityDetected);
 		}
 		document.removeEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
+		document.removeEventListener('wheel', this.handleWheel, {capture: true});
 		this.stopRewindJob();
 		this.stopAutoCloseTimeout();
 		this.stopDelayedTitleHide();
@@ -1290,6 +1292,12 @@ const VideoPlayerBase = class extends Component {
 		stopImmediate,
 		this.showControlsFromPointer
 	);
+
+	handleWheel = () => {
+		if (this.state.infoVisible) {
+			this.activityDetected();
+		}
+	};
 
 	handleControlsHandleAboveHold = () => {
 		if (shouldJump(this.props, this.state)) {

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -849,7 +849,7 @@ const VideoPlayerBase = class extends Component {
 			on('touchmove', this.activityDetected);
 		}
 		document.addEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
-		document.addEventListener('wheel', this.handleWheel, {capture: true});
+		document.addEventListener('wheel', this.activityDetected, {capture: true});
 		this.startDelayedFeedbackHide();
 		if (this.context && typeof this.context === 'function') {
 			this.floatingLayerController = this.context(() => {});
@@ -947,7 +947,7 @@ const VideoPlayerBase = class extends Component {
 			off('touchmove', this.activityDetected);
 		}
 		document.removeEventListener('keydown', this.handleGlobalKeyDown, {capture: true});
-		document.removeEventListener('wheel', this.handleWheel, {capture: true});
+		document.removeEventListener('wheel', this.activityDetected, {capture: true});
 		this.stopRewindJob();
 		this.stopAutoCloseTimeout();
 		this.stopDelayedTitleHide();
@@ -1292,12 +1292,6 @@ const VideoPlayerBase = class extends Component {
 		stopImmediate,
 		this.showControlsFromPointer
 	);
-
-	handleWheel = () => {
-		if (this.state.infoVisible) {
-			this.activityDetected();
-		}
-	};
 
 	handleControlsHandleAboveHold = () => {
 		if (shouldJump(this.props, this.state)) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

- The wheel event listener removed due to UX changes in WRP-852
So the screen automatically disappears after a certain period of time even when the wheel is operated with more component.

- After cli 6.0.0 version, @testing-library/user-event version 14 or higher must be entered and the unit test code must be updated. However, since this branch is for TV MR in 2023, .travis.yml needs to be modified so that the cli is fixed to 5.1.3 and the referenced enact branch is also fixed to the branch for TV MR in 2023.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

- Revert the deletion of the wheel event listener so that only the auto close time is extended while leaving the changed UX as it is.
- Updated .travis.yml so that cli uses version 5.1.3 and enact uses release/4.5.x.develop branch.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-15824

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)