### PR TITLE
WRQ-1306: Change back key behavior on TabLayout to navigate focus from tab contents to tab menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/TabLayout` to move focus from tab contents to tab menu via back key
+
 ## [2.7.12] - 2023-10-23
 
 ### Fixed

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -143,7 +143,7 @@ const TabLayoutBase = kind({
 		}),
 
 		/**
-		 * Disable back key behavior whcih moves focus from tab contents to tab menu
+		 * Disable back key behavior which moves focus from tab contents to tab menu
 		 *
 		 * @type {Boolean}
 		 * @private

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -281,13 +281,16 @@ const TabLayoutBase = kind({
 			const {keyCode, target} = ev;
 			const {anchorTo, collapsed, orientation, 'data-spotlight-id': spotlightId, rtl, type} = props;
 			const popupPanelRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${popupTabLayoutComponentCss.panel}`);
+			const tabLayoutContentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 
-			if (forwardWithPrevent('onKeyUp', ev, props) && type === 'popup' && is('cancel')(keyCode) && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') {
-				if (collapsed) {
-					forward('onExpand', ev, props);
+			if (forwardWithPrevent('onKeyUp', ev, props) && is('cancel')(keyCode)) {
+				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
+					if (collapsed) {
+						forward('onExpand', ev, props);
+					}
+					Spotlight.focus(`[data-spotlight-id='${spotlightId}-tabs-expanded']`);
+					ev.stopPropagation();
 				}
-				Spotlight.move('left');
-				ev.stopPropagation();
 			} else if (is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
 				Spotlight.setPointerMode(false);
 

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -143,6 +143,14 @@ const TabLayoutBase = kind({
 		}),
 
 		/**
+		 * Disable back key behavior whcih moves focus from tab contents to tab menu
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		disableBackKeyNavigation: PropTypes.bool,
+
+		/**
 		 * The currently selected tab.
 		 *
 		 * @type {Number}
@@ -284,7 +292,7 @@ const TabLayoutBase = kind({
 			const tabLayoutContentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 
 			if (forwardWithPrevent('onKeyUp', ev, props) && is('cancel')(keyCode)) {
-				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
+				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !props.disableBackKeyNavigation && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
 					if (collapsed) {
 						forward('onExpand', ev, props);
 					}

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import Button from '../../Button';
 import TabLayout, {TabLayoutBase, Tab} from '../TabLayout';
 
 const keyDown = (keyCode) => (tab) => fireEvent.keyDown(tab, {keyCode});
@@ -332,6 +333,24 @@ describe('TabLayout specs', () => {
 		enterKeyUp(tab);
 
 		const expected = {type: 'onSelect'};
+		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
+
+		expect(actual).toMatchObject(expected);
+	});
+
+	test('should call \'onExpand\' with \'onExpand\' type when pressing \'backKey\' on a tab content', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout collapsed onExpand={spy} rtl={false}>
+				<Tab icon="home" title="Home">
+					<Button>Button</Button>
+				</Tab>
+			</TabLayout>
+		);
+
+		fireEvent.keyUp(screen.getByRole('button'), {keyCode: 27});
+
+		const expected = {type: 'onExpand'};
 		const actual = spy.mock.calls.length && spy.mock.calls[0][0];
 
 		expect(actual).toMatchObject(expected);

--- a/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
+++ b/tests/ui/specs/TabLayout/VerticalTabsWithIcons/VerticalTabsWithIcons-specs.js
@@ -38,6 +38,22 @@ describe('TabLayout', function () {
 					expect(await Page.tabLayout.isCollapsed).to.be.false();
 				});
 
+				it('should expand tabs when focus is moved to a Spottable component in the tabs container via back key', async function () {
+					// 5-way down to second tab
+					await Page.spotlightDown();
+					await (await Page.tabLayout.view(2)).waitForExist();
+					// focus the contents
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.spotlightRight();
+					});
+					expect(await Page.tabLayout.isCollapsed).to.be.true();
+					// Back to the tabs
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.backKey();
+					});
+					expect(await Page.tabLayout.isCollapsed).to.be.false();
+				});
+
 				it('should collapse tabs when focus is moved to a Spottable component in the content container via 5-way Select', async function () {
 					await Page.delay(1000);
 					// 5-way down to second tab
@@ -71,6 +87,24 @@ describe('TabLayout', function () {
 				});
 			});
 			describe('pointer interaction', function () {
+				it('should not move focus to a Spottable component in the tabs container via back key in pointer mode', async function () {
+					// 5-way down to second tab
+					await Page.spotlightDown();
+					await (await Page.tabLayout.view(2)).waitForExist();
+					// focus the contents
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.spotlightRight();
+					});
+					expect(await Page.tabLayout.isCollapsed).to.be.true();
+					// Set pointer mode
+					await Page.tabLayout.hoverTabs();
+					// When pointer mode is true, focus does not move to tabs via back key
+					await Page.waitTransitionEnd(1500, 'waiting for Panel transition', async () => {
+						await Page.backKey();
+					});
+					expect(await Page.tabLayout.isCollapsed).to.be.true();
+				});
+
 				it('should collapse and expand tabs when focus is moved between `Spottable` components in the content and tabs containers via pointer move - [QWTC-1891]', async  function () {
 					// focus the layout's tabs
 					await Page.tabLayout.hoverTabs();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the back key is pressed from the TabLayout content and the `disableBackKeyNavigation` prop is false, the focus should move to the tab menu


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Revert #1511 to add back key behavior of TabLayout which enables navigate focus from tab contents to tab menu
Add private prop `disableBackKeyNavigation`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-1306

### Comments
