### PR TITLE
WRP-19408: Added `QuickGuidePanels` prop `onClose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/QuickGuidePanels` prop `onClose`
+
 ### Fixed
 
 - `sandstone/Scroller` to focus properly when item is selected and `editable` is given

--- a/QuickGuidePanels/QuickGuidePanels.js
+++ b/QuickGuidePanels/QuickGuidePanels.js
@@ -28,6 +28,15 @@ const QuickGuidePanels = (props) => <WizardPanels fullScreenContent {...props} /
 
 QuickGuidePanels.propTypes = {
 	/**
+	 * Hint string read when focusing the close button.
+	 *
+	 * @type {String}
+	 * @default 'Exit quick guide'
+	 * @private
+	 */
+	closeButtonAriaLabel: PropTypes.string,
+
+	/**
 	 * Called when the index value is changed.
 	 *
 	 * @type {Function}
@@ -35,6 +44,14 @@ QuickGuidePanels.propTypes = {
 	 * @public
 	 */
 	onChange: PropTypes.func,
+
+	/**
+	 * Called when the close button is clicked.
+	 *
+	 * @type {Function}
+	 * @public
+	 */
+	onClose: PropTypes.func,
 
 	/**
 	 * Called when the next button is clicked in QuickGuidePanels.

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -1,4 +1,4 @@
-import handle, {forProp, forwardCustomWithPrevent, not} from '@enact/core/handle';
+import handle, {forProp, forwardCustom, forwardCustomWithPrevent, not} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import useChainRefs from '@enact/core/useChainRefs';
@@ -66,6 +66,15 @@ const WizardPanelsBase = kind({
 		 * @public
 		 */
 		'aria-label': PropTypes.string,
+
+		/**
+		 * Hint string read when focusing the close button.
+		 *
+		 * @type {String}
+		 * @default 'Exit quick guide'
+		 * @private
+		 */
+		closeButtonAriaLabel: PropTypes.string,
 
 		/**
 		 * Obtains a reference to the root node.
@@ -181,6 +190,14 @@ const WizardPanelsBase = kind({
 		* @public
 		*/
 		onChange: PropTypes.func,
+
+		/**
+		 * Called when the close button is clicked.
+		 *
+		 * @type {Function}
+		 * @private
+		 */
+		onClose: PropTypes.func,
 
 		/**
 		 * Called when the next button is clicked in WizardPanel.
@@ -308,6 +325,7 @@ const WizardPanelsBase = kind({
 	},
 
 	handlers: {
+		onClose: forwardCustom('onClose'),
 		onNextClick: handle(
 			forwardCustomWithPrevent('onNextClick'),
 			(ev, {index, onChange, totalPanels}) => {
@@ -421,6 +439,7 @@ const WizardPanelsBase = kind({
 	render: ({
 		'aria-label': ariaLabel,
 		children,
+		closeButtonAriaLabel,
 		footer,
 		fullScreenContent,
 		index,
@@ -428,6 +447,7 @@ const WizardPanelsBase = kind({
 		nextNavigationButton,
 		noAnimation,
 		noSubtitle,
+		onClose,
 		onTransition,
 		onWillTransition,
 		reverseTransition,
@@ -456,8 +476,10 @@ const WizardPanelsBase = kind({
 				<Row className={css.fullScreenContentHeader}>
 					{steps}
 					<Button
-						icon="closex"
+						aria-label={closeButtonAriaLabel == null ? $L('Exit quick guide') : closeButtonAriaLabel}
 						className={css.close}
+						icon="closex"
+						onClick={onClose}
 						size="small"
 					/>
 				</Row>

--- a/WizardPanels/tests/WizardPanels-specs.js
+++ b/WizardPanels/tests/WizardPanels-specs.js
@@ -819,4 +819,32 @@ describe('WizardPanel Specs', () => {
 			expect(actual).toBe(expected);
 		}
 	);
+
+
+	describe('fullScreenContent', () => {
+		test(
+			'should fire `onClose` when close button is clicked',
+			async () => {
+				const handleClose = jest.fn();
+				const user = userEvent.setup();
+
+				render(
+					<WizardPanels fullScreenContent onClose={handleClose}>
+						<Panel />
+					</WizardPanels>
+				);
+
+				const closeButton = screen.getByLabelText('Exit quick guide');
+				const expected = {type: 'onClose'};
+
+				await user.click(closeButton);
+
+				await waitFor(() => {
+					const actual = handleClose.mock.calls.length && handleClose.mock.calls[0][0];
+
+					expect(actual).toMatchObject(expected);
+				});
+			}
+		);
+	});
 });

--- a/samples/sampler/stories/default/QuickGuidePanels.js
+++ b/samples/sampler/stories/default/QuickGuidePanels.js
@@ -19,6 +19,7 @@ export const _QuickGuidePanels = (args) => (
 		nextButtonVisibility={args['nextButtonVisibility']}
 		onBack={action('onBack')}
 		onChange={action('onChange')}
+		onClose={action('onClose')}
 		onNextClick={action('onNextClick')}
 		onPrevClick={action('onPrevClick')}
 		prevButtonVisibility={args['prevButtonVisibility']}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`onClose` event handler prop is missing for `QuickGuidePanels`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `onClose` prop

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Note that aria label is not defined yet, so it should be updated later.

A unit test is added.

### Links
[//]: # (Related issues, references)
WRP-19408

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
