### PR TITLE
WRP-21338: Fixed `VirtualGridList` to not apply a scale effect to outside DOM when `snapToCenter` is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/VirtualList` to not scale DOM out of a list by wheeling when `snapToCenter`
+- `sandstone/VirtualList.VirtualGridList` to not scale DOM out of a list by wheeling when `snapToCenter`
 
 ## [2.7.3] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleaed]
+
+### Fixed
+
+- `sandstone/VirtualList` to not scale DOM out of a list by wheeling when `snapToCenter`
+
 ## [2.7.3] - 2023-07-14
 
 ### Fixed

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -326,6 +326,7 @@ const useSpottable = (props, instances) => {
 	function removeScaleEffect () {
 		if (mutableRef.current.scaledTarget) {
 			mutableRef.current.scaledTarget.classList.remove(css.scaled);
+			mutableRef.current.scaledTarget = null;
 		}
 	}
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -673,7 +673,7 @@ const useEventWheel = (props, instances) => {
 
 				if (nextIndex > 0 && nextIndex < dataSize - 1) {
 					if (typeof document === 'object') {
-						const target = document.querySelector(`[data-index="${nextIndex}"] div`);
+						const target = scrollContentRef.current.querySelector(`[data-index="${nextIndex}"] > div`);
 
 						// remove effect
 						themeScrollContentHandle.current.removeScaleEffect();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When scrolling a list by wheeling when `snapToCenter` is given, scaling effect is applied to not the centered item but a outside DOM if the outside DOM has a specific 'data-index' attribute.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to find right DOM node to apply the scaling effect

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21338

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)