### PR TITLE
WRQ-1308: Update audio guidance of Dropdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/Dropdown` to read out more details
+
 ## [2.7.12] - 2023-10-23
 
 ### Fixed

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -337,7 +337,7 @@ const DropdownBase = kind({
 			<div {...calcAriaProps} {...rest}>
 				{title}
 				<DropdownButton
-					aria-label={ariaLabel || placeholder + ` ${$L('Dropdown')}`}
+					aria-label={(ariaLabel || placeholder) + ` ${$L('Dropdown')}`}
 					direction={direction}
 					disabled={hasChildren ? disabled : true}
 					focusEffect="static"

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -337,7 +337,7 @@ const DropdownBase = kind({
 			<div {...calcAriaProps} {...rest}>
 				{title}
 				<DropdownButton
-					aria-label={ariaLabel}
+					aria-label={ariaLabel || placeholder + ` ${$L('Dropdown')}`}
 					direction={direction}
 					disabled={hasChildren ? disabled : true}
 					focusEffect="static"

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -3,12 +3,14 @@ import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import Spotlight from '@enact/spotlight';
+import IdProvider from '@enact/ui/internal/IdProvider';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {Component} from 'react';
 import ReactDOM from 'react-dom';
 
+import $L from '../internal/$L';
 import Icon from '../Icon';
 import Item from '../Item';
 import Skinnable from '../Skinnable';
@@ -50,6 +52,14 @@ const DropdownListBase = kind({
 				key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 			}))
 		]),
+
+		/**
+		 * The `id` of DropdownList referred to when setting aria-labelledby
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		id: PropTypes.string,
 
 		/*
 		 * Called when an item is selected.
@@ -131,7 +141,7 @@ const DropdownListBase = kind({
 		itemSize: () => 126
 	},
 
-	render: ({dataSize, itemSize, scrollTo, width, ...rest}) => {
+	render: ({dataSize, id, itemSize, scrollTo, width, ...rest}) => {
 		delete rest.children;
 		delete rest.onSelect;
 		delete rest.selected;
@@ -139,16 +149,19 @@ const DropdownListBase = kind({
 		delete rest.width;
 
 		return (
-			<VirtualList
-				{...rest}
-				cbScrollTo={scrollTo}
-				dataSize={dataSize}
-				itemSize={ri.scale(itemSize)}
-				style={{
-					height: ri.scaleToRem((itemSize * dataSize) + 36),
-					width: typeof width === 'number' ? ri.scaleToRem(width) : null
-				}}
-			/>
+			<div role="region" aria-labelledby={`${id}_dropdownlist`}>
+				<div id={`${id}_dropdownlist`} aria-label={$L('Dropdown list opened')} />
+				<VirtualList
+					{...rest}
+					cbScrollTo={scrollTo}
+					dataSize={dataSize}
+					itemSize={ri.scale(itemSize)}
+					style={{
+						height: ri.scaleToRem((itemSize * dataSize) + 36),
+						width: typeof width === 'number' ? ri.scaleToRem(width) : null
+					}}
+				/>
+			</div>
 		);
 	}
 });
@@ -307,6 +320,10 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 
 const DropdownListDecorator = compose(
 	DropdownListSpotlightDecorator,
+	IdProvider({
+		generateProp: null,
+		prefix: 'dl_'
+	}),
 	Skinnable({variantsProp: 'skinVariants'})
 );
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update audio guidance of Dropdown component
- When dropdown list is opened, read out `Dropdown list opened`
- When dropdown button is focused, read out `Dropdown` after the contents

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated aria-label in Dropdown
Updated DropdownList to use aria-labelledby to read only when the focus is entered into the list

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ-1308

### Comments
