### PR TITLE
WRP-27297: `Panels.Header` to not show `slotAfter` in incorrect position at the first rendering when `centered` is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Panels.Header` to not show `slotAfter` in incorrect position at first rendering when `centered` is given
+
 ## [2.7.8] - 2023-08-31
 
 ### Changed

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -480,18 +480,24 @@ const HeaderBase = kind({
 		// the cell sizes don't need to be synced.
 		const syncCellSize = (centered ? slotSize : null);
 
+		// Hide slots for the first render to avoid unexpected positioning when 'centered' is given.
+		// After the first render, HeaderMeasurementDecorator measures widths of slots and set right 'slotSize'.
+		const hideSlots = {
+			opacity: centered && (!slotBeforeRef.current || !slotAfterRef.current) ? '0' : null
+		};
+
 		// The side Cells are always present, even if empty, to support the measurement ref.
 		return (
 			<header {...rest}>
 				{slotAbove ? <nav className={css.slotAbove}>{slotAbove}</nav> : null}
 				<Row className={css.titlesRow} align="center">
-					<Cell className={css.slotBefore} shrink={!syncCellSize} size={syncCellSize}>
+					<Cell className={css.slotBefore} shrink={!syncCellSize} size={syncCellSize} style={hideSlots}>
 						<span ref={slotBeforeRef} className={css.slotSizer}>
 							{backButton}{slotBefore}
 						</span>
 					</Cell>
 					{titleCell}
-					<Cell className={css.slotAfter} shrink={!syncCellSize} size={syncCellSize}>
+					<Cell className={css.slotAfter} shrink={!syncCellSize} size={syncCellSize} style={hideSlots}>
 						<span ref={slotAfterRef} className={css.slotSizer}>
 							{slotAfter}{closeButton}
 						</span>

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -19,6 +19,7 @@ import compose from 'ramda/src/compose';
 import {svgGenerator} from '../helper/svg';
 
 const Config = mergeComponentMetadata('Panels', Panels);
+const HeaderConfig = mergeComponentMetadata('Header', Header);
 
 const items = [];
 
@@ -71,7 +72,10 @@ export const _Panels = (args) => {
 			onWillTransition={action('onWillTransition')}
 		>
 			<Panel>
-				<Header title="Panel with Items">
+				<Header
+					centered={args['centered']}
+					title="Panel with Items"
+				>
 					<Button
 						icon="arrowlargeright"
 						iconFlip="auto"
@@ -107,7 +111,10 @@ export const _Panels = (args) => {
 				</Item>
 			</Panel>
 			<Panel>
-				<Header title="Panel with VirtualGridList">
+				<Header
+					centered={args['centered']}
+					title="Panel with VirtualGridList"
+				>
 					<Button
 						icon="arrowlargeright"
 						iconFlip="auto"
@@ -126,7 +133,10 @@ export const _Panels = (args) => {
 				/>
 			</Panel>
 			<Panel>
-				<Header title="Panel with TabLayout" >
+				<Header
+					centered={args['centered']}
+					title="Panel with TabLayout"
+				>
 					<Button
 						icon="arrowlargeright"
 						iconFlip="auto"
@@ -183,7 +193,11 @@ export const _Panels = (args) => {
 				</TabLayout>
 			</Panel>
 			<Panel>
-				<Header title="Panel with Scroller" />
+
+				<Header
+					centered={args['centered']}
+					title="Panel with Scroller"
+				/>
 				<Scroller focusableScrollbar="byEnter" verticalScrollbar="visible">
 					<div style={{height: ri.scaleToRem(2004)}}>
 						<BodyText>
@@ -216,6 +230,8 @@ select(
 boolean('noAnimation', _Panels, Panels, false);
 boolean('noBackButton', _Panels, Panels, false);
 boolean('noCloseButton', _Panels, Panels, false);
+
+boolean('centered', _Panels, HeaderConfig);
 
 _Panels.storyName = 'Panels';
 _Panels.parameters = {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `Panels.Header` is rendered for the first time with `centered` prop, `slotAfter` elements are rendered at unexpected position and they are positioned correctly right after.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To layout `title`, `slotBefore`, and `slotAfter` correctly with the centered title, `slotBefore` and `slotAfter` elements' widths should be measured after rendered. So, `Panels.Header` renders once for measuring and re-renders for the right layout.
In this PR, the logic is changed to hide slots during the inevitable first render for measuring, then to recover slots to show.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-27297

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
