### PR TITLE
WRP-25233: Fix QuickGuidePanels to focus the last focused button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/QuickGuidePanels` to focus the last focused button when navigating between views
+
 ## [2.7.7] - 2023-08-22
 
 ### Added

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -3,6 +3,7 @@ import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import useChainRefs from '@enact/core/useChainRefs';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
+import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator, {spotlightDefaultClass} from '@enact/spotlight/SpotlightContainerDecorator';
 import {Cell, Column, Row} from '@enact/ui/Layout';
 import Changeable from '@enact/ui/Changeable';
@@ -328,7 +329,10 @@ const WizardPanelsBase = kind({
 		onClose: forwardCustom('onClose'),
 		onNextClick: handle(
 			forwardCustomWithPrevent('onNextClick'),
-			(ev, {index, onChange, totalPanels}) => {
+			(ev, {'data-spotlight-id': spotlightId, fullScreenContent, index, onChange, totalPanels}) => {
+				if (fullScreenContent) {
+					Spotlight.set(spotlightId, {enterTo: 'last-focused'});
+				}
 				if (onChange && index !== totalPanels) {
 					const nextIndex = index < (totalPanels - 1) ? (index + 1) : index;
 

--- a/WizardPanels/tests/WizardPanels-specs.js
+++ b/WizardPanels/tests/WizardPanels-specs.js
@@ -823,6 +823,210 @@ describe('WizardPanel Specs', () => {
 
 	describe('fullScreenContent', () => {
 		test(
+			'should hide next button on the last view',
+			() => {
+				render(
+					<WizardPanels fullScreenContent index={2}>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+						<Panel>Last!</Panel>
+					</WizardPanels>
+				);
+
+				const buttons = screen.getAllByRole('button');
+
+				const expected = 2;
+				const actual = buttons.length;
+
+				expect(actual).toBe(expected);
+				expect(buttons[0]).toHaveAttribute('aria-label', 'Exit quick guide');
+				expect(buttons[1]).toHaveAttribute('aria-label', 'Previous');
+			}
+		);
+
+		test(
+			'should hide previous button on the first view',
+			async () => {
+				render(
+					<WizardPanels fullScreenContent index={0}>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+						<Panel>Last!</Panel>
+					</WizardPanels>
+				);
+
+				const buttons = screen.getAllByRole('button');
+
+				const expected = 2;
+				const actual = buttons.length;
+
+				expect(actual).toBe(expected);
+				expect(buttons[0]).toHaveAttribute('aria-label', 'Exit quick guide');
+				expect(buttons[1]).toHaveAttribute('aria-label', 'Next');
+			}
+		);
+
+		test(
+			'should show next button on the first view',
+			async () => {
+				render(
+					<WizardPanels fullScreenContent index={0}>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+						<Panel>Last!</Panel>
+					</WizardPanels>
+				);
+
+				const nextButton = screen.getByLabelText('Next');
+
+				await waitFor(() => {
+					expect(nextButton).toBeInTheDocument();
+				});
+			}
+		);
+
+		test(
+			'should fire onWillTransition with target index and type',
+			async () => {
+				const spy = jest.fn();
+				let index = 0;
+				const {rerender} = render(
+					<WizardPanels fullScreenContent index={index} onWillTransition={spy} noAnimation>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+					</WizardPanels>
+				);
+
+				spy.mockClear();
+				index++;
+
+				rerender(
+					<WizardPanels fullScreenContent index={index} onWillTransition={spy} noAnimation>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+					</WizardPanels>
+				);
+
+				const expected = {index, type: 'onWillTransition'};
+				const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+				await waitFor(() => {
+					expect(actual).toMatchObject(expected);
+				});
+			}
+		);
+
+		test(
+			'should fire onTransition with target index and type',
+			async () => {
+				const spy = jest.fn();
+				let index = 0;
+				const {rerender} = render(
+					<WizardPanels fullScreenContent index={index} onTransition={spy} noAnimation>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+					</WizardPanels>
+				);
+
+				spy.mockClear();
+				index++;
+
+				rerender(
+					<WizardPanels fullScreenContent index={index} onTransition={spy} noAnimation>
+						<Panel>I gots contents</Panel>
+						<Panel>I gots contents2</Panel>
+					</WizardPanels>
+				);
+
+				const expected = {index, type: 'onTransition'};
+				const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+				await waitFor(() => {
+					expect(actual).toMatchObject(expected);
+				});
+			}
+		);
+
+		test(
+			'should fire `onNextClick` and `onChange` with type when go to the next panel',
+			async () => {
+				const handleChange = jest.fn();
+				const handleNextClick = jest.fn();
+				const user = userEvent.setup();
+
+				render(
+					<WizardPanels fullScreenContent index={1} onChange={handleChange} onNextClick={handleNextClick}>
+						<Panel />
+						<Panel />
+						<Panel />
+					</WizardPanels>
+				);
+
+				const nextButton = screen.getByLabelText('Next');
+				const expected = {type: 'onNextClick'};
+
+				await user.click(nextButton);
+
+				await waitFor(() => {
+					expect(handleChange).toBeCalledWith({index: 2, type: 'onChange'});
+				});
+				await waitFor(() => {
+					const actual = handleNextClick.mock.calls.length && handleNextClick.mock.calls[0][0];
+
+					expect(actual).toMatchObject(expected);
+				});
+			}
+		);
+
+		test(
+			'should fire `onPrevClick` and `onChange` with type when go to the previous panel',
+			async () => {
+				const handleChange = jest.fn();
+				const handlePrevClick = jest.fn();
+				const user = userEvent.setup();
+
+				render(
+					<WizardPanels fullScreenContent index={2} onChange={handleChange} onPrevClick={handlePrevClick}>
+						<Panel />
+						<Panel />
+						<Panel />
+					</WizardPanels>
+				);
+
+				const prevButton = screen.getByLabelText('Previous');
+				const expected = {type: 'onPrevClick'};
+
+				await user.click(prevButton);
+
+				await waitFor(() => {
+					expect(handleChange).toBeCalledWith({index: 1, type: 'onChange'});
+				});
+				await waitFor(() => {
+					const actual = handlePrevClick.mock.calls.length && handlePrevClick.mock.calls[0][0];
+
+					expect(actual).toMatchObject(expected);
+				});
+			}
+		);
+
+		test(
+			'should return a ref to the root Panel node',
+			() => {
+				const ref = jest.fn();
+				render(
+					<WizardPanels fullScreenContent ref={ref}>
+						<Panel />
+					</WizardPanels>
+				);
+
+				const expected = 'ARTICLE';
+				const actual = ref.mock.calls[0][0].nodeName;
+
+				expect(actual).toBe(expected);
+			}
+		);
+
+		test(
 			'should fire `onClose` when close button is clicked',
 			async () => {
 				const handleClose = jest.fn();

--- a/tests/ui/apps/QuickGuidePanels/QuickGuidePanels-View.js
+++ b/tests/ui/apps/QuickGuidePanels/QuickGuidePanels-View.js
@@ -1,0 +1,31 @@
+import BodyText from '../../../../BodyText/BodyText';
+import QuickGuidePanels from '../../../../QuickGuidePanels';
+import ThemeDecorator from '../../../../ThemeDecorator/ThemeDecorator';
+import spotlight from '@enact/spotlight';
+
+import UrlPropsDecorator from '../../components/UrlPropsDecorator';
+
+// NOTE: Forcing pointer mode off so we can be sure that regardless of webOS pointer mode the app
+// runs the same way
+spotlight.setPointerMode(false);
+
+const app = (props) => (
+	<QuickGuidePanels
+		id="quickguidepanels"
+		{...props}
+	>
+		<QuickGuidePanels.Panel subtitle="A subtitle for View 1" title="QuickGuidePanels View 1">
+			<div id="view1" />
+		</QuickGuidePanels.Panel>
+		<QuickGuidePanels.Panel subtitle="A subtitle for View 2" title="QuickGuidePanels View 2">
+			<div id="view2" />
+			<BodyText>A simple view</BodyText>
+		</QuickGuidePanels.Panel>
+		<QuickGuidePanels.Panel subtitle="A subtitle for View 3" title="QuickGuidePanels View 3">
+			<div id="view3" />
+			<BodyText>Several buttons!</BodyText>
+		</QuickGuidePanels.Panel>
+	</QuickGuidePanels>
+);
+
+export default UrlPropsDecorator(ThemeDecorator(app));

--- a/tests/ui/specs/QuickGuidePanels/QuickGuidePanels-specs.js
+++ b/tests/ui/specs/QuickGuidePanels/QuickGuidePanels-specs.js
@@ -1,0 +1,33 @@
+const Page = require('./QuickGuidePanelsPage');
+
+describe('QuickGuidePanels', function () {
+	const quickGuidePanels = Page.components.quickGuidePanels;
+
+	beforeEach(async function () {
+		await Page.open();
+	});
+
+	describe('5-way', function () {
+		it('should focus in order of the last focused button, the next button, and the close button', async function () {
+			expect(await quickGuidePanels.view1.isExisting()).to.be.true();
+			expect(await (await quickGuidePanels.nextButton()).isFocused()).to.be.true();
+			await Page.spotlightSelect();
+
+			expect(await quickGuidePanels.view2.isExisting()).to.be.true();
+			expect(await (await quickGuidePanels.nextButton()).isFocused()).to.be.true();
+			await Page.spotlightSelect();
+
+			expect(await quickGuidePanels.view3.isExisting()).to.be.true();
+			expect(await (await quickGuidePanels.closeButton()).isFocused()).to.be.true();
+			await Page.spotlightLeft();
+			await Page.spotlightSelect();
+
+			expect(await quickGuidePanels.view2.isExisting()).to.be.true();
+			expect(await (await quickGuidePanels.prevButton()).isFocused()).to.be.true();
+			await Page.spotlightSelect();
+
+			expect(await quickGuidePanels.view1.isExisting()).to.be.true();
+			expect(await (await quickGuidePanels.nextButton()).isFocused()).to.be.true();
+		});
+	});
+});

--- a/tests/ui/specs/QuickGuidePanels/QuickGuidePanelsPage.js
+++ b/tests/ui/specs/QuickGuidePanels/QuickGuidePanelsPage.js
@@ -1,12 +1,9 @@
 'use strict';
-const {element, getComponent, Page} = require('@enact/ui-test-utils/utils');
+const {element, Page} = require('@enact/ui-test-utils/utils');
 
-const getHeaderSlot = (slot, el) => element(`.Panels_Header_${slot}`, el);
-const getNextButton = async el => await getComponent({component: 'Button'}, await getHeaderSlot('slotAfter', el));
-const getPrevButton = async el => await getComponent({component: 'Button'}, await getHeaderSlot('slotBefore', el));
 const viewSelector = view => `#view${view}`;
 
