### PR TITLE
WRP-21680: Add initialSelected prop in `editable` prop  of scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/Scroller` prop `editable.initialSelected` to allow start edit mode with selected item
+
 ### Fixed
 
 - `sandstone/Scroller` to handle focus moving properly when `editable` is given

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -509,12 +509,12 @@ const EditableWrapper = (props) => {
 	}, [scrollContainerHandle, scrollContentRef]);
 
 	const handleMouseMove = useCallback((ev) => {
-		if (mutableRef.current.selectedItem && Number(mutableRef.current.selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
-			const {clientX} = ev;
+		const {clientX} = ev;
+		mutableRef.current.lastMouseClientX = clientX;
 
+		if (mutableRef.current.selectedItem && Number(mutableRef.current.selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
 			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
-			mutableRef.current.lastMouseClientX = clientX;
 			mutableRef.current.lastInputType = 'mouse';
 			moveItems(toIndex);
 		}
@@ -747,6 +747,7 @@ const EditableWrapper = (props) => {
 			const initialSelectedItem = wrapperRef.current.children[initialSelected.itemIndex - 1];
 			if (initialSelectedItem?.dataset.index) {
 				mutableRef.current.focusedItem = initialSelectedItem;
+				mutableRef.current.lastMouseClientX = initialSelected.mouseClientX;
 				startEditing(initialSelectedItem);
 				setPointerMode(false);
 				Spotlight.focus(initialSelectedItem.children[1]);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -196,7 +196,7 @@ const EditableWrapper = (props) => {
 	}, [dataSize]);
 
 	const startEditing = useCallback((item) => {
-		if (item.dataset?.index && (!item.hasAttribute('disabled') || item.className.includes('hidden'))) {
+		if (item?.dataset?.index && (!item.hasAttribute('disabled') || item.className.includes('hidden'))) {
 			item.classList.add(componentCss.selected, customCss.selected);
 			mutableRef.current.selectedItem = item;
 			mutableRef.current.focusedItem?.classList.remove(customCss.focused);
@@ -724,12 +724,14 @@ const EditableWrapper = (props) => {
 	useLayoutEffect(() => {
 		if (initialSelected?.itemIndex) {
 			const initialSelectedItem = wrapperRef.current.children[initialSelected.itemIndex - 1];
-			mutableRef.current.focusedItem = initialSelectedItem;
-			startEditing(initialSelectedItem);
-			setPointerMode(false);
-			Spotlight.focus(initialSelectedItem.children[1]);
+			if (initialSelectedItem?.dataset.index) {
+				mutableRef.current.focusedItem = initialSelectedItem;
+				startEditing(initialSelectedItem);
+				setPointerMode(false);
+				Spotlight.focus(initialSelectedItem.children[1]);
+			}
 		}
-	}, [initialSelected?.itemIndex, startEditing]);
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<TouchableDiv

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -200,7 +200,7 @@ const EditableWrapper = (props) => {
 			item.classList.add(componentCss.selected, customCss.selected);
 			mutableRef.current.selectedItem = item;
 			mutableRef.current.focusedItem?.classList.remove(customCss.focused);
-			mutableRef.current.focusedItem = null;
+
 			mutableRef.current.selectedItemLabel = (item.ariaLabel || item.textContent) + ' ';
 
 			mutableRef.current.fromIndex = Number(item.style.order) - 1;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -6,7 +6,7 @@ import Spotlight, {getDirection} from '@enact/spotlight';
 import {getContainersForNode} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import Accelerator from '@enact/spotlight/Accelerator';
-import {setPointerMode} from '@enact/spotlight/src/pointer';
+import {getLastPointerPosition, setPointerMode} from '@enact/spotlight/src/pointer';
 import {Announce} from '@enact/ui/AnnounceDecorator';
 import Touchable from '@enact/ui/Touchable';
 import classNames from 'classnames';
@@ -200,7 +200,7 @@ const EditableWrapper = (props) => {
 			item.classList.add(componentCss.selected, customCss.selected);
 			mutableRef.current.selectedItem = item;
 			mutableRef.current.focusedItem?.classList.remove(customCss.focused);
-
+			mutableRef.current.focusedItem = null;
 			mutableRef.current.selectedItemLabel = (item.ariaLabel || item.textContent) + ' ';
 
 			mutableRef.current.fromIndex = Number(item.style.order) - 1;
@@ -618,7 +618,7 @@ const EditableWrapper = (props) => {
 					mutableRef.current.needToPreventEvent = true;
 
 					setTimeout(() => {
-						announceRef.current.announce(
+						announceRef?.current?.announce(
 							selectedItemLabel + $L('move complete'),
 							true
 						);
@@ -683,25 +683,25 @@ const EditableWrapper = (props) => {
 		};
 	}, [handleMouseLeave, scrollContainerRef]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (removeItemFuncRef) {
 			removeItemFuncRef.current = removeItem;
 		}
 	}, [removeItem, removeItemFuncRef]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (hideItemFuncRef) {
 			hideItemFuncRef.current = hideItem;
 		}
 	}, [hideItem, hideItemFuncRef]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (showItemFuncRef) {
 			showItemFuncRef.current = showItem;
 		}
 	}, [showItem, showItemFuncRef]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (focusItemFuncRef) {
 			focusItemFuncRef.current = focusItem;
 		}
@@ -747,7 +747,7 @@ const EditableWrapper = (props) => {
 			const initialSelectedItem = wrapperRef.current.children[initialSelected.itemIndex - 1];
 			if (initialSelectedItem?.dataset.index) {
 				mutableRef.current.focusedItem = initialSelectedItem;
-				mutableRef.current.lastMouseClientX = initialSelected.mouseClientX;
+				mutableRef.current.lastMouseClientX = getLastPointerPosition().x;
 				startEditing(initialSelectedItem);
 				setPointerMode(false);
 				Spotlight.focus(initialSelectedItem.children[1]);

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -116,6 +116,7 @@ export const EditableIcon = (args) => {
 		setEditMode(mode => !mode);
 		mutableRef.current.initialSelected.scrollLeft = 0;
 		mutableRef.current.initialSelected.itemIndex = null;
+		mutableRef.current.initialSelected.mouseClientX = null;
 		mutableRef.current.timer = null;
 	}, [setEditMode]);
 
@@ -155,6 +156,7 @@ export const EditableIcon = (args) => {
 			const targetItemNode = findItemNode(ev.target);
 			if (targetItemNode && targetItemNode.style.order) {
 				mutableRef.current.initialSelected.itemIndex = targetItemNode.style.order;
+				mutableRef.current.initialSelected.mouseClientX = ev.clientX;
 			}
 		}
 	}, [findItemNode]);
@@ -213,6 +215,7 @@ export const EditableIcon = (args) => {
 				setEditMode(false);
 				mutableRef.current.initialSelected.scrollLeft = 0;
 				mutableRef.current.initialSelected.itemIndex = null;
+				mutableRef.current.initialSelected.mouseClientX = null;
 				mutableRef.current.timer = null;
 			}
 		});

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -116,7 +116,6 @@ export const EditableIcon = (args) => {
 		setEditMode(mode => !mode);
 		mutableRef.current.initialSelected.scrollLeft = 0;
 		mutableRef.current.initialSelected.itemIndex = null;
-		mutableRef.current.initialSelected.mouseClientX = null;
 		mutableRef.current.timer = null;
 	}, [setEditMode]);
 
@@ -156,7 +155,6 @@ export const EditableIcon = (args) => {
 			const targetItemNode = findItemNode(ev.target);
 			if (targetItemNode && targetItemNode.style.order) {
 				mutableRef.current.initialSelected.itemIndex = targetItemNode.style.order;
-				mutableRef.current.initialSelected.mouseClientX = ev.clientX;
 			}
 		}
 	}, [findItemNode]);
@@ -215,7 +213,6 @@ export const EditableIcon = (args) => {
 				setEditMode(false);
 				mutableRef.current.initialSelected.scrollLeft = 0;
 				mutableRef.current.initialSelected.itemIndex = null;
-				mutableRef.current.initialSelected.mouseClientX = null;
 				mutableRef.current.timer = null;
 			}
 		});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Enable the editable scroller to start with the selected item when initial item info is given in the `editable` prop

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
If editable.initialSelected is given, call startEditing() function to make the initial item selected
Implement qa-sampler of IconItem to start the edit mode of the scroller by long pressing item in the scroller

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21680

### Comments
