### PR TITLE
WRP-24596: Fix EditableScroller to allow hiding all items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/QuickGuidePanels` read out feature to support A11y
 
+### Fixed
+
+- `sandstone/Scroller` to support hiding all items when `editable` is given
+
 ## [2.7.6] - 2023-08-10
 
 ### Changed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -135,7 +135,7 @@ const EditableWrapper = (props) => {
 	});
 	const announceRef = useRef({});
 
-	mutableRef.current.hideIndex = editable?.hideIndex || dataSize;
+	mutableRef.current.hideIndex = editable?.hideIndex ?? dataSize;
 
 	// Functions
 

--- a/tests/ui/apps/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem-View.js
+++ b/tests/ui/apps/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem-View.js
@@ -1,0 +1,181 @@
+import classNames from 'classnames';
+import spotlight from '@enact/spotlight';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import Cell from '@enact/ui/Layout';
+import ri from '@enact/ui/resolution';
+import {Component, createRef} from 'react';
+
+import Button from '../../../../../Button/Button';
+import IconItem from '../../../../../IconItem';
+import {InputField} from '../../../../../Input';
+import Scroller from '../../../../../Scroller/Scroller';
+import ThemeDecorator from '../../../../../ThemeDecorator/ThemeDecorator';
+import css from './EditableScrollerWithIconItem.module.less';
+
+const ScrollerContainer = SpotlightContainerDecorator('div');
+const OptionsContainer = SpotlightContainerDecorator({leaveFor: {down: '#left'}}, 'div');
+const ItemButtonsContainer = SpotlightContainerDecorator({leaveFor: {left: '', right: ''}}, 'div');
+
+// NOTE: Forcing pointer mode off so we can be sure that regardless of webOS pointer mode the app
+// runs the same way
+spotlight.setPointerMode(false);
+
+const iconItems = [];
+const icons = [
+	'bgm',
+	'bookmark',
+	'browser',
+	'camera',
+	'demosync',
+	'ftp',
+	'gamepad',
+	'network'
+];
+
+const updateDataSize = (dataSize) => {
+	iconItems.length = 0;
+
+	for (let index = 0; index < dataSize; index++) {
+		const props = {
+			background: '#' + Math.floor(Math.random() * (0x1000000 - 0x808080) + 0x404040).toString(16),
+			bordered: index < 2,
+			icon: icons[index % icons.length],
+			label: icons[index % icons.length].toLocaleUpperCase(),
+			labelOn: (index % 3 ) === 2 ? 'focus' : null
+		};
+
+		iconItems.push({index, props: {...props}});
+	}
+	return dataSize;
+};
+
+class app extends Component {
+	constructor (props) {
+		super(props);
+		this.state = {
+			editableCentered: true,
+			nativeScroll: true,
+			numItems: 10,
+			items: iconItems
+		};
+		this.hideIndex = null;
+		this.removeItem = createRef();
+		this.hideItem = createRef();
+		this.showItem = createRef();
+		this.focusItem = createRef();
+		this.scrollingRef = createRef();
+		updateDataSize(this.state.numItems);
+	}
+
+	onToggle = ({currentTarget}) => {
+		const key = currentTarget.getAttribute('id');
+		this.setState((state) => ({[key]: !state[key]}));
+	};
+
+	onChangeNumItems = ({value}) => {
+		this.setState({numItems: value});
+		updateDataSize(value);
+	};
+
+	handleComplete = (ev) => {
+		const {orders, hideIndex} = ev;
+		this.hideIndex = hideIndex;
+
+		// change data from the new orders
+		const newItems = [];
+
+		orders.forEach(order => {
+			newItems.push(this.state.items[order - 1]);
+		});
+
+		for (let i = 0; i < orders.length; i++) {
+			newItems[i].hidden = (i >= hideIndex);
+		}
+
+		this.setState({items: newItems});
+	};
+
+	onClickHideButton = (ev) => {
+		if (this.hideItem.current) {
+			this.hideItem.current();
+		}
+		ev.preventDefault();
+		ev.stopPropagation();
+	};
+
+	onClickShowButton = (ev) => {
+		if (this.showItem.current) {
+			this.showItem.current();
+		}
+		ev.preventDefault();
+		ev.stopPropagation();
+	};
+
+	onFocusItem = (ev) => {
+		if (this.focusItem.current) {
+			this.focusItem.current(ev.target);
+		}
+		ev.preventDefault();
+		ev.stopPropagation();
+	};
+
+	render () {
+		const {editableCentered, nativeScroll, numItems, items} = this.state;
+		const buttonDefaultProps = {minWidth: false, size: 'small'};
+		const scrollMode = nativeScroll ? 'NativeScroll' : 'TranslateScroll';
+		const inputStyle = {width: ri.scaleToRem(300)};
+		return (
+			<div {...this.props} id="scroller">
+				<Cell component={OptionsContainer}>
+					<Button {...buttonDefaultProps} id="nativeScroll" onClick={this.onToggle}>{scrollMode}</Button>
+					<Button {...buttonDefaultProps} id="editableCentered" onClick={this.onToggle}>EditableCentered</Button>
+					<InputField id="numItems" defaultValue={numItems} type="number" onChange={this.onChangeNumItems} size="small" style={inputStyle} />
+				</Cell >
+				<Cell component={ScrollerContainer}>
+					<Scroller
+						dataSize={numItems}
+						direction="horizontal"
+						horizontalScrollbar="hidden"
+						hoverToScroll
+						key={nativeScroll ? 'native' : 'translate'}
+						verticalScrollbar="hidden"
+						editable={{
+							centered: editableCentered,
+							css,
+							selectItemBy: 'press',
+							hideIndex: this.hideIndex,
+							onComplete: this.handleComplete,
+							removeItemFuncRef: this.removeItem,
+							hideItemFuncRef: this.hideItem,
+							showItemFuncRef: this.showItem,
+							focusItemFuncRef: this.focusItem
+						}}
+					>
+						{
+							items.map((item, index) => {
+								return (
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.hidden}>
+										<ItemButtonsContainer className={css.removeButtonContainer}>
+											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={this.onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={this.onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={this.onClickShowButton} icon="plus" /> : null}
+										</ItemButtonsContainer>
+										<IconItem
+											aria-label={`Icon ${item.index}. Edit mode to press and hold OK button`}
+											className={css.iconItem}
+											disabled={item.hidden}
+											onFocus={this.onFocusItem}
+											{...item.props}
+										/>
+									</div>
+								);
+							})
+						}
+					</Scroller>
+				</Cell>
+			</div>
+		);
+	}
+}
+
+export default ThemeDecorator(app);

--- a/tests/ui/apps/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem.module.less
+++ b/tests/ui/apps/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem.module.less
@@ -1,0 +1,106 @@
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hidden {
+		.iconItem {
+			display: none;
+		}
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
+.wrapper { // public class for editable wrapper
+	padding-left: 36px;
+	padding-right: 36px;
+
+	.removeButtonContainer {
+		height: 156px;
+
+		&:hover ~ .editableIconItem {
+			transform: none;
+		}
+		&:focus-within ~ .editableIconItem {
+			transform: none;
+		}
+
+		.removeButton {
+			display: none;
+		}
+	}
+
+	.itemWrapper {
+		text-align: center;
+
+		&:is([disabled]):not(.hidden).focused {
+			.removeButton {
+				display: none;
+			}
+		}
+
+		.editableIconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+
+		&:not(.selected,.focused) .editableIconItem {
+			&:focus {
+				transform: none;
+			}
+		}
+
+		.iconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+	}
+
+	.focused { // public class for focused item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+		}
+	}
+
+	.selected { // public class for selected item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+		}
+
+		.arrow() {
+			font-family: "Sandstone Icons";
+			font-size: 108px;
+			position: absolute;
+			top: 15%;
+			background: none;
+			opacity: 1;
+		}
+
+		&:not(.hidden):not(.noBefore)::before {
+			content: '\EFFF3';
+			.arrow();
+			left: -30px;
+		}
+
+		&:not(.hidden):not(.noAfter)::after {
+			content: '\EFFF4';
+			.arrow();
+			right: -30px;
+		}
+	}
+}

--- a/tests/ui/specs/Scroller/EditableScrollerWithIconItem/EditableScroller-utils.js
+++ b/tests/ui/specs/Scroller/EditableScrollerWithIconItem/EditableScroller-utils.js
@@ -1,0 +1,57 @@
+async function focusedDataIndex () {
+	return await browser.execute(function () {
+		let node = document.activeElement;
+		let index;
+		while (node.dataset) {
+			index = node.dataset['index'];
+			if (index) {
+				break;
+			}
+			node = node.parentNode;
+		}
+		return {
+			node: node ?? null,
+			index: index ?? null
+		};
+	});
+}
+
+async function focusedItemButton () {
+	const {index} = await focusedDataIndex();
+	return await browser.execute(function () {
+		const node = document.activeElement;
+		return {
+			ariaLabel: node.ariaLabel,
+			index
+		};
+	});
+}
+
+async function disabledAttribute () {
+	return await browser.execute(function () {
+		return document.activeElement?.getAttribute?.('aria-disabled') === 'true';
+	});
+}
+
+async function expectFocusedItem (expectedIndex, comment = 'focused item') {
+	const {index} = await focusedDataIndex();
+	expect(index, comment).to.equal(expectedIndex);
+}
+
+async function expectDisabledItem (expectedIndex, comment = 'disabled item') {
+	const {index} = await focusedDataIndex();
+	const disabled = await disabledAttribute();
+	expect(index, comment).to.equal(expectedIndex);
+	expect(disabled).to.be.true();
+}
+
+async function expectDeleteButton (expectedIndex, comment = 'delete button') {
+	const {ariaLabel, index} = await focusedItemButton();
+	expect(index, comment).to.equal(expectedIndex);
+	expect(ariaLabel, comment).to.equal('Delete');
+}
+
+exports.focusedDataIndex = focusedDataIndex;
+exports.expectFocusedItem = expectFocusedItem;
+exports.expectDisabledItem = expectDisabledItem;
+exports.expectDeleteButton = expectDeleteButton;

--- a/tests/ui/specs/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem-specs.js
+++ b/tests/ui/specs/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem-specs.js
@@ -1,0 +1,54 @@
+const ScrollerPage = require('./EditableScrollerWithIconItemPage');
+const {expectFocusedItem, expectDisabledItem} = require('./EditableScroller-utils');
+
+describe('Editable Scroller', function () {
+	beforeEach(async function () {
+		await ScrollerPage.open();
+	});
+
+	it('Should be able to hide all items', async function () {
+		await ScrollerPage.spotlightDown();
+		await ScrollerPage.spotlightSelect();
+		await expectFocusedItem('0');
+
+		/* hide 10 items: note that 10 items are minimal set to make the scroller overflows */
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightRight();
+		await ScrollerPage.spotlightSelect();
+
+		/* move focus out of the scroller */
+		await ScrollerPage.spotlightUp();
+		await ScrollerPage.spotlightUp();
+
+		/* expected no item is displayed */
+		await ScrollerPage.spotlightDown();
+		await expectDisabledItem('0');
+	});
+});

--- a/tests/ui/specs/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItemPage.js
+++ b/tests/ui/specs/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItemPage.js
@@ -1,0 +1,65 @@
+'use strict';
+const {element, Page} = require('@enact/ui-test-utils/utils');
+
+const scrollContentSelector = '.enact_ui_Scroller_Scroller_scroller';
+
+class ScrollerPage extends Page {
+
+	constructor () {
+		super();
+		this.title = 'Scroller Test';
+	}
+
+	async open (layout = '', urlExtra) {
+		await super.open(`EditableScrollerWithIconItem${layout}-View`, urlExtra);
+	}
+
+	// button api
+	get buttonNativeScroll () {
+		return element('#nativeScroll', browser);
+	}
+	get buttonEditableCentered () {
+		return element('#editableCentered', browser);
+	}
+
+	// scrollable api
+	get scroller () {
+		return element('#scroller', browser);
+	}
+
+	// InputField api
+	get inputfieldNumItems () {
+		return element('#numItems', browser);
+	}
+
+	async getScrollerRect () {
+		return await browser.execute(function (_scrollContentSelector) {
+			const scroller = document.querySelector(_scrollContentSelector);
+			return scroller.getBoundingClientRect();
+		}, scrollContentSelector);
+	}
+
+	async getActiveElementRect () {
+		return await browser.execute(function () {
+			return document.activeElement.getBoundingClientRect();
+		});
+	}
+
+	async checkEditableItem () {
+		return await browser.execute(function () {
+			const itemWrapperClass = 'tests_ui_apps_Scroller_EditableItem_Scroller_itemWrapper Scroller_EditableWrapper_selected tests_ui_apps_Scroller_EditableItem_Scroller_selected';
+			return document.activeElement.parentElement.className === itemWrapperClass;
+		});
+	}
+
+	async backSpace () {
+		return await this.keyDelay('Backspace');
+	}
+
+	async numPad (num) {
+		let Inputnum = 'numpad' + String(num);
+		return await this.keyDelay(Inputnum);
+	}
+}
+
+module.exports = new ScrollerPage();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
All items show up if a user quit edit mode after hiding all items.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix a logic to handle all-hidden cases.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-24596

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)