### PR TITLE
WRP-19469: Fixed `QuickGuidePanels` to update a close button position properly in RTL locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/QuickGuidePanels` to update a close button position properly in RTL locales
 - `sandstone/Scroller` to focus properly when item is selected and `editable` is given
 
 ## [2.7.1] - 2023-06-02

--- a/WizardPanels/WizardPanels.module.less
+++ b/WizardPanels/WizardPanels.module.less
@@ -20,7 +20,7 @@
 	}
 
 	.fullScreenContentHeader {
-		z-index: 9;
+		z-index: 10;
 		flex-direction: row-reverse;
 
 		.steps {

--- a/WizardPanels/WizardPanels.module.less
+++ b/WizardPanels/WizardPanels.module.less
@@ -18,29 +18,30 @@
 		text-align: center;
 		margin: @sand-wizardpanels-footer-margin;
 	}
-}
 
-.fullScreenContentHeader {
-	justify-content: center;
-	z-index: 10;
+	.fullScreenContentHeader {
+		z-index: 9;
+		flex-direction: row-reverse;
 
+		.steps {
+			display: flex;
+			justify-content: center;
+			width: 100%;
+			margin-top: @sand-wizardpanels-fullScreenContent-steps-margin-top;
+		}
 
-	.steps {
-		margin-top: @sand-wizardpanels-fullScreenContent-steps-margin-top;
-	}
-
-	.close {
-		display: flex;
-		position: absolute;
-		top: @sand-wizardpanels-fullScreenContent-close-button-margin-top;
-		right: @sand-wizardpanels-fullScreenContent-close-button-right;
+		.close {
+			position: absolute;
+			top: @sand-wizardpanels-fullScreenContent-close-button-margin-top;
+			margin-inline-end: @sand-wizardpanels-fullScreenContent-close-button-margin-end;
+		}
 	}
 }
 
 .navigationButtonContainer {
 	z-index: 10;
 	margin-top: @sand-wizardpanels-fullScreenContent-container-margin-top;
-		
+
 	.navigationButton {
 		margin: @sand-wizardpanels-fullScreenContent-navigation-button-margin;
 	}

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -1009,7 +1009,7 @@
 		@sand-heading-title-line-height
 	)[@result]
 ) + 10px;
-@sand-wizardpanels-fullScreenContent-close-button-right:        114px;
+@sand-wizardpanels-fullScreenContent-close-button-margin-end:   150px;
 @sand-wizardpanels-fullScreenContent-navigation-button-margin:  0 12px;
 @sand-wizardpanels-fullScreenContent-container-margin-top:      828px;
 @sand-wizardpanels-fullScreenContent-steps-margin-top:          90px;

--- a/tests/screenshot/apps/components/QuickGuidePanels.js
+++ b/tests/screenshot/apps/components/QuickGuidePanels.js
@@ -2,11 +2,7 @@ import QuickGuidePanels, {Panel} from '../../../../QuickGuidePanels';
 
 import {withConfig} from './utils';
 
-const defaultQuickGuidePanelsTests = withConfig({
-	wrapper: {
-		full: true
-	}
-}, [
+const defaultQuickGuidePanelsTests = [
 	<QuickGuidePanels>
 		<Panel>View 1</Panel>
 		<Panel>View 2</Panel>
@@ -17,6 +13,12 @@ const defaultQuickGuidePanelsTests = withConfig({
 		<Panel>View 2</Panel>
 		<Panel>View 3</Panel>
 	</QuickGuidePanels>
-]);
+];
 
-export default defaultQuickGuidePanelsTests;
+const QuickGuidePanelsTests = [
+	...withConfig({wrapper: {full: true}}, defaultQuickGuidePanelsTests),
+	...withConfig({wrapper: {full: true}, locale: 'vi-VN'}, defaultQuickGuidePanelsTests), // Tallglyph validation
+	...withConfig({wrapper: {full: true}, locale: 'ar-SA'}, defaultQuickGuidePanelsTests)  // RTL validation
+];
+
+export default QuickGuidePanelsTests;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A close buton of `QuickGuidePanels` is always right-side even in RTL locales.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed a close button's position in RTL locales.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-19469

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
