### PR TITLE
WRP-26318: Fix editable scroller a11y feature to not cut off panel's audio guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Panels.Header` to not show `slotAfter` in incorrect position at first rendering when `centered` is given
+- `sandstone/Scroller` to read out properly when `editable` is given 
 
 ## [2.7.8] - 2023-08-31
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -216,7 +216,7 @@ const EditableWrapper = (props) => {
 			if (!initialSelected?.itemIndex) {
 				setTimeout(() => {
 					announceRef.current.announce(
-						mutableRef.current.selectedItemLabel + $L('Press left or right button to move or press up button for other actions')
+						mutableRef.current.selectedItemLabel + $L('Press the left/right button to move or press the up button to select other options.')
 					);
 				}, completeAnnounceDelay);
 			}
@@ -225,7 +225,7 @@ const EditableWrapper = (props) => {
 
 	const finalizeEditing = useCallback((orders) => {
 		if (initialSelected?.itemIndex) {
-			mutableRef.current.selectedItem.children[1].ariaLabel = `${mutableRef.current.selectedItem.ariaLabel} ${$L('Press OK button to move or press up button for other actions')}`;
+			mutableRef.current.selectedItem.children[1].ariaLabel = `${mutableRef.current.selectedItem.ariaLabel} ${$L('Press the OK button to move or press the up button to select other options.')}`;
 		}
 		forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
 		reset();
@@ -573,7 +573,7 @@ const EditableWrapper = (props) => {
 
 					setTimeout(() => {
 						announceRef.current.announce(
-							selectedItemLabel + $L('move complete'),
+							selectedItemLabel + $L('Movement completed'),
 							true
 						);
 					}, completeAnnounceDelay);
@@ -640,7 +640,7 @@ const EditableWrapper = (props) => {
 
 				setTimeout(() => {
 					announceRef?.current?.announce(
-						selectedItemLabel + $L('move complete'),
+						selectedItemLabel + $L('Movement completed'),
 						true
 					);
 				}, completeAnnounceDelay);
@@ -774,7 +774,7 @@ const EditableWrapper = (props) => {
 
 		iconItemList.forEach((iconItemWrapper, index) => {
 			if (iconItemWrapper?.children[1]) {
-				iconItemWrapper.children[1].ariaLabel += index === initialSelected?.itemIndex - 1 ? ` ${$L('Press left or right button to move or press up button for other actions')}` : ` ${$L('Press OK button to move or press up button for other actions')}`;
+				iconItemWrapper.children[1].ariaLabel += index === initialSelected?.itemIndex - 1 ? ` ${$L('Press the left/right button to move or press the up button to select other options.')}` : ` ${$L('Press the OK button to move or press the up button to select other options.')}`;
 			}
 		})
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -229,7 +229,7 @@ const EditableWrapper = (props) => {
 		}
 		forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
 		reset();
-	}, [editable, reset]);
+	}, [editable, initialSelected?.itemIndex, reset]);
 
 	const findItemNode = useCallback((node) => {
 		for (let current = node; current !== scrollContentRef.current && current !== document; current = current.parentNode) {
@@ -776,7 +776,7 @@ const EditableWrapper = (props) => {
 			if (iconItemWrapper?.children[1]) {
 				iconItemWrapper.children[1].ariaLabel += index === initialSelected?.itemIndex - 1 ? ` ${$L('Press the left/right button to move or press the up button to select other options.')}` : ` ${$L('Press the OK button to move or press the up button to select other options.')}`;
 			}
-		})
+		});
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -151,10 +151,11 @@ const EditableWrapper = (props) => {
 		mutableRef.current.selectedItemLabel = '';
 		mutableRef.current.lastMoveDirection = null;
 		mutableRef.current.prevToIndex = null;
+		initialSelected.itemIndex = null;
 		wrapperRef.current.style.setProperty('--selected-item-offset', '0px');
 
 		Spotlight.set(spotlightId, {restrict: 'self-first'});
-	}, [customCss.focused, customCss.selected]);
+	}, [customCss.focused, customCss.selected, initialSelected]);
 
 	// Finalize the order
 	const finalizeOrders = useCallback(() => {
@@ -212,14 +213,20 @@ const EditableWrapper = (props) => {
 			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
 
 			updateArrowIcon(mutableRef.current.fromIndex);
-
-			announceRef.current.announce(
-				mutableRef.current.selectedItemLabel + $L('Press left or right button to move or press up button for other actions')
-			);
+			if (!initialSelected?.itemIndex) {
+				setTimeout(() => {
+					announceRef.current.announce(
+						mutableRef.current.selectedItemLabel + $L('Press left or right button to move or press up button for other actions')
+					);
+				}, completeAnnounceDelay);
+			}
 		}
-	}, [customCss.focused, customCss.selected, updateArrowIcon]);
+	}, [customCss.focused, customCss.selected, initialSelected?.itemIndex, updateArrowIcon]);
 
 	const finalizeEditing = useCallback((orders) => {
+		if (initialSelected?.itemIndex) {
+			mutableRef.current.selectedItem.children[1].ariaLabel = `${mutableRef.current.selectedItem.ariaLabel} ${$L('Press OK button to move or press up button for other actions')}`;
+		}
 		forwardCustom('onComplete', () => ({orders, hideIndex: mutableRef.current.hideIndex}))(null, editable);
 		reset();
 	}, [editable, reset]);
