### PR TITLE
WRP-20670: Support A11y for Editable scroller according to the latest UX

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -234,7 +234,7 @@ const EditableWrapper = (props) => {
 			mutableRef.current.focusedItem?.classList.add(customCss.focused);
 			mutableRef.current.prevToIndex = Number(itemNode.style.order) - 1;
 			const focusedItemLabel = (itemNode.ariaLabel || itemNode.textContent) + ' ';
-			if (!announceDisabled && (!item.hasAttribute('disabled') || item.className.includes('hidden'))) {
+			if (!announceDisabled && (!itemNode.hasAttribute('disabled') || itemNode.className.includes('hidden'))) {
 				setTimeout(() => {
 					announceRef.current.announce(
 						focusedItemLabel + $L('Press OK key to move or press up key for other actions')

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -207,7 +207,7 @@ const EditableWrapper = (props) => {
 			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
 
 			announceRef.current.announce(
-				mutableRef.current.selectedItemLabel + $L('Move left and right or press up key to delete')
+				mutableRef.current.selectedItemLabel + $L('Move left and right or press up key for other actions')
 			);
 		}
 	}, [customCss.focused, customCss.selected]);
@@ -226,13 +226,21 @@ const EditableWrapper = (props) => {
 		return null;
 	}, [scrollContentRef]);
 
-	const focusItem = useCallback((target) => {
+	const focusItem = useCallback((target, announceDisabled = false) => {
 		const itemNode = findItemNode(target);
 		if (itemNode && !mutableRef.current.selectedItem) {
 			mutableRef.current.focusedItem?.classList.remove(customCss.focused);
 			mutableRef.current.focusedItem = itemNode;
 			mutableRef.current.focusedItem?.classList.add(customCss.focused);
 			mutableRef.current.prevToIndex = Number(itemNode.style.order) - 1;
+			const focusedItemLabel = (itemNode.ariaLabel || itemNode.textContent) + ' ';
+			if (!announceDisabled && (!item.hasAttribute('disabled') || item.className.includes('hidden'))) {
+				setTimeout(() => {
+					announceRef.current.announce(
+						focusedItemLabel + $L('Press OK key to move or press up key for other actions')
+					);
+				}, completeAnnounceDelay);
+			}
 		}
 	}, [customCss.focused, findItemNode]);
 
@@ -257,7 +265,7 @@ const EditableWrapper = (props) => {
 			const orders = finalizeOrders();
 			finalizeEditing(orders);
 			if (selectItemBy === 'press') {
-				focusItem(ev.target);
+				focusItem(ev.target, true);
 			}
 			mutableRef.current.needToPreventEvent = true;
 		} else {
@@ -551,7 +559,7 @@ const EditableWrapper = (props) => {
 					const orders = finalizeOrders();
 					finalizeEditing(orders);
 					if (selectItemBy === 'press') {
-						focusItem(ev.target);
+						focusItem(ev.target, true);
 					}
 					mutableRef.current.needToPreventEvent = true;
 
@@ -613,7 +621,7 @@ const EditableWrapper = (props) => {
 					const orders = finalizeOrders();
 					finalizeEditing(orders);
 					if (selectItemBy === 'press') {
-						focusItem(ev.target);
+						focusItem(ev.target, true);
 					}
 					mutableRef.current.needToPreventEvent = true;
 

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -253,7 +253,7 @@ export const EditableIcon = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
@@ -261,7 +261,6 @@ export const EditableIcon = (args) => {
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											{...item.iconItemProps}
-											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
 											className={css.editableIconItem}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
 											onClick={action('onClickItem')}
@@ -289,11 +288,11 @@ export const EditableIcon = (args) => {
 							<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
 								items.map((item, index) => {
 									return (
-										<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+										<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 											<div className={css.removeButtonContainer} />
 											<IconItem
 												{...item.iconItemProps}
-												aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
+												aria-label={`Icon ${item.index}. Edit mode to press and hold OK key`}
 												className={css.iconItem}
 												disabled={item.iconItemProps['disabled'] || item.hidden}
 												onClick={action('onClickItem')}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -346,7 +346,6 @@ export const EditableList = (args) => {
 											{item.disabled ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
 										</ContainerDivWithLeaveForConfig>
 										<ImageItem
-											aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
 											src={item.src}
 											className={css.imageItem}
 											disabled={item.disabled}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Need to update A11y feature of the editable scroller as the previous version can only support delete motion

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Specs:
- When focus items in Scroller in normal mode (It is implemented in the sampler. It should be implemented on App)
item label + <"Edit mode to press and hold OK key">
- When focus items in Scroller in edit mode
item label + <"Press OK key to move or press up key for other actions">

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-20670

### Comments
