### PR TITLE
WRP-21913: Fix QuickGuidePanels to not lose focus when the last view is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/QuickGuidePanels` to not lose focus when the last view is displayed
+
 ## [2.7.5] - 2023-08-04
 
 ### Added

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -384,7 +384,6 @@ const WizardPanelsBase = kind({
 					futureIcon={'circle'}
 					current={currentStep}
 					layout="quickGuidePanels"
-					slot="slotAbove"
 					total={totalSteps}
 				/> :
 				<Steps
@@ -395,7 +394,7 @@ const WizardPanelsBase = kind({
 				/>
 			);
 		},
-		prevNavigationButton: ({index, onPrevClick, prevButton, prevButtonVisibility}) => {
+		prevNavigationButton: ({fullScreenContent, index, onPrevClick, prevButton, prevButtonVisibility}) => {
 			const isPrevButtonVisible = prevButtonVisibility === 'always' || (prevButtonVisibility === 'auto' && index !== 0);
 
 			return (
@@ -409,12 +408,12 @@ const WizardPanelsBase = kind({
 					iconFlip="auto"
 					minWidth={false}
 					onClick={onPrevClick}
-					slot="slotBefore"
+					slot={fullScreenContent ? null : 'slotBefore'}
 					visible={isPrevButtonVisible}
 				/>
 			);
 		},
-		nextNavigationButton: ({index, nextButton, nextButtonVisibility, onNextClick, totalPanels}) => {
+		nextNavigationButton: ({fullScreenContent, index, nextButton, nextButtonVisibility, onNextClick, totalPanels}) => {
 			const isNextButtonVisible = nextButtonVisibility === 'always' || (nextButtonVisibility === 'auto' && index < totalPanels - 1);
 
 			return (
@@ -427,9 +426,10 @@ const WizardPanelsBase = kind({
 					icon="arrowlargeright"
 					iconFlip="auto"
 					iconPosition="after"
+					id={fullScreenContent ? 'fullScreenNextButton' : null}
 					minWidth={false}
 					onClick={onNextClick}
-					slot="slotAfter"
+					slot={fullScreenContent ? null : 'slotAfter'}
 					visible={isNextButtonVisible}
 				/>
 			);
@@ -483,7 +483,7 @@ const WizardPanelsBase = kind({
 						size="small"
 					/>
 				</Row>
-				<Row className={css.navigationButtonContainer}>
+				<Row className={css.fullScreenNavigationButtonContainer}>
 					<Cell shrink>
 						{prevNavigationButton}
 					</Cell>
@@ -496,6 +496,8 @@ const WizardPanelsBase = kind({
 					arranger={BasicArranger}
 					duration={400}
 					noAnimation
+					onTransition={onTransition}
+					onWillTransition={onWillTransition}
 				>
 					{children}
 				</ViewManager>
@@ -744,7 +746,7 @@ const WizardPanelsDecorator = compose(
 	SpotlightContainerDecorator({
 		continue5WayHold: true,
 		// prefer any spottable within the panel body (content or footer) followed by header
-		defaultElement: [`.${spotlightDefaultClass}`, `.${css.content} *, .${css.footer} *`, 'header > *'],
+		defaultElement: [`.${spotlightDefaultClass}`, `.${css.content} *, .${css.footer} *`, 'header > *', `#fullScreenNextButton`, `.${css.close} *`],
 		enterTo: 'default-element'
 	}),
 	I18nContextDecorator({rtlProp: 'rtl'}),

--- a/WizardPanels/WizardPanels.module.less
+++ b/WizardPanels/WizardPanels.module.less
@@ -38,7 +38,7 @@
 	}
 }
 
-.navigationButtonContainer {
+.fullScreenNavigationButtonContainer {
 	z-index: 10;
 	margin-top: @sand-wizardpanels-fullScreenContent-container-margin-top;
 

--- a/tests/screenshot/apps/components/QuickGuidePanels.js
+++ b/tests/screenshot/apps/components/QuickGuidePanels.js
@@ -12,6 +12,14 @@ const defaultQuickGuidePanelsTests = [
 		<Panel>View 1</Panel>
 		<Panel>View 2</Panel>
 		<Panel>View 3</Panel>
+	</QuickGuidePanels>,
+	<QuickGuidePanels index={2}>
+		<Panel>View 1</Panel>
+		<Panel>View 2</Panel>
+		<Panel>View 3</Panel>
+	</QuickGuidePanels>,
+	<QuickGuidePanels>
+		<Panel>View 1</Panel>
 	</QuickGuidePanels>
 ];
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the last view of QuickGuidePanels is displayed, focus disappear.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix QuickGuidePanels not to lose focus when the last view is displayed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21913

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
