### PR TITLE
WRP-27860: Fix `EditableScroller` to check validity of initial selected item info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to not show console error when an abnormal `editable.initialSelected` is given
+
 ## [2.7.9] - 2023-09-12
 
 ### Changed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -151,7 +151,9 @@ const EditableWrapper = (props) => {
 		mutableRef.current.selectedItemLabel = '';
 		mutableRef.current.lastMoveDirection = null;
 		mutableRef.current.prevToIndex = null;
-		initialSelected.itemIndex = null;
+		if (initialSelected) {
+			initialSelected.itemIndex = null;
+		}
 		wrapperRef.current.style.setProperty('--selected-item-offset', '0px');
 
 		Spotlight.set(spotlightId, {restrict: 'self-first'});

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -763,10 +763,10 @@ const EditableWrapper = (props) => {
 
 	useLayoutEffect(() => {
 		const iconItemList = Array.from(wrapperRef.current.children);
-		const initialSelected = mutableRef.current.initialSelected;
+		let initialSelected = mutableRef.current.initialSelected;
 
 		if (initialSelected && !(initialSelected?.itemIndex > 0)) { // filter nullish values
-			mutableRef.current.initialSelected.itemIndex = 1; // fallback to select the first item for abnormal index value
+			initialSelected = mutableRef.current.initialSelected = null;
 		}
 
 		if (initialSelected?.itemIndex) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Scroller` could make a script error on run-time if `editable` prop has an abnormal `initialSelected` value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a guard code to prevent logic from a script error.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-27860

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)