### PR TITLE
WRQ-155: Update `Scroller` to complete editing by 'down' key when `editable` is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/Scroller` with `editable` prop to complete editing when 'down' key is pressed during editing
+
 ## [2.7.12] - 2023-10-23
 
 ### Fixed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -558,7 +558,7 @@ const EditableWrapper = (props) => {
 		}
 	}, [finalizeEditing, finalizeOrders, scrollContainerHandle, scrollContentRef]);
 
-	const finalizeEditingWithFocusByKeyDown = useCallback((target) => {
+	const completeEditingByKeyDown = useCallback((target) => {
 		const {selectedItem, selectedItemLabel} = mutableRef.current;
 		const orders = finalizeOrders();
 
@@ -586,7 +586,7 @@ const EditableWrapper = (props) => {
 		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
 			if (!repeat) {
 				if (selectedItem) {
-					finalizeEditingWithFocusByKeyDown(target);
+					completeEditingByKeyDown(target);
 					mutableRef.current.needToPreventEvent = true;
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
@@ -598,7 +598,7 @@ const EditableWrapper = (props) => {
 				}, holdDuration - 300);
 			}
 		} else if (is('down', keyCode) && target.getAttribute('role') !== 'button' && !repeat && selectedItem) {
-			finalizeEditingWithFocusByKeyDown(target);
+			completeEditingByKeyDown(target);
 			mutableRef.current.needToPreventEvent = true;
 		} else if (is('left', keyCode) || is('right', keyCode)) {
 			if (selectedItem) {
@@ -638,7 +638,7 @@ const EditableWrapper = (props) => {
 				}
 			}
 		}
-	}, [finalizeEditing, finalizeOrders, findItemNode, moveItemsByKeyDown, reset, selectItemBy, startEditing, finalizeEditingWithFocusByKeyDown]);
+	}, [finalizeEditing, finalizeOrders, findItemNode, moveItemsByKeyDown, reset, selectItemBy, startEditing, completeEditingByKeyDown]);
 
 	const handleKeyUpCapture = useCallback((ev) => {
 		const {keyCode, target} = ev;
@@ -646,7 +646,7 @@ const EditableWrapper = (props) => {
 
 		if (is('cancel', keyCode)) {
 			if (selectedItem) {
-				finalizeEditingWithFocusByKeyDown(target);
+				completeEditingByKeyDown(target);
 				ev.stopPropagation(); // To prevent onCancel by CancelDecorator
 			}
 		} else {
@@ -662,7 +662,7 @@ const EditableWrapper = (props) => {
 			ev.preventDefault();
 			mutableRef.current.needToPreventEvent = false;
 		}
-	}, [finalizeEditingWithFocusByKeyDown]);
+	}, [completeEditingByKeyDown]);
 
 	useEffect(() => {
 		if (mutableRef.current.nextSpotlightRect !== null) {

--- a/tests/ui/specs/Scroller/WithEditableSelectItemByPress/ScrollerWithEditableSelectItemByPress-specs.js
+++ b/tests/ui/specs/Scroller/WithEditableSelectItemByPress/ScrollerWithEditableSelectItemByPress-specs.js
@@ -222,11 +222,12 @@ describe('Editable Scroller', function () {
 		await expect(await element.isDisplayedInViewport()).to.be.true();
 	});
 
-	it('Should unselect the selected item with 5-way down', async function () {
+	it('Should unselect the selected item with 5-way down [QWTC-13660]', async function () {
 		// Select the first item
 		await ScrollerPage.spotlightDown();
 		await ScrollerPage.spotlightSelect();
 		await expectFocusedIconItem('0');
+		await expectItemWrapperClass('tests_ui_apps_Scroller_WithEditableSelectItemByPress_ScrollerWithEditableSelectItemByPress_selected');
 
 		// 5-way Right to move Item 0.
 		await ScrollerPage.spotlightRight();
@@ -235,6 +236,7 @@ describe('Editable Scroller', function () {
 		// 5-way Down to finish editing
 		await ScrollerPage.spotlightDown();
 		await expectFocusedIconItem('0');
+		await expectItemWrapperClass('tests_ui_apps_Scroller_WithEditableSelectItemByPress_ScrollerWithEditableSelectItemByPress_focused');
 
 		// 5-way Left to check if no item is selected
 		await ScrollerPage.spotlightLeft();

--- a/tests/ui/specs/Scroller/WithEditableSelectItemByPress/ScrollerWithEditableSelectItemByPress-specs.js
+++ b/tests/ui/specs/Scroller/WithEditableSelectItemByPress/ScrollerWithEditableSelectItemByPress-specs.js
@@ -12,36 +12,11 @@ describe('Editable Scroller', function () {
 		await expectFocusedIconItem('0');
 
 		/* hide 10 items: note that 10 items are minimal set to make the scroller overflows */
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
-		await ScrollerPage.spotlightUp();
-		await ScrollerPage.spotlightRight();
-		await ScrollerPage.spotlightSelect();
+		for (let i = 0; i < 10; i++) {
+			await ScrollerPage.spotlightUp();
+			await ScrollerPage.spotlightRight();
+			await ScrollerPage.spotlightSelect();
+		}
 
 		/* move focus out of the scroller */
 		await ScrollerPage.spotlightUp();
@@ -245,6 +220,25 @@ describe('Editable Scroller', function () {
 		// Verify: Item 9 is displayed in Viewport.
 		const element = await $('#item9');
 		await expect(await element.isDisplayedInViewport()).to.be.true();
+	});
+
+	it('Should unselect the selected item with 5-way down', async function () {
+		// Select the first item
+		await ScrollerPage.spotlightDown();
+		await ScrollerPage.spotlightSelect();
+		await expectFocusedIconItem('0');
+
+		// 5-way Right to move Item 0.
+		await ScrollerPage.spotlightRight();
+		await expectFocusedIconItem('0');
+
+		// 5-way Down to finish editing
+		await ScrollerPage.spotlightDown();
+		await expectFocusedIconItem('0');
+
+		// 5-way Left to check if no item is selected
+		await ScrollerPage.spotlightLeft();
+		await expectFocusedIconItem('1');
 	});
 
 	describe('Editable Scroller in RTL locales', function () {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
A new UX requirement that `Scroller` should complete editing by 'down' key just like by 'enter' key when `editable` is given.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated Scroller/EditableWrapper is updated to support 'down' key.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-155

### Comments
