### PR TITLE
WRP-26268: Rename PalmServiceBridge as WebOSServiceBridge

### DIFF
--- a/samples/qa-a11y/src/views/ReadAlert.js
+++ b/samples/qa-a11y/src/views/ReadAlert.js
@@ -18,7 +18,7 @@ const ReadAlertView = () => {
 	const onClick2 = onClick(false);
 
 	useEffect( () => {
-		if (window.PalmServiceBridge) {
+		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',
 				method: 'getSystemSettings',
@@ -35,7 +35,7 @@ const ReadAlertView = () => {
 	}, []);
 
 	const onToggle = useCallback(({selected}) => {
-		if (window.PalmServiceBridge) {
+		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
 			setAudioGuidance(selected);
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`PalmServiceBridge` was renamed as `WebOSServiceBridge` in 2018 with an fallback alias for compatibility on legacy webOS.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated qa-a11y sample to use `WebOSServiceBridge`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-26268

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)