### PR TITLE
WRP-17258: Fix `scroller/EditableWrapper` to release selectedItem when focus leaves scroll container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to focus properly when item is selected and `editable` is given
+
 ## [2.7.1] - 2023-06-02
 
 ### Added

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -545,7 +545,7 @@ const EditableWrapper = (props) => {
 					ev.stopPropagation();
 				}
 			} else if (is('up', keyCode) || is('down', keyCode)) {
-				let nextTarget = getTargetByDirectionFromElement('up', target);
+				let nextTarget = getTargetByDirectionFromElement(getDirection(keyCode), target);
 
 				// Check if focus leaves scroll container.
 				if (!getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -640,7 +640,7 @@ const EditableWrapper = (props) => {
 			const bodyWidth = document.body.getBoundingClientRect().width;
 			const {lastMouseClientX, selectedItem} = mutableRef.current;
 			const {isHoveringToScroll, rtl} = scrollContainerHandle.current;
-			if (selectedItem && mutableRef.current.lastInputType !== 'key') {
+			if (selectedItem && mutableRef.current.lastInputType !== 'key' && Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
 				mutableRef.current.lastInputType = 'scroll';
 				if (isHoveringToScroll) {
 					const toIndex = getNextIndexFromPosition(lastMouseClientX, 0);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -586,15 +586,16 @@ const EditableWrapper = (props) => {
 	useEffect(() => {
 		// Calculate the item width once
 		const {rtl} = scrollContainerHandle.current;
+		const container = scrollContentRef.current;
 		const item = wrapperRef.current?.children[0];
 		if (item && typeof window !== 'undefined') {
 			const bodyWidth = document.body.getBoundingClientRect().width;
 			const neighbor = item.nextElementSibling || item.previousElementSibling;
 			mutableRef.current.itemWidth = Math.abs(item.offsetLeft - neighbor?.offsetLeft);
-			mutableRef.current.centeredOffset = rtl ? bodyWidth - item.getBoundingClientRect().right : item.getBoundingClientRect().left;
+			mutableRef.current.centeredOffset = rtl ? bodyWidth - (item.getBoundingClientRect().right + container.scrollLeft) : item.getBoundingClientRect().left + container.scrollLeft;
 			wrapperRef.current?.style.setProperty('--item-width', mutableRef.current.itemWidth + 'px');
 		}
-	}, [centered, dataSize, scrollContainerHandle]);
+	}, [centered, dataSize, scrollContainerHandle, scrollContentRef]);
 
 	useEffect(() => {
 		mutableRef.current.spotlightId = scrollContainerRef.current && scrollContainerRef.current.dataset.spotlightId;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -545,7 +545,7 @@ const EditableWrapper = (props) => {
 					ev.stopPropagation();
 				}
 			} else if (is('up', keyCode) || is('down', keyCode)) {
-				let nextTarget = getTargetByDirectionFromElement(getDirection(keyCode), target);
+				const nextTarget = getTargetByDirectionFromElement(getDirection(keyCode), target);
 
 				// Check if focus leaves scroll container.
 				if (!getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -183,7 +183,7 @@ export const EditableIcon = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
@@ -191,7 +191,7 @@ export const EditableIcon = (args) => {
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
-											className={item.disabled ? css.hideItem : css.iconItem}
+											className={css.iconItem}
 											disabled={item.disabled}
 											onClick={action('onClickItem')}
 											{...item.iconItemProps}
@@ -211,11 +211,11 @@ export const EditableIcon = (args) => {
 						<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<div className={css.removeButtonContainer} />
 										<IconItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
-											className={item.disabled ? css.hideItem : css.iconItem}
+											className={css.iconItem}
 											onClick={action('onClickItem')}
 											disabled={item.disabled}
 											{...item.iconItemProps}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -183,7 +183,7 @@ export const EditableIcon = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
@@ -211,7 +211,7 @@ export const EditableIcon = (args) => {
 						<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<div className={css.removeButtonContainer} />
 										<IconItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}

--- a/samples/sampler/stories/qa/IconItem.module.less
+++ b/samples/sampler/stories/qa/IconItem.module.less
@@ -37,8 +37,7 @@
 	.itemWrapper {
 		text-align: center;
 
-		.iconItem,
-		.hideItem {
+		.iconItem {
 			width: 312px;
 			height: 240px;
 			margin: 60px;
@@ -59,13 +58,13 @@
 			opacity: 1;
 		}
 
-		&:has(> .iconItem)::before{
+		&:not(.hideItem)::before {
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&:has(> .iconItem)::after{
+		&:not(.hideItem)::after {
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;

--- a/samples/sampler/stories/qa/IconItem.module.less
+++ b/samples/sampler/stories/qa/IconItem.module.less
@@ -13,8 +13,10 @@
 	min-width: fit-content;
 	padding-top: 60px;
 
-	.hideItem {
-		display: none;
+	.hidden {
+		.iconItem {
+			display: none;
+		}
 	}
 }
 
@@ -58,13 +60,13 @@
 			opacity: 1;
 		}
 
-		&:not(.hideItem)::before {
+		&:not(.hidden)::before {
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&:not(.hideItem)::after {
+		&:not(.hidden)::after {
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -331,7 +331,7 @@ export const EditableList = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
@@ -361,7 +361,7 @@ export const EditableList = (args) => {
 						<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<div className={css.removeButtonContainer} />
 										<ImageItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -331,7 +331,7 @@ export const EditableList = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
@@ -340,7 +340,7 @@ export const EditableList = (args) => {
 										<ImageItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
 											src={item.src}
-											className={item.disabled ? css.hideItem : css.imageItem}
+											className={css.imageItem}
 											disabled={item.disabled}
 											onClick={action('onClickItem')}
 										>
@@ -361,12 +361,12 @@ export const EditableList = (args) => {
 						<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hideItem]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 										<div className={css.removeButtonContainer} />
 										<ImageItem
 											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
 											src={item.src}
-											className={item.disabled ? css.hideItem : css.imageItem}
+											className={css.imageItem}
 											disabled={item.disabled}
 											onClick={action('onClickItem')}
 										>

--- a/samples/sampler/stories/qa/Scroller.module.less
+++ b/samples/sampler/stories/qa/Scroller.module.less
@@ -37,8 +37,7 @@
 	.itemWrapper {
 		text-align: center;
 
-		.imageItem,
-		.hideItem {
+		.imageItem {
 			width: 768px;
 			height: 588px;
 		}
@@ -58,13 +57,13 @@
 			opacity: 1;
 		}
 
-		&:has(> .imageItem)::before{
+		&:not(.hideItem)::before {
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&:has(> .imageItem)::after{
+		&:not(.hideItem)::after {
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;

--- a/samples/sampler/stories/qa/Scroller.module.less
+++ b/samples/sampler/stories/qa/Scroller.module.less
@@ -13,8 +13,10 @@
 	min-width: fit-content;
 	padding-top: 60px;
 
-	.hideItem {
-		display: none;
+	.hidden {
+		.imageItem {
+			display: none;
+		}
 	}
 }
 
@@ -57,13 +59,13 @@
 			opacity: 1;
 		}
 
-		&:not(.hideItem)::before {
+		&:not(.hidden)::before {
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&:not(.hideItem)::after {
+		&:not(.hidden)::after {
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

In this PR, I fixed 2 issues related to `scroller/EditableWrapper`

1) Fix `scroller/EditableWrapper` to release selectedItem when focus leaves the scroll container.
: When an item is selected in the editable scroller and the focus leaves the scroll container(e.g., by key handling), the selected item remains selected even if the focus moves back into the scroll container. 
 -> It is fixed to release selectedItem when the focus leaves the scroll container. 

2) Fix `scroller/EditableWrapper` centeredOffset to calculate properly.
: When deleting an item after scrolling, centeredOffset was miscalculated. 

3) Fix `scroller/EditableWrapper` not to move items by scroll when selectedItem is hidden.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

1) In the handleKeyDownCapture handler, when keyCode is 'up' or 'down', find the next spotlight item and if it is not included in the scroll container, release selectedItem and reset.

2) When deleting an item after scrolling, it needs to consider the container.scrollLeft too as getBoundingClientRect() only considers the relative left position of the viewport.

3) When moveItemsByScroll, check selectedItem.style.order is hidden or not.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-17258

### Comments