-class WizardPanelsInterface {
+class QuickGuidePanelsInterface {
 	constructor (id) {
 		this.id = id;
 		this.selector = `#${this.id}`;
@@ -33,10 +30,13 @@ class WizardPanelsInterface {
 	}
 
 	async nextButton () {
-		return await getNextButton(this.self);
+		return await element('[aria-label="Next"]', this.self);
 	}
 	async prevButton () {
-		return await getPrevButton(this.self);
+		return await element('[aria-label="Previous"]', this.self);
+	}
+	async closeButton () {
+		return await element('[aria-label="Exit quick guide"]', this.self);
 	}
 
 	get view1 () {
@@ -48,22 +48,19 @@ class WizardPanelsInterface {
 	get view3 () {
 		return this.self.$(viewSelector(3));
 	}
-	get view4 () {
-		return this.self.$(viewSelector(4));
-	}
 }
 
-class WizardPanelsPage extends Page {
+class QuickGuidePanelsPage extends Page {
 	constructor () {
 		super();
-		this.title = 'WizardPanels Test';
+		this.title = 'QuickGuidePanels Test';
 		this.components = {};
-		this.components.wizardPanels = new WizardPanelsInterface('wizardpanels');
+		this.components.quickGuidePanels = new QuickGuidePanelsInterface('quickguidepanels');
 	}
 
 	async open (urlExtra) {
-		await super.open('WizardPanels-View', urlExtra);
+		await super.open('QuickGuidePanels-View', urlExtra);
 	}
 }
 
-module.exports = new WizardPanelsPage();
+module.exports = new QuickGuidePanelsPage();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a user selects the previous button on QuickGuidePanels, the focus is on the next button that is the default focus target.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated logic to focus the last focused button.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-25233

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)