### PR TITLE
WRP-21684: Support apps to show arrow only for moveable direction

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -70,6 +70,14 @@ const holdConfig = {
 	]
 };
 
+const addRemoveClass = (node, className, condition) => {
+	if (condition) {
+		node.classList.add(className);
+	} else {
+		node.classList.remove(className);
+	}
+};
+
 /**
  * A Sandstone-styled EditableWrapper.
  *
@@ -195,6 +203,11 @@ const EditableWrapper = (props) => {
 
 	}, [dataSize]);
 
+	const updateArrowIcon = useCallback((index) => {
+		addRemoveClass(mutableRef.current.selectedItem, customCss.noBefore, index === 0);
+		addRemoveClass(mutableRef.current.selectedItem, customCss.noAfter, index === mutableRef.current.hideIndex - 1);
+	}, [customCss.noBefore, customCss.noAfter]);
+
 	const startEditing = useCallback((item) => {
 		if (item?.dataset?.index && (!item.hasAttribute('disabled') || item.className.includes('hidden'))) {
 			item.classList.add(componentCss.selected, customCss.selected);
@@ -206,11 +219,13 @@ const EditableWrapper = (props) => {
 			mutableRef.current.fromIndex = Number(item.style.order) - 1;
 			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
 
+			updateArrowIcon(mutableRef.current.fromIndex);
+
 			announceRef.current.announce(
 				mutableRef.current.selectedItemLabel + $L('Move left and right or press up key to delete')
 			);
 		}
-	}, [customCss.focused, customCss.selected]);
+	}, [customCss.focused, customCss.selected, updateArrowIcon]);
 
 	const finalizeEditing = useCallback((orders) => {
 		forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
@@ -383,9 +398,11 @@ const EditableWrapper = (props) => {
 
 					mutableRef.current.prevToIndex = toIndex;
 				}
+
+				updateArrowIcon(toIndex);
 			}
 		}
-	}, [addRearrangedItems, removeRearrangedItems, scrollContainerHandle]);
+	}, [addRearrangedItems, removeRearrangedItems, scrollContainerHandle, updateArrowIcon]);
 
 	const moveItemsByKeyDown = useCallback((ev) => {
 		const {keyCode} = ev;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -70,14 +70,6 @@ const holdConfig = {
 	]
 };
 
-const addRemoveClass = (node, className, condition) => {
-	if (condition) {
-		node.classList.add(className);
-	} else {
-		node.classList.remove(className);
-	}
-};
-
 /**
  * A Sandstone-styled EditableWrapper.
  *
@@ -204,8 +196,8 @@ const EditableWrapper = (props) => {
 	}, [dataSize]);
 
 	const updateArrowIcon = useCallback((index) => {
-		addRemoveClass(mutableRef.current.selectedItem, customCss.noBefore, index === 0);
-		addRemoveClass(mutableRef.current.selectedItem, customCss.noAfter, index === mutableRef.current.hideIndex - 1);
+		mutableRef.current.selectedItem?.classList.toggle(customCss.noBefore, index === 0);
+		mutableRef.current.selectedItem?.classList.toggle(customCss.noAfter, index === mutableRef.current.hideIndex - 1);
 	}, [customCss.noBefore, customCss.noAfter]);
 
 	const startEditing = useCallback((item) => {

--- a/samples/sampler/stories/qa/IconItem.module.less
+++ b/samples/sampler/stories/qa/IconItem.module.less
@@ -99,13 +99,13 @@
 			opacity: 1;
 		}
 
-		&:not(.hidden)::before {
+		&:not(.hidden):not(.noBefore)::before {
 			content: '\EFFF3';
 			.arrow();
 			left: -30px;
 		}
 
-		&:not(.hidden)::after {
+		&:not(.hidden):not(.noAfter)::after {
 			content: '\EFFF4';
 			.arrow();
 			right: -30px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Apps need to show or hide arrow indicator for moveable direction.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated `EditableScroller` to add or remove 'noBefore' and/or 'noAfter' class names so that apps can use to display arrows.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21684

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)