@@ -233,21 +240,13 @@ const EditableWrapper = (props) => {
 		return null;
 	}, [scrollContentRef]);
 
-	const focusItem = useCallback((target, announceDisabled = false) => {
+	const focusItem = useCallback((target) => {
 		const itemNode = findItemNode(target);
 		if (itemNode && !mutableRef.current.selectedItem) {
 			mutableRef.current.focusedItem?.classList.remove(customCss.focused);
 			mutableRef.current.focusedItem = itemNode;
 			mutableRef.current.focusedItem?.classList.add(customCss.focused);
 			mutableRef.current.prevToIndex = Number(itemNode.style.order) - 1;
-			const focusedItemLabel = (itemNode.ariaLabel || itemNode.textContent) + ' ';
-			if (!announceDisabled && (!itemNode.hasAttribute('disabled') || itemNode.className.includes('hidden'))) {
-				setTimeout(() => {
-					announceRef.current.announce(
-						focusedItemLabel + $L('Press OK button to move or press up button for other actions')
-					);
-				}, completeAnnounceDelay);
-			}
 		}
 	}, [customCss.focused, findItemNode]);
 
@@ -272,7 +271,7 @@ const EditableWrapper = (props) => {
 			const orders = finalizeOrders();
 			finalizeEditing(orders);
 			if (selectItemBy === 'press') {
-				focusItem(ev.target, true);
+				focusItem(ev.target);
 			}
 			mutableRef.current.needToPreventEvent = true;
 		} else {
@@ -568,7 +567,7 @@ const EditableWrapper = (props) => {
 					const orders = finalizeOrders();
 					finalizeEditing(orders);
 					if (selectItemBy === 'press') {
-						focusItem(target, true);
+						focusItem(target);
 					}
 					mutableRef.current.needToPreventEvent = true;
 
@@ -577,7 +576,7 @@ const EditableWrapper = (props) => {
 							selectedItemLabel + $L('move complete'),
 							true
 						);
-					}, completeAnnounceDelay);
+					}, 500);
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
 					mutableRef.current.needToPreventEvent = true;
@@ -636,7 +635,7 @@ const EditableWrapper = (props) => {
 				const orders = finalizeOrders();
 				finalizeEditing(orders);
 				if (selectItemBy === 'press') {
-					focusItem(target, true);
+					focusItem(target);
 				}
 
 				setTimeout(() => {
@@ -644,7 +643,7 @@ const EditableWrapper = (props) => {
 						selectedItemLabel + $L('move complete'),
 						true
 					);
-				}, completeAnnounceDelay);
+				}, 500);
 
 				ev.stopPropagation(); // To prevent onCancel by CancelDecorator
 			}
