### PR TITLE
WRP-26238: Fix TabLayout to handle focus properly after pressing enter key

### DIFF
--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -256,7 +256,7 @@ const TabLayoutBase = kind({
 	handlers: {
 		onKeyDown: (ev, props) => {
 			const {keyCode, target} = ev;
-			const {collapsed, orientation, 'data-spotlight-id': spotlightId, anchorTo, rtl} = props;
+			const {collapsed, orientation, 'data-spotlight-id': spotlightId} = props;
 			const direction = getDirection(keyCode);
 
 			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target) && target.tagName !== 'INPUT') {
@@ -274,8 +274,23 @@ const TabLayoutBase = kind({
 					}
 				}
 			} else if (is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
+				ev.stopPropagation();
+			}
+		},
+		onKeyUp: (ev, props) => {
+			const {keyCode, target} = ev;
+			const {anchorTo, collapsed, orientation, 'data-spotlight-id': spotlightId, rtl, type} = props;
+			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
+
+			if (forwardWithPrevent('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') {
+				if (collapsed) {
+					forward('onExpand', ev, props);
+				}
+				Spotlight.move('left');
+				ev.stopPropagation();
+			} else if (is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
 				Spotlight.setPointerMode(false);
-				ev.preventDefault();
+
 				let moveTo;
 				if (orientation === 'vertical') {
 					if (anchorTo === 'left') {
@@ -299,20 +314,6 @@ const TabLayoutBase = kind({
 					moveTo = 'down';
 				}
 				Spotlight.move(moveTo);
-				ev.stopPropagation();
-			}
-		},
-		onKeyUp: (ev, props) => {
-			const {keyCode, target} = ev;
-			const {collapsed, 'data-spotlight-id': spotlightId, type} = props;
-			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
-
-			if (forwardWithPrevent('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') {
-				if (collapsed) {
-					forward('onExpand', ev, props);
-				}
-				Spotlight.move('left');
-				ev.stopPropagation();
 			}
 		},
 		onSelect: handle(


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the enter key is pressed in the PopupTabLayout menu, the subPanel needs to be changed immediately and moves focus to the sub panel.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Move Spotlight.move() logic to the keyUp handler in TabLayout to move the spotlight to the subPanel after subPanel view is changed

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-26238

### Comments
