### PR TITLE
WRP-19595: Fix `scroller/EditableWrapper` to show buttons when an item in scroller is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/Icon` supported icon list, adding new icons `exclamation`, `show`, and `hide`
+- `sandstone/Scroller` to support showing buttons when an item is focused and `editable` is given
 - `sandstone/QuickGuidePanels` prop `onClose`
 
 ### Fixed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -407,8 +407,8 @@ const EditableWrapper = (props) => {
 		if (targetItem) {
 			// rearrangedItems need for the case when removing item while moving selected item
 			const rearrangedItems = mutableRef.current.rearrangedItems;
-			const selectedItemRect = targetItem && targetItem.getBoundingClientRect();
-			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
+			const targetItemRect = targetItem && targetItem.getBoundingClientRect();
+			mutableRef.current.nextSpotlightRect = {x: targetItemRect.right, y: targetItemRect.top};
 			mutableRef.current.hideIndex -= 1;
 
 			const orders = finalizeOrders();
@@ -429,14 +429,14 @@ const EditableWrapper = (props) => {
 		if (targetItem) {
 			// rearrangedItems need for the case when hiding item while moving selected item
 			const rearrangedItems = mutableRef.current.rearrangedItems;
-			const selectedItemOrder = Number(targetItem.style.order);
-			const selectedItemRect = targetItem && targetItem.getBoundingClientRect();
-			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
+			const targetItemOrder = Number(targetItem.style.order);
+			const targetItemRect = targetItem && targetItem.getBoundingClientRect();
+			mutableRef.current.nextSpotlightRect = {x: targetItemRect.right, y: targetItemRect.top};
 			mutableRef.current.hideIndex -= 1;
 
 			const orders = finalizeOrders();
-			orders.splice(orders.indexOf(selectedItemOrder), 1);
-			orders.push(selectedItemOrder);
+			orders.splice(orders.indexOf(targetItemOrder), 1);
+			orders.push(targetItemOrder);
 			rearrangedItems.forEach(item => {
 				item.style.order -= 1;
 			});
@@ -452,13 +452,13 @@ const EditableWrapper = (props) => {
 		const targetItem = selectedItem || focusedItem;
 
 		if (targetItem) {
-			const selectedItemOrder = Number(targetItem.style.order);
-			const selectedItemRect = targetItem && targetItem.getBoundingClientRect();
-			mutableRef.current.nextSpotlightRect = {x: selectedItemRect.right, y: selectedItemRect.top};
+			const targetItemOrder = Number(targetItem.style.order);
+			const targetItemRect = targetItem && targetItem.getBoundingClientRect();
+			mutableRef.current.nextSpotlightRect = {x: targetItemRect.right, y: targetItemRect.top};
 
 			const orders = Array.from({length: dataSize}, (_, i) => i + 1);
-			orders.splice(selectedItemOrder - 1, 1);
-			orders.splice(mutableRef.current.hideIndex, 0, selectedItemOrder);
+			orders.splice(targetItemOrder - 1, 1);
+			orders.splice(mutableRef.current.hideIndex, 0, targetItemOrder);
 
 			mutableRef.current.hideIndex += 1;
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -201,6 +201,11 @@ const EditableWrapper = (props) => {
 		}
 	}, [customCss.selected]);
 
+	const finalizeEditing = useCallback((orders) => {
+		forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
+		reset();
+	}, [editable]);
+
 	const findItemNode = useCallback((node) => {
 		for (let current = node; current !== scrollContentRef.current && current !== document; current = current.parentNode) {
 			if (current.dataset.index) {
@@ -228,8 +233,7 @@ const EditableWrapper = (props) => {
 		if (mutableRef.current.selectedItem) {
 			// Finalize orders and forward `onComplete` event
 			const orders = finalizeOrders();
-			forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-			reset();
+			finalizeEditing(orders);
 			focusItem(ev.target);
 			mutableRef.current.needToPreventEvent = true;
 		} else {
@@ -417,8 +421,7 @@ const EditableWrapper = (props) => {
 				item.style.order -= 1;
 			});
 
-			forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-			reset();
+			finalizeEditing(orders);
 		}
 	}, [editable, finalizeOrders, reset]);
 
@@ -442,8 +445,7 @@ const EditableWrapper = (props) => {
 			});
 			targetItem.style.order = orders.length;
 
-			forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-			reset();
+			finalizeEditing(orders);
 		}
 	}, [editable, finalizeOrders, reset]);
 
@@ -462,8 +464,7 @@ const EditableWrapper = (props) => {
 
 			mutableRef.current.hideIndex += 1;
 
-			forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-			reset();
+			finalizeEditing(orders);
 		}
 	}, [dataSize, editable, reset]);
 
@@ -513,8 +514,7 @@ const EditableWrapper = (props) => {
 
 		if (selectedItem || focusedItem) {
 			const orders = finalizeOrders();
-			forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-			reset();
+			finalizeEditing(orders);
 
 			if (lastInputType === 'scroll') {
 				const offset = itemWidth * (!rtl ^ !(lastMouseClientX > scrollContentCenter) ? 1 : -1);
@@ -535,8 +535,7 @@ const EditableWrapper = (props) => {
 			if (!repeat) {
 				if (selectedItem) {
 					const orders = finalizeOrders();
-					forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-					reset();
+					finalizeEditing(orders);
 					focusItem(ev.target);
 					mutableRef.current.needToPreventEvent = true;
 
@@ -577,8 +576,7 @@ const EditableWrapper = (props) => {
 					Spotlight.move(getDirection(keyCode));
 
 					const orders = finalizeOrders();
-					forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
-					reset();
+					finalizeEditing(orders);
 
 					ev.preventDefault();
 					ev.stopPropagation();

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -35,14 +35,24 @@ const TouchableDiv = Touchable('div');
  * * `wrapper` - The content wrapper component class
  * * `selected` - The selected item class
  * * `focused` - The focused item class
+ * @property {Function|Object} [focusItemFuncRef] Obtains a reference to `focusItem` function.
+ *  If you would like to use `focused` CSS class to an item, you can get the reference to `focusItem` function via `useRef`.
+ * `focusItem` function need to be called with an item node when an item is focused.
+ * @property {Function|Object} [hideItemFuncRef] Obtains a reference to `hideItem` function.
+ *  If you would like to hide an item, you can get the reference to `hideItem` function via `useRef`.
  * @property {Function|Object} [removeItemFuncRef] Obtains a reference to `removeItem` function.
  *  If you would like to remove an item, you can get the reference to `removeItem` function via `useRef`.
+ * @property {string} [selectItemBy] Decides how to start editing items.
+ *  It can be either `'press'` or `'longPress'`. If unset, it defaults to `'longPress'`.
+ * @property {Function|Object} [showItemFuncRef] Obtains a reference to `showItem` function.
+ *  If you would like to show an item, you can get the reference to `showItem` function via `useRef`.
  * @public
  */
 const EditableShape = PropTypes.shape({
 	onComplete: PropTypes.func.isRequired,
 	centered: PropTypes.bool,
 	css: PropTypes.object,
+	focusItemFuncRef: EnactPropTypes.ref,
 	hideItemFuncRef: EnactPropTypes.ref,
 	removeItemFuncRef: EnactPropTypes.ref,
 	selectItemBy: PropTypes.string,

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -242,7 +242,7 @@ const EditableWrapper = (props) => {
 	const handleHoldStart = useCallback(() => {
 		const {targetItemNode} = mutableRef.current;
 
-		if (targetItemNode && targetItemNode.dataset.index) {
+		if (targetItemNode && targetItemNode.dataset.index && selectItemBy === 'longPress') {
 			// Start editing by adding selected transition to selected item
 			startEditing(targetItemNode);
 		}
@@ -526,7 +526,7 @@ const EditableWrapper = (props) => {
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
 				}
-			} else if (repeat && targetItemNode && !mutableRef.current.timer) {
+			} else if (repeat && targetItemNode && !mutableRef.current.timer && selectItemBy === 'longPress') {
 				mutableRef.current.timer = setTimeout(() => {
 					startEditing(targetItemNode);
 				}, holdDuration - 300);

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -232,6 +232,7 @@ export const EditableList = (args) => {
 	const removeItem = useRef();
 	const hideItem = useRef();
 	const showItem = useRef();
+	const focusItem = useRef();
 	const divRef = useRef();
 	const mutableRef = useRef({
 		hideIndex: null
@@ -269,6 +270,12 @@ export const EditableList = (args) => {
 			showItem.current();
 		}
 		ev.preventDefault();
+	}, []);
+
+	const onFocusItem = useCallback((ev) => {
+		if (focusItem.current) {
+			focusItem.current(ev.target);
+		}
 	}, []);
 
 	const handleComplete = useCallback((ev) => {
@@ -313,6 +320,7 @@ export const EditableList = (args) => {
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
 							showItemFuncRef: showItem,
+							focusItemFuncRef: focusItem,
 							selectItemBy: 'press'
 						}}
 						focusableScrollbar={args['focusableScrollbar']}
@@ -343,6 +351,7 @@ export const EditableList = (args) => {
 											className={css.imageItem}
 											disabled={item.disabled}
 											onClick={action('onClickItem')}
+											onFocus={onFocusItem}
 										>
 											{`Image ${item.index}`}
 										</ImageItem>

--- a/samples/sampler/stories/qa/Scroller.module.less
+++ b/samples/sampler/stories/qa/Scroller.module.less
@@ -45,6 +45,12 @@
 		}
 	}
 
+	.focused { // public class for focused item
+		.removeButton {
+			display: inline-block;
+		}	
+	}
+
 	.selected { // public class for selected item
 		.removeButton {
 			display: inline-block;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In this PR, a feature related to `scroller/EditableWrapper` is added.
- Implement `scroller/EditableWrapper` to show buttons when an item in scroller is focused


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add focusItemFuncRef in `editable` and `focusedItem` in mutableRef to edit(e.g. remove/hide/show) an item that is not selected but focused. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-19595

### Comments
