### PR TITLE
WRP-21312: change enter key behavior to match the latest UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/TabLayout` enter key behavior to match the latest UX
+
 ## [2.7.4] - 2023-07-19
 
 ### Fixed

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -298,10 +298,8 @@ const TabLayoutBase = kind({
 				} else {
 					moveTo = 'down';
 				}
-
 				Spotlight.move(moveTo);
 				ev.stopPropagation();
-
 			}
 		},
 		onKeyUp: (ev, props) => {

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -273,7 +273,7 @@ const TabLayoutBase = kind({
 						forward('onExpand', ev, props);
 					}
 				}
-			} else if (!target.hasAttribute('disabled') && is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
+			} else if (is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
 				Spotlight.setPointerMode(false);
 				ev.preventDefault();
 				let moveTo;

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -4,7 +4,6 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import TabLayout, {TabLayoutBase, Tab} from '../TabLayout';
-import Button from '../../Button';
 
 const keyDown = (keyCode) => (tab) => fireEvent.keyDown(tab, {keyCode});
 const keyUp = (keyCode) => (tab) => fireEvent.keyUp(tab, {keyCode});
@@ -195,10 +194,9 @@ describe('TabLayout specs', () => {
 	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'vertial\' and \'rtl\'', () => {
 		const spy = jest.fn();
 		render(
-			<TabLayout onSelect={spy} orientation="vertical" rtl={true}>
-				<Tab data-testid="tab" title="Play">
-					 View One
-					<div><Button>Button One</Button></div>
+			<TabLayout onSelect={spy} orientation="vertical" rtl>
+				<Tab data-testid="tab" title="Home">
+					<div>Home</div>
 				</Tab>
 			</TabLayout>
 		);
@@ -217,9 +215,8 @@ describe('TabLayout specs', () => {
 		const spy = jest.fn();
 		render(
 			<TabLayout onSelect={spy} anchorTo="end" rtl={false}>
-				<Tab data-testid="tab" title="Play">
-					 View One
-					<div><Button>Button One</Button></div>
+				<Tab data-testid="tab" title="Home">
+					<div>Home</div>
 				</Tab>
 			</TabLayout>
 		);
@@ -237,10 +234,9 @@ describe('TabLayout specs', () => {
 	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'end\' and \'rtl\'', () => {
 		const spy = jest.fn();
 		render(
-			<TabLayout onSelect={spy} anchorTo="end" rtl={true}>
-				<Tab data-testid="tab" title="Play">
-					 View One
-					<div><Button>Button One</Button></div>
+			<TabLayout onSelect={spy} anchorTo="end" rtl>
+				<Tab data-testid="tab" title="Home">
+					<div>Home</div>
 				</Tab>
 			</TabLayout>
 		);
@@ -259,9 +255,8 @@ describe('TabLayout specs', () => {
 		const spy = jest.fn();
 		render(
 			<TabLayout onSelect={spy} anchorTo="right">
-				<Tab data-testid="tab" title="Play">
-					 View One
-					<div><Button>Button One</Button></div>
+				<Tab data-testid="tab" title="Home">
+					<div>Home</div>
 				</Tab>
 			</TabLayout>
 		);
@@ -280,9 +275,8 @@ describe('TabLayout specs', () => {
 		const spy = jest.fn();
 		render(
 			<TabLayout onSelect={spy} orientation="horizontal">
-				<Tab data-testid="tab" title="Play">
-					 View One
-					<div><Button>Button One</Button></div>
+				<Tab data-testid="tab" title="Home">
+					<div>Home</div>
 				</Tab>
 			</TabLayout>
 		);

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -4,6 +4,7 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import TabLayout, {TabLayoutBase, Tab} from '../TabLayout';
+import Button from '../../Button';
 
 const keyDown = (keyCode) => (tab) => fireEvent.keyDown(tab, {keyCode});
 const keyUp = (keyCode) => (tab) => fireEvent.keyUp(tab, {keyCode});
@@ -168,10 +169,10 @@ describe('TabLayout specs', () => {
 		expect(actual).toMatchObject(expected);
 	});
 
-	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab', () => {
+	test('should call \'onSelect\' with \'onSelect\' type when \'vertical\'and pressing \'Enter\' on a tab while \'vertial\' and \'ltr\'', () => {
 		const spy = jest.fn();
 		render(
-			<TabLayout onSelect={spy} orientation="vertical">
+			<TabLayout onSelect={spy} orientation="vertical" rtl={false}>
 				<Tab icon="home" title="Home">
 					<div>Home</div>
 				</Tab>
@@ -182,6 +183,111 @@ describe('TabLayout specs', () => {
 		);
 
 		const tab = screen.getAllByTestId('tab')[1];
+		enterKeyDown(tab);
+		enterKeyUp(tab);
+
+		const expected = {type: 'onSelect'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+	});
+
+	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'vertial\' and \'rtl\'', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout onSelect={spy} orientation="vertical" rtl={true}>
+				<Tab data-testid="tab" title="Play">
+					 View One
+					<div><Button>Button One</Button></div>
+				</Tab>
+			</TabLayout>
+		);
+
+		const tab = screen.getAllByTestId('tab')[0];
+		enterKeyDown(tab);
+		enterKeyUp(tab);
+
+		const expected = {type: 'onSelect'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+	});
+
+	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'end\' and \'ltr\'', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout onSelect={spy} anchorTo="end" rtl={false}>
+				<Tab data-testid="tab" title="Play">
+					 View One
+					<div><Button>Button One</Button></div>
+				</Tab>
+			</TabLayout>
+		);
+
+		const tab = screen.getAllByTestId('tab')[0];
+		enterKeyDown(tab);
+		enterKeyUp(tab);
+
+		const expected = {type: 'onSelect'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+	});
+
+	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'end\' and \'rtl\'', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout onSelect={spy} anchorTo="end" rtl={true}>
+				<Tab data-testid="tab" title="Play">
+					 View One
+					<div><Button>Button One</Button></div>
+				</Tab>
+			</TabLayout>
+		);
+
+		const tab = screen.getAllByTestId('tab')[0];
+		enterKeyDown(tab);
+		enterKeyUp(tab);
+
+		const expected = {type: 'onSelect'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+	});
+
+	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'right\'', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout onSelect={spy} anchorTo="right">
+				<Tab data-testid="tab" title="Play">
+					 View One
+					<div><Button>Button One</Button></div>
+				</Tab>
+			</TabLayout>
+		);
+
+		const tab = screen.getAllByTestId('tab')[0];
+		enterKeyDown(tab);
+		enterKeyUp(tab);
+
+		const expected = {type: 'onSelect'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+	});
+
+	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'horizontal\'', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout onSelect={spy} orientation="horizontal">
+				<Tab data-testid="tab" title="Play">
+					 View One
+					<div><Button>Button One</Button></div>
+				</Tab>
+			</TabLayout>
+		);
+
+		const tab = screen.getAllByTestId('tab')[0];
 		enterKeyDown(tab);
 		enterKeyUp(tab);
 

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -168,7 +168,7 @@ describe('TabLayout specs', () => {
 		expect(actual).toMatchObject(expected);
 	});
 
-	test('should call \'onSelect\' with \'onSelect\' type when \'vertical\'and pressing \'Enter\' on a tab while \'vertial\' and \'ltr\'', () => {
+	test('should call \'onSelect\' with \'onSelect\' type when pressing \'Enter\' on a tab while \'vertial\' and \'ltr\'', () => {
 		const spy = jest.fn();
 		render(
 			<TabLayout onSelect={spy} orientation="vertical" rtl={false}>

--- a/tests/ui/specs/TabLayout/TabLayout-specs.js
+++ b/tests/ui/specs/TabLayout/TabLayout-specs.js
@@ -22,6 +22,17 @@ describe('TabLayout', function () {
 					expect(await actual).to.equal(expected);
 				});
 
+				it('should focus to tab content element via 5-way enter in tab menu', async function () {
+					const expected = 'Button One';
+					const originalView = (await Page.tabLayout.currentView()).getAttribute('id');
+
+					expect(await originalView).to.equal('view1');
+					await Page.spotlightSelect();
+					const actual = await browser.execute(getFocusedText);
+
+					expect(actual).to.equal(expected);
+				});
+
 				it('should not focus a spotlightDisabled tab', async function () {
 					await Page.spotlightDown(); // go to tab 2
 					await Page.spotlightDown(); // go to tab 3

--- a/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
+++ b/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
@@ -9,7 +9,7 @@ describe('TabLayout', function () {
 	describe('vertical tabs with icons', function () {
 		describe('collapsing/expanding behavior', function () {
 			describe('5-way interaction', function () {
-				it('should collapse tabs when focus is moved to a Spottable component in the content container - [QWTC-1892]', async function () {
+				it('should collapse tabs when focus is moved to a Spottable component in the content container via 5-way Right - [QWTC-1892]', async function () {
 					await Page.delay(1000);
 					// 5-way down to second tab
 					await Page.spotlightDown();
@@ -36,6 +36,19 @@ describe('TabLayout', function () {
 						await Page.spotlightLeft();
 					});
 					expect(await Page.tabLayout.isCollapsed).to.be.false();
+				});
+
+				it('should collapse tabs when focus is moved to a Spottable component in the content container via 5-way Select', async function () {
+					await Page.delay(1000);
+					// 5-way down to second tab
+					await Page.spotlightDown();
+					await (await Page.tabLayout.view(2)).waitForExist();
+					// Step 5-2: 5-way Select to Spottable component
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.spotlightSelect();
+					});
+					// check that layout is collapsed
+					expect(await Page.tabLayout.isCollapsed).to.be.true();
 				});
 
 				it('should not show disabled tab contents when focused', async function () {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Change enter key behavior of TabLayout

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move focus to the element of the tab content via 5-way enter key in the tab menu.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21312

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)