### PR TITLE
WRP-27786: Fix `TabLayout` to ignore back key behavior in cursor mode

### DIFF
--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -284,7 +284,7 @@ const TabLayoutBase = kind({
 			const tabLayoutContentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 
 			if (forwardWithPrevent('onKeyUp', ev, props) && is('cancel')(keyCode)) {
-				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && tabLayoutContentRef?.contains(target))) {
+				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
 					if (collapsed) {
 						forward('onExpand', ev, props);
 					}

--- a/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
+++ b/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
@@ -47,7 +47,7 @@ describe('TabLayout', function () {
 						await Page.spotlightRight();
 					});
 					expect(await Page.tabLayout.isCollapsed).to.be.true();
-					// Step 4: Back to the tabs
+					// Back to the tabs
 					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
 						await Page.backKey();
 					});
@@ -87,6 +87,24 @@ describe('TabLayout', function () {
 				});
 			});
 			describe('pointer interaction', function () {
+				it('should not move focus to a Spottable component in the tabs container via back key in pointer mode', async function () {
+					// 5-way down to second tab
+					await Page.spotlightDown();
+					await (await Page.tabLayout.view(2)).waitForExist();
+					// focus the contents
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.spotlightRight();
+					});
+					expect(await Page.tabLayout.isCollapsed).to.be.true();
+					// Set pointer mode
+					await Page.tabLayout.hoverTabs();
+					// When pointer mode is true, focus does not move to tabs via back key
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.backKey();
+					});
+					expect(await Page.tabLayout.isCollapsed).to.be.true();
+				});
+
 				it('should collapse and expand tabs when focus is moved between `Spottable` components in the content and tabs containers via pointer move - [QWTC-1891]', async  function () {
 					// focus the layout's tabs
 					await Page.tabLayout.hoverTabs();


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/sandstone/pull/1495, the back key behavior in TabLayout is implemented.
The focus moves to the tab area when the back key is pressed from the tabLayout content.
However, in cursor mode, this back key behavior needs to be ignored.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check if it is pointer mode by using spotlight.getPointerMode().

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-27786

### Comments
