### PR TITLE
WRP-22023: Support 'back' key to escape selection mode in EditableScroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `sandstone/Scroller` back key behavior to match the latest UX when `editable` is given
+
 ### Fixed
 
 - `sandstone/Scroller` to handle focus moving properly when `editable` is given

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -606,6 +606,27 @@ const EditableWrapper = (props) => {
 					ev.stopPropagation();
 				}
 			}
+		} else if (is('cancel', keyCode)) {
+			if (!repeat) {
+				if (selectedItem) {
+					const orders = finalizeOrders();
+					finalizeEditing(orders);
+					if (selectItemBy === 'press') {
+						focusItem(ev.target);
+					}
+					mutableRef.current.needToPreventEvent = true;
+
+					setTimeout(() => {
+						announceRef.current.announce(
+							selectedItemLabel + $L('move complete'),
+							true
+						);
+					}, completeAnnounceDelay);
+
+					ev.preventDefault();
+					ev.stopPropagation();
+				}
+			}
 		}
 	}, [finalizeEditing, finalizeOrders, findItemNode, focusItem, moveItemsByKeyDown, reset, selectItemBy, startEditing]);
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
An updated UX requires to exit 'selecting' state when 'back' key is pressed just as 'ok' key is pressed.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added behavior for 'back' key so that selection mode is finished with saving editing.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-22023

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
