### PR TITLE
WRQ-379: Fix EditableWrapper movement completion announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to read out the announcement of completion properly when `editable` is given
+
 ## [2.7.11] - 2023-10-13
 
 ### Fixed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -572,12 +572,13 @@ const EditableWrapper = (props) => {
 						focusItem(target);
 					}
 					mutableRef.current.needToPreventEvent = true;
-
+					selectedItem.children[1].ariaLabel = '';
 					setTimeout(() => {
 						announceRef.current.announce(
 							selectedItemLabel + $L('Movement completed'),
 							true
 						);
+						selectedItem.children[1].ariaLabel = `${selectedItem.ariaLabel} ${$L('Press the OK button to move or press the up button to select other options.')}`;
 					}, completeAnnounceDelay);
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
@@ -639,12 +640,13 @@ const EditableWrapper = (props) => {
 				if (selectItemBy === 'press') {
 					focusItem(target);
 				}
-
+				selectedItem.children[1].ariaLabel = '';
 				setTimeout(() => {
 					announceRef?.current?.announce(
 						selectedItemLabel + $L('Movement completed'),
 						true
 					);
+					selectedItem.children[1].ariaLabel = `${selectedItem.ariaLabel} ${$L('Press the OK button to move or press the up button to select other options.')}`;
 				}, completeAnnounceDelay);
 
 				ev.stopPropagation(); // To prevent onCancel by CancelDecorator


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Sometimes, focus audio guidance is announced before the movement completion audio guidance.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix aria-label of the selected item to be an empty string while reading out movement completion audio guidance

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-379

### Comments
