### PR TITLE
WRP-20570: `hoverToScroll` works properly inside another scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` and `sandstone/VirtualList` to not stop scrolling by `hoverToScroll` inside another scroller
+
 ## [2.7.2] - 2023-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` and `sandstone/VirtualList` to not stop scrolling by `hoverToScroll` inside another scroller
+- `sandstone/Scroller` and `sandstone/VirtualList` to scroll properly by hovering inside a nested scroller
 
 ## [2.7.2] - 2023-06-30
 

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -374,8 +374,10 @@ const VirtualGridListInScroller = ({args, onNext, ...rest}) => {
 		virtualGridLists.push(
 			<VirtualGridList
 				{...virtualGridListProps}
+				hoverToScroll={args['hoverToScroll']}
 				id={id}
 				key={id}
+				noScrollByWheel={args['noScrollByWheel']}
 				spotlightId={id}
 			/>
 		);
@@ -434,8 +436,10 @@ VirtualGridListInScrollerSamples.propTypes = {
 export const RestoreFocusInScroller = (args) => <VirtualGridListInScrollerSamples args={args} />;
 
 number('dataSize', RestoreFocusInScroller, Config, defaultDataSize);
+boolean('hoverToScroll', RestoreFocusInScroller, Config);
 number('minWidth', RestoreFocusInScroller, Config, 688);
 number('minHeight', RestoreFocusInScroller, Config, 570);
+boolean('noScrollByWheel', RestoreFocusInScroller, Config);
 number('spacing', RestoreFocusInScroller, Config, 0);
 
 RestoreFocusInScroller.storyName = 'in Scroller with restoring focus';

--- a/tests/ui/specs/VirtualList/VirtualGridList/qa-VirtualGridList/VirtualGridList-QWTC-2296-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/qa-VirtualGridList/VirtualGridList-QWTC-2296-specs.js
@@ -23,38 +23,17 @@ describe('qa-VirtualGridList translate mode', function () {
 		// Step 4 Verify: Image 10 is the first item on the first fully visible row.
 		expect(await Page.itemOffsetBottomById(10)).to.be.above(itemSize.height);
 
-		// Step 5: Hover the Scroll thumb on the verticalScrollbar track.
-		await Page.scrollThumb.moveTo();
+		// Step 5: Position the pointer between image18 and image19.
+		await (await Page.item(8)).moveTo({xOffset: itemSize.width + 1, yOffset: itemSize.height - 1});
 		// Step 5 Verify: Spotlight hides.
 		await expectNoFocusedItem();
 
-		// Step 6: Press Channel Down.
-		await Page.pageDown();
-		await Page.delay(1000);
-		// Step 6 Verify: Image 20 is the first item on the first fully visible row.
-		expect(await Page.itemOffsetBottomById(20)).to.be.above(itemSize.height);
-
-		// Step 7: Position the pointer between image18 and image19.
-		await (await Page.item(18)).moveTo({xOffset: itemSize.width + 1, yOffset: itemSize.height - 1});
-		// Step 7 Verify: Spotlight hides.
-		await expectNoFocusedItem();
-
-		// Step 8: Press Channel Up.
+		// Step 6: Press Channel Up.
 		await Page.pageUp();
 		await Page.delay(1000);
-		// Step 8 Verify: Image 10 is the first item on the first fully visible row.
-		expect(await Page.itemOffsetBottomById(10)).to.be.above(itemSize.height);
-
-		// Step 9: Hover the Scroll thumb on the verticalScrollbar track.
-		await Page.scrollThumb.moveTo();
-		// Step 9 Verify: Spotlight hides.
-		await expectNoFocusedItem();
-
-		// Step 10: Press Channel Up.
-		await Page.pageUp();
-		await Page.delay(1000);
-		// Step 10 Verify: Image 0 is the first item on the first fully visible row.
+		// Step 6 Verify: Image 0 is the first item on the first fully visible row.
 		expect(await Page.itemOffsetBottomById(0)).to.be.equal(itemSize.height);
+		await expectNoFocusedItem();
 
 	});
 });

--- a/tests/ui/specs/VirtualList/VirtualGridList/qa-VirtualGridList/VirtualGridList-QWTC-2296-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/qa-VirtualGridList/VirtualGridList-QWTC-2296-specs.js
@@ -23,7 +23,7 @@ describe('qa-VirtualGridList translate mode', function () {
 		// Step 4 Verify: Image 10 is the first item on the first fully visible row.
 		expect(await Page.itemOffsetBottomById(10)).to.be.above(itemSize.height);
 
-		// Step 5: Position the pointer between image18 and image19.
+		// Step 5: Position the pointer between image8 and image9.
 		await (await Page.item(8)).moveTo({xOffset: itemSize.width + 1, yOffset: itemSize.height - 1});
 		// Step 5 Verify: Spotlight hides.
 		await expectNoFocusedItem();

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import {useScrollbar as useScrollbarBase} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import {memo, useCallback} from 'react';
@@ -10,7 +11,7 @@ import componentCss from './Scrollbar.module.less';
 const useThemeScrollbar = (props) => {
 	const {
 		restProps,
-		scrollbarProps,
+		scrollbarProps: {className: scrollbarClassName, ...restScrollbarProps},
 		scrollbarTrackProps
 	} = useScrollbarBase(props);
 
@@ -25,7 +26,7 @@ const useThemeScrollbar = (props) => {
 	} = restProps;
 
 	const
-		{ref: scrollbarContainerRef} = scrollbarProps,
+		{ref: scrollbarContainerRef} = restScrollbarProps,
 		{ref: scrollbarTrackRef} = scrollbarTrackProps,
 		{vertical} = props;
 
@@ -63,7 +64,8 @@ const useThemeScrollbar = (props) => {
 	return {
 		restProps: rest,
 		scrollbarProps: {
-			...scrollbarProps,
+			...restScrollbarProps,
+			className: classNames(scrollbarClassName, {[componentCss.focusableScrollbar]: focusableScrollbar}),
 			onClick
 		},
 		scrollbarTrackProps: {

--- a/useScroll/Scrollbar.module.less
+++ b/useScroll/Scrollbar.module.less
@@ -8,7 +8,7 @@
 	background: none;
 	border-color: transparent;
 	opacity: 1;
-
+	pointer-events: none;
 	transition: opacity 100ms ease-out;
 	will-change: opacity;
 
@@ -20,9 +20,12 @@
 		});
 	}
 
+	&.focusableScrollbar {
+		pointer-events: auto;
+	}
+
 	/* ScrollbarTrack */
 	.scrollbarTrackShown {
 		opacity: 1;
 	}
 }
-


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scrolling by `hoverToScroll` stops if *ALL* conditions below meet,
- A scroller or list (inner scroller) exists inside another scroller (outer scroller) that has a orthogonal scroll direction to the inner scroller.
- The inner scroller has `hoverToScroll` prop.
- The outer scroller has a (always either during-scroll) visible scrollbar.
- A user moves the pointer on a cross-area of "hoverToScroll" area of the inner scroller and "scrollbar" area of the outer scroller.

This pull request is to make the outer scroller scrolling properly in the situation described above.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The cause is that "scrollbar" DOM of the outer scroller is layered above the inner scroller in the cross-area, So, pointer events are dispatched to the "scrollbar" DOM. These events cannot be propagated to the inner scroller ever due to its DOM tree structure.

To make events to be dispatched to the inner scroller nodes, "pointer-events: none" CSS attribute is added to the "scrollbar" DOM of the outer scroller.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-20570

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)