### PR TITLE
WRP-25755: [Sandsonte Samples] qa-a11y: Add new component from sandst…

### DIFF
--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -35,6 +35,7 @@ import Popup from '../views/Popup';
 import PopupTabLayout from '../views/PopupTabLayout';
 import ProgressBar from '../views/ProgressBar';
 import ProgressButton from '../views/ProgressButton';
+import QuickGuidePanels from '../views/QuickGuidePanels';
 import RadioItem from '../views/RadioItem';
 import RangePicker from '../views/RangePicker';
 import ReadAlert from '../views/ReadAlert';
@@ -85,6 +86,7 @@ const views = [
 	{title: 'PopupTabLayout', view: PopupTabLayout},
 	{title: 'ProgressBar', view: ProgressBar},
 	{title: 'ProgressButton', view: ProgressButton},
+	{isHeader: false, title: 'QuickGuidePanels', view: QuickGuidePanels},
 	{title: 'RadioItem', view: RadioItem},
 	{title: 'RangePicker', view: RangePicker},
 	{title: 'ReadAlert', view: ReadAlert},

--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -86,7 +86,7 @@ const views = [
 	{title: 'PopupTabLayout', view: PopupTabLayout},
 	{title: 'ProgressBar', view: ProgressBar},
 	{title: 'ProgressButton', view: ProgressButton},
-	{isHeader: false, title: 'QuickGuidePanels', view: QuickGuidePanels},
+	{noCloseButton: true, title: 'QuickGuidePanels', view: QuickGuidePanels},
 	{title: 'RadioItem', view: RadioItem},
 	{title: 'RangePicker', view: RangePicker},
 	{title: 'ReadAlert', view: ReadAlert},

--- a/samples/qa-a11y/src/App/View.js
+++ b/samples/qa-a11y/src/App/View.js
@@ -3,9 +3,9 @@ import Scroller from '@enact/sandstone/Scroller';
 import Layout, {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 
-const View = ({debugProps = false, handleDebug, isAriaHidden = false, isDebugMode = false, isHeader = true, title, view: ComponentView}) => {
+const View = ({debugProps = false, handleDebug, isAriaHidden = false, isDebugMode = false, isHeader = true, noCloseButton = false, title, view: ComponentView}) => {
 	const
-		header = isHeader ? <Header aria-hidden={isAriaHidden} title={title} type="compact" /> : null,
+		header = isHeader ? <Header aria-hidden={isAriaHidden} noCloseButton={noCloseButton} title={title} type="compact" /> : null,
 		props = debugProps ? {handleDebug, isDebugMode} : null;
 
 	return (

--- a/samples/qa-a11y/src/App/View.js
+++ b/samples/qa-a11y/src/App/View.js
@@ -26,6 +26,7 @@ View.propTypes = {
 	isAriaHidden: PropTypes.bool,
 	isDebugMode: PropTypes.bool,
 	isHeader: PropTypes.bool,
+	noCloseButton: PropTypes.bool,
 	title: PropTypes.string,
 	view: PropTypes.func
 };

--- a/samples/qa-a11y/src/views/QuickGuidePanels.js
+++ b/samples/qa-a11y/src/views/QuickGuidePanels.js
@@ -1,29 +1,27 @@
-/* eslint-disable react/jsx-no-bind */
-
 import QuickGuidePanels from '@enact/sandstone/QuickGuidePanels';
 import {Header} from '@enact/sandstone/Panels';
 
 const QuickGuidePanelsView = () => (
-    <>
-        <Header title="QuickGuidePanels" />
-        <QuickGuidePanels>
-            <QuickGuidePanels.Panel aria-label={'Panel 0'} >
-                <div style={{marginTop: 150}}>
-                    This is Panel 0
-                </div>
-            </QuickGuidePanels.Panel>
-            <QuickGuidePanels.Panel aria-label={'Panel 1'} >
-                <div style={{marginTop: 150}}>
-                    This is Panel 1
-                </div>
-            </QuickGuidePanels.Panel>
-            <QuickGuidePanels.Panel >
-                <div style={{marginTop: 150}}>
-                    This is Panel 2
-                </div>
-            </QuickGuidePanels.Panel>
-        </QuickGuidePanels>
-    </>
+	<>
+		<Header title="QuickGuidePanels" />
+		<QuickGuidePanels>
+			<QuickGuidePanels.Panel aria-label={'Panel 0'} >
+				<div style={{marginTop: 150}}>
+					This is Panel 0
+				</div>
+			</QuickGuidePanels.Panel>
+			<QuickGuidePanels.Panel aria-label={'Panel 1'} >
+				<div style={{marginTop: 150}}>
+					This is Panel 1
+				</div>
+			</QuickGuidePanels.Panel>
+			<QuickGuidePanels.Panel >
+				<div style={{marginTop: 150}}>
+					This is Panel 2
+				</div>
+			</QuickGuidePanels.Panel>
+		</QuickGuidePanels>
+	</>
 );
 
 export default QuickGuidePanelsView;

--- a/samples/qa-a11y/src/views/QuickGuidePanels.js
+++ b/samples/qa-a11y/src/views/QuickGuidePanels.js
@@ -1,27 +1,17 @@
 import QuickGuidePanels from '@enact/sandstone/QuickGuidePanels';
-import {Header} from '@enact/sandstone/Panels';
 
 const QuickGuidePanelsView = () => (
-	<>
-		<Header title="QuickGuidePanels" />
-		<QuickGuidePanels>
-			<QuickGuidePanels.Panel aria-label={'Panel 0'} >
-				<div style={{marginTop: 150}}>
-					This is Panel 0
-				</div>
-			</QuickGuidePanels.Panel>
-			<QuickGuidePanels.Panel aria-label={'Panel 1'} >
-				<div style={{marginTop: 150}}>
-					This is Panel 1
-				</div>
-			</QuickGuidePanels.Panel>
-			<QuickGuidePanels.Panel >
-				<div style={{marginTop: 150}}>
-					This is Panel 2
-				</div>
-			</QuickGuidePanels.Panel>
-		</QuickGuidePanels>
-	</>
+	<QuickGuidePanels>
+		<QuickGuidePanels.Panel aria-label={'Panel 0'} >
+			This is Panel 0
+		</QuickGuidePanels.Panel>
+		<QuickGuidePanels.Panel aria-label={'Panel 1'} >
+			This is Panel 1
+		</QuickGuidePanels.Panel>
+		<QuickGuidePanels.Panel >
+			This is Panel 2
+		</QuickGuidePanels.Panel>
+	</QuickGuidePanels>
 );
 
 export default QuickGuidePanelsView;

--- a/samples/qa-a11y/src/views/QuickGuidePanels.js
+++ b/samples/qa-a11y/src/views/QuickGuidePanels.js
@@ -1,0 +1,29 @@
+/* eslint-disable react/jsx-no-bind */
+
+import QuickGuidePanels from '@enact/sandstone/QuickGuidePanels';
+import {Header} from '@enact/sandstone/Panels';
+
+const QuickGuidePanelsView = () => (
+    <>
+        <Header title="QuickGuidePanels" />
+        <QuickGuidePanels>
+            <QuickGuidePanels.Panel aria-label={'Panel 0'} >
+                <div style={{marginTop: 150}}>
+                    This is Panel 0
+                </div>
+            </QuickGuidePanels.Panel>
+            <QuickGuidePanels.Panel aria-label={'Panel 1'} >
+                <div style={{marginTop: 150}}>
+                    This is Panel 1
+                </div>
+            </QuickGuidePanels.Panel>
+            <QuickGuidePanels.Panel >
+                <div style={{marginTop: 150}}>
+                    This is Panel 2
+                </div>
+            </QuickGuidePanels.Panel>
+        </QuickGuidePanels>
+    </>
+);
+
+export default QuickGuidePanelsView;


### PR DESCRIPTION
…one(QuickGuide Panels)

Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Create a11y view for QuickGuide Panels.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
a11y view for QuickGuidePanels is created by refering to sandstone sampler. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-25755

### Comments
