### PR TITLE
WRP-22553: Fix Dropdown to focus properly the first option and the last option via page up and page down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Dropdown' to focus properly the first option and the last option via page up and page down
+
 ## [2.7.5] - 2023-08-04
 
 ### Added

--- a/tests/ui/apps/Dropdown/Dropdown-View.js
+++ b/tests/ui/apps/Dropdown/Dropdown-View.js
@@ -29,6 +29,9 @@ const app = (props) => <div {...props}>
 		<Dropdown id="dropdownDefault" title="Default">
 			{['one', 'two', 'three', 'four', 'five']}
 		</Dropdown>
+		<Dropdown id="dropdownMoreChildren" title="More Children">
+			{['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']}
+		</Dropdown>
 		<Dropdown id="dropdownSelected" defaultSelected={1} title="Selected">
 			{['one', 'two', 'three', 'four', 'five']}
 		</Dropdown>

--- a/tests/ui/specs/Dropdown/Dropdown-specs.js
+++ b/tests/ui/specs/Dropdown/Dropdown-specs.js
@@ -99,6 +99,36 @@ describe('Dropdown', function () {
 			// Verify Step 8: The 'Default' Dropdown is closed.
 			expect(await dropdown.list.isExisting()).to.not.be.true();
 		});
+
+		it('should move Spotlight to the next/previous item on PageDown/PageUp', async function () {
+			const dropdown = Page.components.dropdownMoreChildren;
+
+			// 5-way Spot and 5-way Select the 'More Children' Dropdown.
+			await Page.openDropdown(dropdown);
+			// Verify: The 'Default' Dropdown opens.
+			// Verify: Spotlight is on the first option.
+			waitForFocusedText(dropdown, 'one', 500, undefined, 100);
+
+			// ChannelDown(PageDown).
+			// Verify: Spotlight is on the fifth option.
+			await Page.pageDown();
+			waitForFocusedText(dropdown, 'five', 500, undefined, 100);
+
+			// ChannelDown(PageDown) to the last option.
+			// Verify: Spotlight is on the ninth option.
+			await Page.pageDown();
+			waitForFocusedText(dropdown, 'nine', 500, undefined, 100);
+
+			// ChannelUp(PageUp).
+			// Verify: Spotlight is on the sixth option.
+			await Page.pageUp();
+			waitForFocusedText(dropdown, 'six', 500, undefined, 100);
+
+			// ChannelUp(PageUp) to the first option.
+			// Verify: Spotlight is on the first option.
+			await Page.pageUp();
+			waitForFocusedText(dropdown, 'one', 500, undefined, 100);
+		});
 	});
 
 	describe('pointer', function () {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -12,6 +12,7 @@ import {forward} from '@enact/core/handle';
 import platform from '@enact/core/platform';
 import Spotlight from '@enact/spotlight';
 import {spottableClass} from '@enact/spotlight/Spottable';
+import {getContainerId} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import {assignPropertiesOf, constants, useScrollBase} from '@enact/ui/useScroll';
@@ -57,7 +58,7 @@ const dataIndexAttribute = 'data-index';
 const isIntersecting = (elem, container) => elem && intersects(getRect(container), getRect(elem));
 const getIntersectingElement = (elem, container) => isIntersecting(elem, container) && elem;
 const getTargetInViewByDirectionFromPosition = (direction, position, container) => {
-	const target = getTargetByDirectionFromPosition(direction, position, container);
+	const target = getTargetByDirectionFromPosition(direction, position, getContainerId(container));
 	return getIntersectingElement(target, container);
 };
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus disappears on the first options and the last options when pressing page up/down on Dropdown that has more than 5 options.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs after #1437. The cause is that a logic uses DOM node rather than Spotlight container ID to find Spotlight target after scrolling from the same position as before scrolling. To avoid issue of #1437, I updated the logic to use Spotlight container ID of the same DOM node the logic used instead of revert the PR.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
UI tests are added.

### Links
[//]: # (Related issues, references)
WRP-22553
#1437

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
