### PR TITLE
WRP-21706: Fixed `sandstone/VirtualList` to move focus properly by 5-way directional key hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/VirtualList` to move focus properly by 5-way directional key hold when `spotlight/SpotlightContainerDecorator` config option `continue5WayHold` is set
+
 ## [2.7.4] - 2023-07-19
 
 ### Fixed

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -1,5 +1,6 @@
 import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
+import {getContainerConfig} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import utilEvent from '@enact/ui/useScroll/utilEvent';
@@ -137,11 +138,12 @@ const useEventKey = (props, instances, context) => {
 					);
 					const index = !isNotItem ? getNumberValue(targetIndex) : -1;
 					const candidate = getTargetByDirectionFromElement(direction, target);
-					const candidateIndex = candidate && candidate.dataset && getNumberValue(candidate.dataset.index);
+					const candidateInside = utilDOM.containsDangerously(ev.currentTarget, candidate);
+					const candidateIndex = candidate && candidateInside && candidate.dataset && getNumberValue(candidate.dataset.index) || -1;
 					let isLeaving = false;
 
 					if (isNotItem) { // if the focused node is not an item
-						if (!utilDOM.containsDangerously(ev.currentTarget, candidate)) { // if the candidate is out of a list
+						if (!candidateInside) { // if the candidate is out of a list
 							isLeaving = true;
 						}
 					} else if (index >= 0 && candidateIndex !== index) { // the focused node is an item and focus will move out of the item
@@ -194,7 +196,9 @@ const useEventKey = (props, instances, context) => {
 
 							if (repeat && isLeaving) { // if focus is about to leave items by holding down an arrowy key
 								ev.preventDefault();
-								ev.stopPropagation();
+								if (spotlightId && !getContainerConfig(spotlightId)?.continue5WayHold) {
+									ev.stopPropagation();
+								}
 							} else if (!isLeaving) {
 								handleDirectionKeyDown(ev, 'keyDown', {direction, keyCode, repeat, target});
 							}

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -139,7 +139,7 @@ const useEventKey = (props, instances, context) => {
 					const index = !isNotItem ? getNumberValue(targetIndex) : -1;
 					const candidate = getTargetByDirectionFromElement(direction, target);
 					const candidateInside = utilDOM.containsDangerously(ev.currentTarget, candidate);
-					const candidateIndex = candidate && candidateInside && candidate.dataset && getNumberValue(candidate.dataset.index) || -1;
+					const candidateIndex = candidate && candidateInside && candidate.dataset && getNumberValue(candidate.dataset.index);
 					let isLeaving = false;
 
 					if (isNotItem) { // if the focused node is not an item
@@ -194,6 +194,7 @@ const useEventKey = (props, instances, context) => {
 								directions.left && column === 0 ||
 								directions.right && (!focusableScrollbar || !isScrollbarVisible) && (column === dimensionToExtent - 1 || index === dataSize - 1 && row === 0);
 
+							/* istanbul ignore if */
 							if (repeat && isLeaving) { // if focus is about to leave items by holding down an arrowy key
 								ev.preventDefault();
 								if (spotlightId && !getContainerConfig(spotlightId)?.continue5WayHold) {

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -10,6 +10,7 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
+import Spotlight from '@enact/spotlight';
 import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList/VirtualListBasic';
 import PropTypes from 'prop-types';
 import {Component} from 'react';
@@ -348,6 +349,9 @@ SnapToCenterVirtualGridList.parameters = {
 	propTables: [Config]
 };
 
+const numOfListsInScroller = 4;
+const idOfListsInScroller = (index) => (`vgl_${index}`);
+
 const VirtualGridListInScroller = ({args, onNext, ...rest}) => {
 	const virtualGridListProps = {
 		...rest,
@@ -368,8 +372,8 @@ const VirtualGridListInScroller = ({args, onNext, ...rest}) => {
 
 	const virtualGridLists = [];
 
-	for (let i = 0; i < 4; i++) {
-		const id = `vgl_${i}`;
+	for (let i = 0; i < numOfListsInScroller; i++) {
+		const id = idOfListsInScroller(i);
 
 		virtualGridLists.push(
 			<VirtualGridList
@@ -401,6 +405,12 @@ class VirtualGridListInScrollerSamples extends Component {
 		this.state = {
 			index: 0
 		};
+	}
+
+	componentDidMount () {
+		for (let i = 0; i < numOfListsInScroller; i++) {
+			Spotlight.set(idOfListsInScroller(i), {continue5WayHold: true});
+		}
 	}
 
 	onBack = () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus moving by holding 5-way key is blocked when it needs to across Spotlight container. To make it working, a developer can configure option [`continue5WayHold`](https://enactjs.com/docs/modules/spotlight/SpotlightContainerDecorator/#SpotlightContainerDecorator.defaultConfig.continue5WayHold) of spotlight/SpotlightContainerDecorator. In virtual lists, this config option does not work.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed `sandstone/VirtualList` to move focus properly by 5-way directional key hold when `spotlight/SpotlightContainerDecorator` config option `continue5WayHold` is set.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21706
[continue5WayHold](https://enactjs.com/docs/modules/spotlight/SpotlightContainerDecorator/#SpotlightContainerDecorator.defaultConfig.continue5WayHold)

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
