### PR TITLE
WRP-23234: Add a11y feature for sandstone/QuickGuidePanels 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/QuickGuidePanels` read out feature to support A11y
+
 ## [2.7.6] - 2023-08-10
 
 ### Changed

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -485,8 +485,7 @@ const WizardPanelsBase = kind({
 
 		return ( fullScreenContent ?
 			<article role="region" aria-labelledby={`quickguidepanel_index_${index}`} ref={rest.componentRef}>
-				<div aria-label={ariaLabel} id={`quickguidepanel_index_${index}`} />
-				<Column {...rest}>
+				<Column aria-label={ariaLabel} id={`quickguidepanel_index_${index}`} {...rest}>
 					<Row className={css.fullScreenContentHeader}>
 						{steps}
 						{closeButton}

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -372,6 +372,17 @@ const WizardPanelsBase = kind({
 				noSubtitle
 			}
 		),
+		closeButton: ({closeButtonAriaLabel, onClose, totalPanels}) => {
+			return (
+				totalPanels ? <Button
+					aria-label={closeButtonAriaLabel == null ? $L('Exit quick guide') : closeButtonAriaLabel}
+					className={css.close}
+					icon="closex"
+					onClick={onClose}
+					size="small"
+				/> : null
+			);
+		},
 		steps: ({current, fullScreenContent, index, noSteps, total, totalPanels}) => {
 			const currentStep = (noSteps && 1) || ((typeof current === 'number' && current > 0) ? current : (index + 1));
 			const totalSteps = (noSteps && 1) || ((typeof total === 'number' && total > 0) ? total : totalPanels);
@@ -439,7 +450,7 @@ const WizardPanelsBase = kind({
 	render: ({
 		'aria-label': ariaLabel,
 		children,
-		closeButtonAriaLabel,
+		closeButton,
 		footer,
 		fullScreenContent,
 		index,
@@ -447,7 +458,6 @@ const WizardPanelsBase = kind({
 		nextNavigationButton,
 		noAnimation,
 		noSubtitle,
-		onClose,
 		onTransition,
 		onWillTransition,
 		reverseTransition,
@@ -456,10 +466,12 @@ const WizardPanelsBase = kind({
 		title,
 		...rest
 	}) => {
+		delete rest.closeButtonAriaLabel;
 		delete rest.current;
 		delete rest.nextButton;
 		delete rest.nextButtonVisibility;
 		delete rest.noSteps;
+		delete rest.onClose;
 		delete rest.onNextClick;
 		delete rest.onPrevClick;
 		delete rest.prevButton;
@@ -477,13 +489,7 @@ const WizardPanelsBase = kind({
 				<Column {...rest}>
 					<Row className={css.fullScreenContentHeader}>
 						{steps}
-						<Button
-							aria-label={closeButtonAriaLabel == null ? $L('Exit quick guide') : closeButtonAriaLabel}
-							className={css.close}
-							icon="closex"
-							onClick={onClose}
-							size="small"
-						/>
+						{closeButton}
 					</Row>
 					<Row className={css.fullScreenNavigationButtonContainer}>
 						<Cell shrink>

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -472,36 +472,39 @@ const WizardPanelsBase = kind({
 		}
 
 		return ( fullScreenContent ?
-			<Column {...rest}>
-				<Row className={css.fullScreenContentHeader}>
-					{steps}
-					<Button
-						aria-label={closeButtonAriaLabel == null ? $L('Exit quick guide') : closeButtonAriaLabel}
-						className={css.close}
-						icon="closex"
-						onClick={onClose}
-						size="small"
-					/>
-				</Row>
-				<Row className={css.fullScreenNavigationButtonContainer}>
-					<Cell shrink>
-						{prevNavigationButton}
-					</Cell>
-					<Cell />
-					<Cell shrink>
-						{nextNavigationButton}
-					</Cell>
-				</Row>
-				<ViewManager
-					arranger={BasicArranger}
-					duration={400}
-					noAnimation
-					onTransition={onTransition}
-					onWillTransition={onWillTransition}
-				>
-					{children}
-				</ViewManager>
-			</Column> :
+			<article role="region" aria-labelledby={`quickguidepanel_index_${index}`} ref={rest.componentRef}>
+				<div aria-label={ariaLabel} id={`quickguidepanel_index_${index}`} />
+				<Column {...rest}>
+					<Row className={css.fullScreenContentHeader}>
+						{steps}
+						<Button
+							aria-label={closeButtonAriaLabel == null ? $L('Exit quick guide') : closeButtonAriaLabel}
+							className={css.close}
+							icon="closex"
+							onClick={onClose}
+							size="small"
+						/>
+					</Row>
+					<Row className={css.fullScreenNavigationButtonContainer}>
+						<Cell shrink>
+							{prevNavigationButton}
+						</Cell>
+						<Cell />
+						<Cell shrink>
+							{nextNavigationButton}
+						</Cell>
+					</Row>
+					<ViewManager
+						arranger={BasicArranger}
+						duration={400}
+						noAnimation
+						onTransition={onTransition}
+						onWillTransition={onWillTransition}
+					>
+						{children}
+					</ViewManager>
+				</Column>
+			</article> :
 			<DecoratedPanelBase
 				{...rest}
 				header={

--- a/samples/sampler/stories/default/QuickGuidePanels.js
+++ b/samples/sampler/stories/default/QuickGuidePanels.js
@@ -33,7 +33,7 @@ export const _QuickGuidePanels = (args) => (
 				This is Panel 1
 			</div>
 		</QuickGuidePanels.Panel>
-		<QuickGuidePanels.Panel>
+		<QuickGuidePanels.Panel aria-label={'aria test'}>
 			This is Panel 2
 		</QuickGuidePanels.Panel>
 	</QuickGuidePanels>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Need to support A11y feature for sandstone/QuickGuidePanels

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- When entering the panel, read out the step number and read out which button is focused

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-23234

### Comments
