### PR TITLE
WRP-20670: Update phrase of editable scroller a11y

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -214,7 +214,7 @@ const EditableWrapper = (props) => {
 			updateArrowIcon(mutableRef.current.fromIndex);
 
 			announceRef.current.announce(
-				mutableRef.current.selectedItemLabel + $L('Move left and right or press up key for other actions')
+				mutableRef.current.selectedItemLabel + $L('Press left or right button to move or press up button for other actions')
 			);
 		}
 	}, [customCss.focused, customCss.selected, updateArrowIcon]);
@@ -244,7 +244,7 @@ const EditableWrapper = (props) => {
 			if (!announceDisabled && (!itemNode.hasAttribute('disabled') || itemNode.className.includes('hidden'))) {
 				setTimeout(() => {
 					announceRef.current.announce(
-						focusedItemLabel + $L('Press OK key to move or press up key for other actions')
+						focusedItemLabel + $L('Press OK button to move or press up button for other actions')
 					);
 				}, completeAnnounceDelay);
 			}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -292,7 +292,7 @@ export const EditableIcon = (args) => {
 											<div className={css.removeButtonContainer} />
 											<IconItem
 												{...item.iconItemProps}
-												aria-label={`Icon ${item.index}. Edit mode to press and hold OK key`}
+												aria-label={`Icon ${item.index}. Edit mode to press and hold OK button`}
 												className={css.iconItem}
 												disabled={item.iconItemProps['disabled'] || item.hidden}
 												onClick={action('onClickItem')}
@@ -379,12 +379,12 @@ export const EditableIconWithLongPress = (args) => {
 			{
 				items.map((item, index) => {
 					return (
-						<div key={item.index} className={css.itemWrapper} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+						<div key={item.index} className={css.itemWrapper} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
 							<div className={css.removeButtonContainer}>
 								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
 							</div>
 							<IconItem
-								aria-label={`Image ${item.index}. Edit mode to press and hold OK key`}
+								aria-label={`Icon ${item.index}. Edit mode to press and hold OK button`}
 								className={css.iconItem}
 								onClick={action('onClickItem')}
 								{...item.iconItemProps}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some a11y phrase of editable scroller updated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added phrase:
`Press OK button to move or press up button for other actions`
`Press left or right button to move or press up button for other actions`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-20670

### Comments
