### PR TITLE
WRP-24016: Fixed unexpected focus lose when 'cancel' key is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` to support hiding all items when `editable` is given
+- `sandstone/Scroller` to not lose focus by back key when `editable` is given
 
 ## [2.7.6] - 2023-08-10
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The spotlight focus disappears when a user press cancel key during one item is selected for moving in `EditableScroller` that is inside `Panels`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs `onBack` occurs to `Panels` on cancel key press because `Panels`'s event is based on 'keyup' and `EditableScroller`'s event is based on 'keydown'. To fix UX issue, `EditableScroller` is updated to use 'keyup'.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-24016

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)