### PR TITLE
WRQ-456: Apply GA and cookie banner only when there is a relevant environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - node
+    - "20"
 sudo: false
 before_install:
     - sudo apt-get update

--- a/samples/sampler/.storybook/preview.js
+++ b/samples/sampler/.storybook/preview.js
@@ -50,20 +50,21 @@ const skins = {
 
 configureActions();
 
-const GA_MEASUREMENT_ID  = "G-ZNPW7ST2D8";
-const options = {
-	gtagOptions: {
-		content_group: 'storybook',
-	},
-};
+if (process.env.STORYBOOK_APPLY_GA_COOKIEBANNER) {
+	const GA_MEASUREMENT_ID  = "G-ZNPW7ST2D8";
+	const options = {
+		gtagOptions: {
+			content_group: 'storybook',
+		},
+	};
 
-ReactGA4.initialize(GA_MEASUREMENT_ID, options);
+	ReactGA4.initialize(GA_MEASUREMENT_ID, options);
 
-const script = document.createElement("script");
-script.src = `//cdn.cookie-script.com/s/3a846584c6b545a3d1ac4dcfc8ac15a2.js`;
-script.type = "text/javascript";
-
-document.body.appendChild(script);
+	const script = document.createElement("script");
+	script.src = `//cdn.cookie-script.com/s/3a846584c6b545a3d1ac4dcfc8ac15a2.js`;
+	script.type = "text/javascript";
+	document.body.appendChild(script);
+}
 
 export const parameters = {
 	docs: {


### PR DESCRIPTION
### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The cookie banner appears first when running an automation test, which prevents the test from proceeding properly.
So the cookie banner and GA needs to be modified so that it can only be applied when the sandstone sampler is deployed on enactjs.com

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Apply GA and cookie banner only when there is a relevant environment variable.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The environment variable name required the prefixed with STORYBOOK_
(https://storybook.js.org/docs/6.5/react/configure/environment-variables)

### Links
[//]: # (Related issues, references)
WRQ-456

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)