@@ -761,6 +760,7 @@ const EditableWrapper = (props) => {
 	}, [initialSelected?.itemIndex, initialSelected?.scrollLeft, scrollContainerHandle]);
 
 	useLayoutEffect(() => {
+		const iconItemList = Array.from(wrapperRef.current.children);
 		if (initialSelected?.itemIndex) {
 			const initialSelectedItem = wrapperRef.current.children[initialSelected.itemIndex - 1];
 			if (initialSelectedItem?.dataset.index) {
@@ -771,6 +771,12 @@ const EditableWrapper = (props) => {
 				Spotlight.focus(initialSelectedItem.children[1]);
 			}
 		}
+
+		iconItemList.forEach((iconItemWrapper, index) => {
+			if (iconItemWrapper?.children[1]) {
+				iconItemWrapper.children[1].ariaLabel += index === initialSelected?.itemIndex - 1 ? ` ${$L('Press left or right button to move or press up button for other actions')}` : ` ${$L('Press OK button to move or press up button for other actions')}`;
+			}
+		})
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -576,7 +576,7 @@ const EditableWrapper = (props) => {
 							selectedItemLabel + $L('move complete'),
 							true
 						);
-					}, 500);
+					}, completeAnnounceDelay);
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
 					mutableRef.current.needToPreventEvent = true;
@@ -643,7 +643,7 @@ const EditableWrapper = (props) => {
 						selectedItemLabel + $L('move complete'),
 						true
 					);
