### PR TITLE
Revert back key behavior of TabLayout that moves focus from tab content to tab menu (#1495, #1505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [2.7.9] - 2023-09-12
 
-### Changed
-
-- `sandstone/TabLayout` back key behavior to match the latest UX
-
 ### Fixed
 
 - `sandstone/Panels.Header` to not show `slotAfter` in incorrect position at first rendering when `centered` is given

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/TabLayout` to revert 2.7.9 fix that change back key behavior
+
 ## [2.7.10] - 2023-09-20
 
 ### Fixed
@@ -10,6 +16,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/VirtualList` to not snatch focus from other list on the first render
 
 ## [2.7.9] - 2023-09-12
+
+### Changed
+
+- `sandstone/TabLayout` back key behavior to match the latest UX
 
 ### Fixed
 

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -281,16 +281,13 @@ const TabLayoutBase = kind({
 			const {keyCode, target} = ev;
 			const {anchorTo, collapsed, orientation, 'data-spotlight-id': spotlightId, rtl, type} = props;
 			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
-			const tabLayoutContentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 
-			if (forwardWithPrevent('onKeyUp', ev, props) && is('cancel')(keyCode)) {
-				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && tabLayoutContentRef?.contains(target))) {
-					if (collapsed) {
-						forward('onExpand', ev, props);
-					}
-					Spotlight.focus(`[data-spotlight-id='${spotlightId}-tabs-expanded']`);
-					ev.stopPropagation();
+			if (forwardWithPrevent('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') {
+				if (collapsed) {
+					forward('onExpand', ev, props);
 				}
+				Spotlight.move('left');
+				ev.stopPropagation();
 			} else if (is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
 				Spotlight.setPointerMode(false);
 

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -284,7 +284,7 @@ const TabLayoutBase = kind({
 			const tabLayoutContentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 
 			if (forwardWithPrevent('onKeyUp', ev, props) && is('cancel')(keyCode)) {
-				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
+				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && tabLayoutContentRef?.contains(target))) {
 					if (collapsed) {
 						forward('onExpand', ev, props);
 					}

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom';
 import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import Button from '../../Button';
 import TabLayout, {TabLayoutBase, Tab} from '../TabLayout';
 
 const keyDown = (keyCode) => (tab) => fireEvent.keyDown(tab, {keyCode});
@@ -333,24 +332,6 @@ describe('TabLayout specs', () => {
 		enterKeyUp(tab);
 
 		const expected = {type: 'onSelect'};
-		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
-
-		expect(actual).toMatchObject(expected);
-	});
-
-	test('should call \'onExpand\' with \'onExpand\' type when pressing \'backKey\' on a tab content', () => {
-		const spy = jest.fn();
-		render(
-			<TabLayout collapsed onExpand={spy} rtl={false}>
-				<Tab icon="home" title="Home">
-					<Button>Button</Button>
-				</Tab>
-			</TabLayout>
-		);
-
-		fireEvent.keyUp(screen.getByRole('button'), {keyCode: 27});
-
-		const expected = {type: 'onExpand'};
 		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
 
 		expect(actual).toMatchObject(expected);

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -84,6 +84,7 @@ const PopupTabLayoutSamplesBase = ({args, rtl}) => {
 				noAutoDismiss={args['noAutoDismiss']}
 				onTabAnimationEnd={action('onTabAnimationEnd')}
 				onHide={action('onHide')}
+				onSelect={action('onSelect')}
 				onShow={action('onShow')}
 				scrimType={args['scrimType']}
 				spotlightRestrict={args['spotlightRestrict']}

--- a/samples/sampler/stories/default/PopupTabLayout.js
+++ b/samples/sampler/stories/default/PopupTabLayout.js
@@ -84,7 +84,6 @@ const PopupTabLayoutSamplesBase = ({args, rtl}) => {
 				noAutoDismiss={args['noAutoDismiss']}
 				onTabAnimationEnd={action('onTabAnimationEnd')}
 				onHide={action('onHide')}
-				onSelect={action('onSelect')}
 				onShow={action('onShow')}
 				scrimType={args['scrimType']}
 				spotlightRestrict={args['spotlightRestrict']}

--- a/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
+++ b/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
@@ -47,7 +47,7 @@ describe('TabLayout', function () {
 						await Page.spotlightRight();
 					});
 					expect(await Page.tabLayout.isCollapsed).to.be.true();
-					// Back to the tabs
+					// Step 4: Back to the tabs
 					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
 						await Page.backKey();
 					});
@@ -87,24 +87,6 @@ describe('TabLayout', function () {
 				});
 			});
 			describe('pointer interaction', function () {
-				it('should not move focus to a Spottable component in the tabs container via back key in pointer mode', async function () {
-					// 5-way down to second tab
-					await Page.spotlightDown();
-					await (await Page.tabLayout.view(2)).waitForExist();
-					// focus the contents
-					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
-						await Page.spotlightRight();
-					});
-					expect(await Page.tabLayout.isCollapsed).to.be.true();
-					// Set pointer mode
-					await Page.tabLayout.hoverTabs();
-					// When pointer mode is true, focus does not move to tabs via back key
-					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
-						await Page.backKey();
-					});
-					expect(await Page.tabLayout.isCollapsed).to.be.true();
-				});
-
 				it('should collapse and expand tabs when focus is moved between `Spottable` components in the content and tabs containers via pointer move - [QWTC-1891]', async  function () {
 					// focus the layout's tabs
 					await Page.tabLayout.hoverTabs();

--- a/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
+++ b/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
@@ -38,22 +38,6 @@ describe('TabLayout', function () {
 					expect(await Page.tabLayout.isCollapsed).to.be.false();
 				});
 
-				it('should expand tabs when focus is moved to a Spottable component in the tabs container via back key', async function () {
-					// 5-way down to second tab
-					await Page.spotlightDown();
-					await (await Page.tabLayout.view(2)).waitForExist();
-					// focus the contents
-					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
-						await Page.spotlightRight();
-					});
-					expect(await Page.tabLayout.isCollapsed).to.be.true();
-					// Step 4: Back to the tabs
-					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
-						await Page.backKey();
-					});
-					expect(await Page.tabLayout.isCollapsed).to.be.false();
-				});
-
 				it('should collapse tabs when focus is moved to a Spottable component in the content container via 5-way Select', async function () {
 					await Page.delay(1000);
 					// 5-way down to second tab


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/sandstone/pull/1495, we implemented the back key behavior of TabLayout that moves focus from content to the tab menu(area). However, this behavior causes side effects. We decided to revert back key behavior of TabLayout.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Revert https://github.com/enactjs/sandstone/pull/1495, https://github.com/enactjs/sandstone/pull/1505 changes

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-28759

### Comments
