### PR TITLE
WRP-26288: Passed noAnimation prop to Popup inside sandstone/colorPicker

### DIFF
--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -237,6 +237,15 @@ const ColorPickerBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
+		 * Disables transition animation.
+		 *
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		noAnimation: PropTypes.bool,
+
+		/**
 		 * Called to open or close the color picker.
 		 *
 		 * @type {Function}
@@ -274,6 +283,7 @@ const ColorPickerBase = kind({
 
 	defaultProps: {
 		disabled: false,
+		noAnimation: false,
 		popupOpen: false
 	},
 
@@ -293,7 +303,7 @@ const ColorPickerBase = kind({
 		publicClassNames: true
 	},
 
-	render: ({color, colorHandler, css, disabled, handleClosePopup, handleOpenPopup, popupOpen, presetColors, text, ...rest}) => {
+	render: ({color, colorHandler, css, disabled, handleClosePopup, handleOpenPopup, noAnimation, popupOpen, presetColors, text, ...rest}) => {
 		delete rest.onTogglePopup;
 
 		const CloseIcon = useCallback((props) => <Icon {...props} css={css} />, [css]);
@@ -313,6 +323,7 @@ const ColorPickerBase = kind({
 				<Popup
 					className={css.colorPopup}
 					css={css}
+					noAnimation={noAnimation}
 					onClose={handleClosePopup}
 					open={disabled ? false : popupOpen}
 					position="left"

--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -237,15 +237,6 @@ const ColorPickerBase = kind({
 		disabled: PropTypes.bool,
 
 		/**
-		 * Disables transition animation.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		noAnimation: PropTypes.bool,
-
-		/**
 		 * Called to open or close the color picker.
 		 *
 		 * @type {Function}
@@ -283,7 +274,6 @@ const ColorPickerBase = kind({
 
 	defaultProps: {
 		disabled: false,
-		noAnimation: false,
 		popupOpen: false
 	},
 
@@ -303,7 +293,7 @@ const ColorPickerBase = kind({
 		publicClassNames: true
 	},
 
-	render: ({color, colorHandler, css, disabled, handleClosePopup, handleOpenPopup, noAnimation, popupOpen, presetColors, text, ...rest}) => {
+	render: ({color, colorHandler, css, disabled, handleClosePopup, handleOpenPopup, popupOpen, presetColors, text, ...rest}) => {
 		delete rest.onTogglePopup;
 
 		const CloseIcon = useCallback((props) => <Icon {...props} css={css} />, [css]);
@@ -323,7 +313,7 @@ const ColorPickerBase = kind({
 				<Popup
 					className={css.colorPopup}
 					css={css}
-					noAnimation={noAnimation}
+					noAnimation
 					onClose={handleClosePopup}
 					open={disabled ? false : popupOpen}
 					position="left"

--- a/samples/sampler/stories/qa/ColorPicker.js
+++ b/samples/sampler/stories/qa/ColorPicker.js
@@ -30,6 +30,7 @@ export const WithPresetColors = (args) => {
 				color={color}
 				colorHandler={setColor}
 				disabled={args.disabled}
+				noAnimation={args['noAnimation']}
 				presetColors={presetColors}
 				text={args.text}
 			/>
@@ -38,6 +39,7 @@ export const WithPresetColors = (args) => {
 };
 
 boolean('disabled', WithPresetColors, Config, false);
+boolean('noAnimation', WithPresetColors, Config);
 text('text', WithPresetColors, Config, 'Color Picker');
 
 WithPresetColors.storyName = 'with preset colors';

--- a/samples/sampler/stories/qa/ColorPicker.js
+++ b/samples/sampler/stories/qa/ColorPicker.js
@@ -30,7 +30,6 @@ export const WithPresetColors = (args) => {
 				color={color}
 				colorHandler={setColor}
 				disabled={args.disabled}
-				noAnimation={args['noAnimation']}
 				presetColors={presetColors}
 				text={args.text}
 			/>
@@ -39,7 +38,6 @@ export const WithPresetColors = (args) => {
 };
 
 boolean('disabled', WithPresetColors, Config, false);
-boolean('noAnimation', WithPresetColors, Config);
 text('text', WithPresetColors, Config, 'Color Picker');
 
 WithPresetColors.storyName = 'with preset colors';


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added noAnimation prop to sandstone/colorPicker

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Passed noAnimation prop to Popup inside sandstone/colorPicker

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-26288

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))