-				}, 500);
+				}, completeAnnounceDelay);
 
 				ev.stopPropagation(); // To prevent onCancel by CancelDecorator
 			}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -261,9 +261,9 @@ export const EditableIcon = (args) => {
 								return (
 									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
-											{item.hidden ? null : <Button aria-label="Delete button" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-											{item.hidden ? null : <Button aria-label="Hide button" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-											{item.hidden ? <Button aria-label="Show button" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											{...item.iconItemProps}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -2,6 +2,7 @@ import {add, is} from '@enact/core/keymap';
 import Button from '@enact/sandstone/Button';
 import IconItem from '@enact/sandstone/IconItem';
 import Scroller from '@enact/sandstone/Scroller';
+import $L from '@enact/sandstone/internal/$L';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
@@ -266,6 +267,7 @@ export const EditableIcon = (args) => {
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											{...item.iconItemProps}
+											aria-label={`Icon ${item.index}`}
 											className={css.editableIconItem}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
 											onClick={action('onClickItem')}
@@ -297,7 +299,7 @@ export const EditableIcon = (args) => {
 											<div className={css.removeButtonContainer} />
 											<IconItem
 												{...item.iconItemProps}
-												aria-label={`Icon ${item.index}. Edit mode to press and hold OK button`}
+												aria-label={`Icon ${item.index} ${$L('Edit mode to press and hold OK button')}`}
 												className={css.iconItem}
 												disabled={item.iconItemProps['disabled'] || item.hidden}
 												onClick={action('onClickItem')}
@@ -389,7 +391,7 @@ export const EditableIconWithLongPress = (args) => {
 								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
 							</div>
 							<IconItem
-								aria-label={`Icon ${item.index}. Edit mode to press and hold OK button`}
+								aria-label={`Icon ${item.index} ${$L('Edit mode to press and hold OK button')}`}
 								className={css.iconItem}
 								onClick={action('onClickItem')}
 								{...item.iconItemProps}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -261,9 +261,9 @@ export const EditableIcon = (args) => {
 								return (
 									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
-											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+											{item.hidden ? null : <Button aria-label="Delete button" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide button" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show button" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											{...item.iconItemProps}
@@ -299,7 +299,7 @@ export const EditableIcon = (args) => {
 											<div className={css.removeButtonContainer} />
 											<IconItem
 												{...item.iconItemProps}
-												aria-label={`Icon ${item.index} ${$L('Edit mode to press and hold OK button')}`}
+												aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
 												className={css.iconItem}
 												disabled={item.iconItemProps['disabled'] || item.hidden}
 												onClick={action('onClickItem')}
@@ -391,7 +391,7 @@ export const EditableIconWithLongPress = (args) => {
 								<Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />
 							</div>
 							<IconItem
-								aria-label={`Icon ${item.index} ${$L('Edit mode to press and hold OK button')}`}
+								aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
 								className={css.iconItem}
 								onClick={action('onClickItem')}
 								{...item.iconItemProps}

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -1,18 +1,31 @@
+import {is} from '@enact/core/keymap';
+import Button from '@enact/sandstone/Button';
+import IconItem from '@enact/sandstone/IconItem';
 import ImageItem from '@enact/sandstone/ImageItem';
 import Item from '@enact/sandstone/Item';
 import {Header, Panel, Panels} from '@enact/sandstone/Panels';
 import Scroller from '@enact/sandstone/Scroller';
 import {VirtualGridList} from '@enact/sandstone/VirtualList';
+import $L from '@enact/sandstone/internal/$L';
 import Spotlight from '@enact/spotlight';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
-import {select} from '@enact/storybook-utils/addons/controls';
+import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
+import Touchable from '@enact/ui/Touchable';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import compose from 'ramda/src/compose';
-import {useCallback, useState} from 'react';
+import {useCallback, useState, useRef, useLayoutEffect} from 'react';
 
+import galleryIcon from '../../images/icon_app_gallery.png';
+import gameHomeIcon from '../../images/icon_app_game.png';
+import homeOfficeIcon from '../../images/icon_app_homeoffice.png';
+import mediaDiscoveryIcon from '../../images/icon_app_mediadiscovery.png';
 import {svgGenerator} from '../helper/svg';
+
+import css from './Panels.module.less';
 
 const Config = mergeComponentMetadata('Panels', Panels);
 
@@ -136,6 +149,288 @@ export default {
 
 WithAutoFocusControl.storyName = 'with AutoFocus Control';
 WithAutoFocusControl.parameters = {
+	props: {
+		noPanels: true
+	}
+};
+
+const ScrollerConfig = mergeComponentMetadata('Scroller', Scroller);
+
+let itemsArr = [];
+const imageSrcs = [
+	'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3MDAiIGhlaWdodD0iNzAwIiB2aWV3Qm94PSIwIDAgNzAwIDcwMCI+PGRlZnM+PHN0eWxlPi5hLC5ie2ZpbGw6I2ZmZjt9LmJ7b3BhY2l0eTowLjg7fTwvc3R5bGU+PC9kZWZzPjxwb2x5Z29uIGNsYXNzPSJhIiBwb2ludHM9IjM0OS45IDUyNy44IDE5OS45IDQyOS44IDE5OS45IDM3NC40IDM1MC4xIDQ3Mi43IDM0OS45IDM0OC41IDE5OS45IDI2MS4xIDE5OS45IDIwOS4zIDM1MCAyOTMuNiAzNTAgMjkzLjYgMzUwLjIgMjkzLjcgMzQ5LjkgMTY5LjMgMTAyLjcgNDguNSAxMDIuNyA0NzIuNiAzNTAuMSA2NTEuNiAzNDkuOSA1MjcuOCIvPjxwb2x5Z29uIGNsYXNzPSJiIiBwb2ludHM9IjM1MC4xIDY1MS42IDU5Ny4zIDQ3Mi44IDU5Ny4zIDM2Ni4zIDM0OS45IDUyNy44IDM1MC4xIDY1MS42Ii8+PHBvbHlnb24gY2xhc3M9ImIiIHBvaW50cz0iMzUwLjEgNDcyLjcgNTIzLjUgMzU5LjMgNTIzLjUgMjQ3LjQgMzQ5LjkgMzQ4LjUgMzUwLjEgNDcyLjciLz48cG9seWdvbiBjbGFzcz0iYiIgcG9pbnRzPSIzNTAgMjkzLjYgMzUwIDI5My42IDM1MC4yIDI5My43IDU5Ny4zIDE1NC44IDU5Ny4zIDQ4LjQgMzQ5LjkgMTY5LjMgMzUwIDI5My42Ii8+PC9zdmc+',
+	galleryIcon,
+	gameHomeIcon,
+	homeOfficeIcon,
+	mediaDiscoveryIcon
+];
+
+const populateItems = ({index}) => {
+	const color = Math.floor(Math.random() * (0x1000000 - 0x101010) + 0x101010).toString(16);
+	const iconItemProps = {
+		background: (function () {
+			if (index < 2) return '#1b1b1b';
+			else if (index % 6 === 0) return '#ffffff';
+			else return '#' + color;
+		})(),
+		bordered: index < 2,
+		icon: index === 0 ? 'demosync' : (index === 1 ? 'usb' : ''), // eslint-disable-line no-nested-ternary
+		image: index > 1 ? {
+			src: imageSrcs[index % 5],
+			size: {
+				width: ri.scaleToRem(150),
+				height: ri.scaleToRem(150)
+			}
+		} : null,
+		label: (function () {
+			if (index === 1) return 'USB';
+			else if (index === 6) return 'Gallery';
+		})(),
+		labelColor: index === 6 ? 'dark' : null,
+		labelOn: index === 6 ? 'focus' : null,
+		disabled: index === 1
+	};
+
+	return {index, iconItemProps};
+};
+
+for (let i = 0; i < 20; i++) {
+	itemsArr.push(populateItems({index: i}));
+}
+
+const ContainerDivWithLeaveForConfig = SpotlightContainerDecorator({leaveFor: {left: '', right: ''}}, 'div');
+const TouchableDiv = Touchable('div');
+
+export const WithEditableScroller = (args) => {
+	const dataSize = args['editableDataSize'];
+	const [iconItems, setIconItems] = useState(itemsArr);
+	const [panelIndex, setPanelIndex] = useState(0);
+	const removeItem = useRef();
+	const hideItem = useRef();
+	const showItem = useRef();
+	const focusItem = useRef();
+	const divRef = useRef();
+	const mutableRef = useRef({
+		hideIndex: null,
+		initialSelected: {},
+		timer: null
+	});
+
+	useLayoutEffect(() => {
+		itemsArr = [];
+		for (let i = 0; i < dataSize; i++) {
+			itemsArr.push(populateItems({index: i}));
+		}
+		setIconItems(itemsArr);
+		mutableRef.current.hideIndex = dataSize;
+	}, [dataSize]);
+
+	const findItemNode = useCallback((node) => {
+		for (let current = node; current !== divRef.current && current !== document; current = current.parentNode) {
+			if (current.dataset.index) {
+				return current;
+			}
+		}
+	}, [divRef]);
+
+	const onClickRemoveButton = useCallback((ev) => {
+		if (removeItem.current) {
+			removeItem.current();
+		}
+		ev.preventDefault();
+	}, []);
+
+	const onClickHideButton = useCallback((ev) => {
+		if (hideItem.current) {
+			hideItem.current();
+		}
+		ev.preventDefault();
+	}, []);
+
+	const onClickShowButton = useCallback((ev) => {
+		if (showItem.current) {
+			showItem.current();
+		}
+		ev.preventDefault();
+	}, []);
+
+	const onFocusItem = useCallback((ev) => {
+		if (focusItem.current) {
+			focusItem.current(ev.target);
+		}
+	}, []);
+
+	const handleHoldStart = useCallback(() => {
+		setPanelIndex(panelIndex + 1);
+	}, [panelIndex]);
+
+	const handleMouseDown = useCallback((ev) => {
+		if (!ev.target.className.includes('Button')) {
+			const targetItemNode = findItemNode(ev.target);
+			if (targetItemNode && targetItemNode.style.order) {
+				mutableRef.current.initialSelected.itemIndex = targetItemNode.style.order;
+			}
+		}
+	}, [findItemNode]);
+
+	const handleKeyDown = useCallback((ev) => {
+		const {keyCode, repeat, target} = ev;
+		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
+			if (repeat && !mutableRef.current.timer) {
+				const targetItemNode = findItemNode(ev.target);
+				if (targetItemNode && targetItemNode.style.order) {
+					mutableRef.current.initialSelected.itemIndex = targetItemNode.style.order;
+				}
+				mutableRef.current.timer = setTimeout(() => {
+					setPanelIndex(panelIndex + 1);
+				}, 200);
+
+			}
+		}
+	}, [findItemNode, panelIndex]);
+
+	const handleKeyUp = useCallback((ev) => {
+		if (ev.target.getAttribute('role') === 'button') {
+			return;
+		}
+		if (mutableRef.current.timer) {
+			clearTimeout(mutableRef.current.timer);
+			mutableRef.current.timer = null;
+		}
+	}, []);
+
+	const handleScroll = useCallback((ev) => {
+		mutableRef.current.initialSelected.scrollLeft = ev.scrollLeft;
+	}, []);
+
+	const handleComplete = useCallback((ev) => {
+		const {orders, hideIndex} = ev;
+		mutableRef.current.hideIndex = hideIndex;
+
+		// change data from the new orders
+		const newItems = [];
+
+		orders.forEach(order => {
+			newItems.push(iconItems[order - 1]);
+		});
+
+		for (let i = 0; i < orders.length; i++) {
+			newItems[i].hidden = (i >= hideIndex);
+		}
+
+		setIconItems(newItems);
+	}, [iconItems]);
+
+	const forward = useCallback(() => {
+		setPanelIndex(panelIndex + 1);
+		mutableRef.current.initialSelected.scrollLeft = 0;
+		mutableRef.current.initialSelected.itemIndex = null;
+		mutableRef.current.timer = null;
+	}, [panelIndex]);
+
+	const backward = useCallback(() => {
+		setPanelIndex(panelIndex - 1);
+		mutableRef.current.initialSelected.scrollLeft = 0;
+		mutableRef.current.initialSelected.itemIndex = null;
+		mutableRef.current.timer = null;
+	}, [panelIndex]);
+
+	return (
+		<Panels
+			index={panelIndex}
+			noCloseButton
+			onBack={backward}
+		>
+			<Panel>
+				<Header title="Panel with Editable Scroller" subtitle="Click pencil button to start edit mode" />
+				<div ref={divRef}>
+					<Button style={{marginLeft: '36px'}} onClick={forward} icon="edit" />
+					<TouchableDiv
+						onHoldStart={handleHoldStart}
+						onMouseDown={handleMouseDown}
+						onKeyDown={handleKeyDown}
+						onKeyUp={handleKeyUp}
+					>
+						<Scroller
+							direction="horizontal"
+							onClick={action('onClickScroller')}
+							onKeyDown={action('onKeyDown')}
+							onScroll={handleScroll}
+							onScrollStart={action('onScrollStart')}
+							onScrollStop={action('onScrollStop')}
+						>
+							<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
+								iconItems.map((item, index) => {
+									return (
+										<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+											<div className={css.removeButtonContainer} />
+											<IconItem
+												{...item.iconItemProps}
+												aria-label={`Icon ${item.index} ${$L('Edit mode to press and hold OK button')}`}
+												className={css.iconItem}
+												disabled={item.iconItemProps['disabled'] || item.hidden}
+												onClick={action('onClickItem')}
+											/>
+										</div>
+									);
+								})}
+							</div>
+						</Scroller>
+					</TouchableDiv>
+				</div>
+			</Panel>
+			<Panel>
+				<Header title="Edit AppList" subtitle="This is subtitle of editAppList" />
+				<div ref={divRef}>
+					<Scroller
+						direction="horizontal"
+						editable={{
+							centered: args['editableCentered'],
+							css,
+							hideIndex: mutableRef.current.hideIndex,
+							onComplete: handleComplete,
+							removeItemFuncRef: removeItem,
+							hideItemFuncRef: hideItem,
+							showItemFuncRef: showItem,
+							focusItemFuncRef: focusItem,
+							initialSelected: mutableRef.current.initialSelected,
+							selectItemBy: 'press'
+						}}
+					>
+						{
+							iconItems.map((item, index) => {
+								return (
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
+										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
+											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+										</ContainerDivWithLeaveForConfig>
+										<IconItem
+											{...item.iconItemProps}
+											spotlightId={`item_${index}`}
+											aria-label={`Icon ${item.index}`}
+											className={css.editableIconItem}
+											disabled={item.iconItemProps['disabled'] || item.hidden}
+											onClick={action('onClickItem')}
+											onFocus={onFocusItem}
+										/>
+									</div>
+								);
+							})
+						}
+					</Scroller>
+				</div>
+			</Panel>
+		</Panels>
+	);
+};
+
+boolean('editableCentered', WithEditableScroller, ScrollerConfig, true);
+number('editableDataSize', WithEditableScroller, ScrollerConfig, 20);
+
+WithEditableScroller.storyName = 'with Editable Scroller';
+WithEditableScroller.parameters = {
 	props: {
 		noPanels: true
 	}

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -344,7 +344,7 @@ export const WithEditableScroller = (args) => {
 			<Panel>
 				<Header title="Panel with Editable Scroller" subtitle="Click pencil button to start edit mode" />
 				<div ref={divRef}>
-					<Button style={{marginLeft: '36px'}} onClick={forward} icon="edit" />
+					<Button aria-label="Edit mode" style={{marginLeft: '36px'}} onClick={forward} icon="edit" />
 					<TouchableDiv
 						onHoldStart={handleHoldStart}
 						onMouseDown={handleMouseDown}
@@ -402,9 +402,9 @@ export const WithEditableScroller = (args) => {
 								return (
 									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
-											{item.hidden ? null : <Button aria-label="Delete button" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-											{item.hidden ? null : <Button aria-label="Hide button" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-											{item.hidden ? <Button aria-label="Show button" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											{...item.iconItemProps}

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -366,7 +366,7 @@ export const WithEditableScroller = (args) => {
 											<div className={css.removeButtonContainer} />
 											<IconItem
 												{...item.iconItemProps}
-												aria-label={`Icon ${item.index} ${$L('Edit mode to press and hold OK button')}`}
+												aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
 												className={css.iconItem}
 												disabled={item.iconItemProps['disabled'] || item.hidden}
 												onClick={action('onClickItem')}
@@ -402,9 +402,9 @@ export const WithEditableScroller = (args) => {
 								return (
 									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
-											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+											{item.hidden ? null : <Button aria-label="Delete button" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide button" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show button" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
 										</ContainerDivWithLeaveForConfig>
 										<IconItem
 											{...item.iconItemProps}

--- a/samples/sampler/stories/qa/Panels.module.less
+++ b/samples/sampler/stories/qa/Panels.module.less
@@ -1,0 +1,115 @@
+@import "@enact/sandstone/styles/mixins.less";
+
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hidden {
+		.iconItem {
+			display: none;
+		}
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
+.wrapper { // public class for editable wrapper
+	padding-left: 36px;
+	padding-right: 36px;
+
+	.removeButtonContainer {
+		height: 156px;
+
+		&:hover ~ .editableIconItem {
+			transform: none;
+		}
+		&:focus-within ~ .editableIconItem {
+			transform: none;
+		}
+
+		.removeButton {
+			display: none;
+		}
+	}
+
+	.itemWrapper {
+		text-align: center;
+
+		&:is([disabled]):not(.hidden).focused {
+			.removeButton {
+				display: none;
+			}
+		}
+
+		.editableIconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+
+		&:not(.selected,.focused) .editableIconItem {
+			&:focus {
+				transform: none;
+			}
+		}
+
+		.iconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+	}
+
+	.focused { // public class for focused item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+		}
+	}
+
+	.selected { // public class for selected item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+		}
+
+		.arrow() {
+			font-family: "Sandstone Icons";
+			font-size: 108px;
+			position: absolute;
+			top: 15%;
+			background: none;
+			opacity: 1;
+		}
+
+		&:not(.hidden):not(.noBefore)::before {
+			content: '\EFFF3';
+			.arrow();
+			.position-start-end(-30px, initial);
+		}
+
+		&:not(.hidden):not(.noAfter)::after {
+			content: '\EFFF4';
+			.arrow();
+			.position-start-end(initial, -30px);
+		}
+
+		.enact-locale-rtl({
+			&:not(.hidden):not(.noBefore)::before,
+			&:not(.hidden):not(.noAfter)::after {
+				transform: scaleX(-1);
+			}
+		});
+	}
+}

--- a/tests/ui/apps/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem-View.js
+++ b/tests/ui/apps/Scroller/EditableScrollerWithIconItem/EditableScrollerWithIconItem-View.js
@@ -161,7 +161,7 @@ class app extends Component {
 											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={this.onClickShowButton} icon="plus" /> : null}
 										</ItemButtonsContainer>
 										<IconItem
-											aria-label={`Icon ${item.index}. Edit mode to press and hold OK button`}
+											aria-label={`Icon ${item.index}. Press and hold the OK button to edit.`}
 											className={css.iconItem}
 											disabled={item.hidden}
 											onFocus={this.onFocusItem}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix the editable scroller a11y feature to not cut off panel's audio guidance
Audio guide statement updated according to the latest UX

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove announce() which is used in the focus handler in the editable scroller 
Fix audioGuide to be read with aria-label of iconItem when the iconItem is focused

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-26318

### Comments
