### PR TITLE
WRP-27604: Fix `VirtualList` not to snatch focus from other list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Panels.Header` to not show `slotAfter` in incorrect position at first rendering when `centered` is given
 - `sandstone/Scroller` to read out properly when `editable` is given 
+- `sandstone/VirtualList` to not snatch focus from other list on the first render
 
 ## [2.7.8] - 2023-08-31
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -145,8 +145,9 @@ const useSpottable = (props, instances) => {
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
 	if (props.dataSize !== mutableRef.current.dataSize) {
-		const focusedIndex = Spotlight.getCurrent()?.dataset?.index;
-		if (focusedIndex > props.dataSize - 1) { // if a focused item is about to disappear
+		const current = Spotlight.getCurrent();
+		if (current && props.scrollContainerContainsDangerously(current) && current.dataset?.index > props.dataSize - 1) {
+			// if a focused item is about to disappear
 			setPreservedIndex(props.dataSize - 1);
 		}
 		mutableRef.current.dataSize = props.dataSize;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Bug is reported that a list can snatch the focus from other list in the following condition;
- The fist virtual list is rendered already.
- The focus is on N-th item of the first virtual list.
- The second virtual list has smaller number of items than N is rendered.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
A virtual list has a logic to focus the last item when a currently focused item is about to disappear by reducing `dataSize`. Unfortunately, there was no check if the currently focused item belongs to a list or not. So, checking logic is added.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-27604
WRP-3602

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
