### PR TITLE
WRQ-1307: Update audio guidance of TabLayout component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Changed
+
+- `sandstone/TabLayout` to read out more details
+
 ## [2.7.12] - 2023-10-23
 
 ### Fixed

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -3,12 +3,15 @@ import kind from '@enact/core/kind';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Group from '@enact/ui/Group';
+import IdProvider from '@enact/ui/internal/IdProvider';
 import {Cell, Layout} from '@enact/ui/Layout';
 import Toggleable from '@enact/ui/Toggleable';
+import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {useMemo} from 'react';
 
+import $L from '../internal/$L';
 import DebounceDecorator from '../internal/DebounceDecorator';
 import Button from '../Button';
 import Skinnable from '../Skinnable';
@@ -150,6 +153,7 @@ const TabGroupBase = kind({
 		tabs: PropTypes.array.isRequired,
 		collapsed: PropTypes.bool,
 		css: PropTypes.object,
+		id: PropTypes.string,
 		onBlur: PropTypes.func,
 		onBlurList: PropTypes.func,
 		onFocus: PropTypes.func,
@@ -176,7 +180,7 @@ const TabGroupBase = kind({
 		tabsSpotlightDisabled: ({spotlightDisabled, tabs}) => spotlightDisabled || tabs.find(tab => tab && !tab.spotlightDisabled) == null
 	},
 
-	render: ({css, collapsed, noIcons, onBlur, onBlurList, onFocus, onFocusTab, onSelect, orientation, selectedIndex, spotlightId, spotlightDisabled, tabs, tabSize, tabsDisabled, tabsSpotlightDisabled, ...rest}) => {
+	render: ({css, collapsed, id, noIcons, onBlur, onBlurList, onFocus, onFocusTab, onSelect, orientation, selectedIndex, spotlightId, spotlightDisabled, tabs, tabSize, tabsDisabled, tabsSpotlightDisabled, ...rest}) => {
 		delete rest.children;
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -228,23 +232,27 @@ const TabGroupBase = kind({
 						spotlightDisabled={tabsSpotlightDisabled}
 					/>
 				) : (
-					<GroupComponent
-						childComponent={Tab}
-						className={componentCss.tabs}
-						component={groupComponent}
-						indexProp="index"
-						itemProps={itemProps}
-						onSelect={onSelect}
-						orientation={orientation}
-						role="list"
-						select="radio"
-						selected={selectedIndex}
-						selectedProp="selected"
-						spotlightId={spotlightId}
-						spotlightDisabled={spotlightDisabled}
-					>
-						{children}
-					</GroupComponent>
+					<div role="region" aria-labelledby={`${id}_tabgroup`}>
+						<GroupComponent
+							id={`${id}_tabgroup`}
+							childComponent={Tab}
+							aria-label={`${new IString($L('{total} items in total')).format({'total': tabs.length})}`}
+							className={componentCss.tabs}
+							component={groupComponent}
+							indexProp="index"
+							itemProps={itemProps}
+							onSelect={onSelect}
+							orientation={orientation}
+							role="list"
+							select="radio"
+							selected={selectedIndex}
+							selectedProp="selected"
+							spotlightId={spotlightId}
+							spotlightDisabled={spotlightDisabled}
+						>
+							{children}
+						</GroupComponent>
+					</div>
 				)}
 				{isHorizontal ? <hr className={componentCss.horizontalLine} /> : null}
 			</Component>
@@ -253,7 +261,11 @@ const TabGroupBase = kind({
 });
 
 const TabGroupDecorator = compose(
-	DebounceDecorator({cancel: 'onBlur', debounce: 'onFocusTab', delay: 300})
+	DebounceDecorator({cancel: 'onBlur', debounce: 'onFocusTab', delay: 300}),
+	IdProvider({
+		generateProp: null,
+		prefix: 'tg_'
+	})
 );
 
 // Only documenting TabGroup since base is not useful for extension as-is

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -40,7 +40,8 @@ const TabBase = kind({
 		selected: PropTypes.bool,
 		size: PropTypes.number,
 		sprite: PropTypes.object,
-		stopped: PropTypes.bool
+		stopped: PropTypes.bool,
+		total: PropTypes.number
 	},
 
 	defaultProps: {
@@ -76,8 +77,7 @@ const TabBase = kind({
 		}
 	},
 
-	render: ({children, collapsed, css, orientation, size, ...rest}) => {
-		delete rest.index;
+	render: ({children, collapsed, css, index, orientation, size, total, ...rest}) => {
 		delete rest.onFocusTab;
 		delete rest.onTabClick;
 		delete rest.stopped;
@@ -86,13 +86,14 @@ const TabBase = kind({
 		if (collapsed) children = null;
 
 		const commonProps = {
+			'aria-label':`${children} ${$L('Tab')} ${new IString($L('{selectedValue} of {total}')).format({selectedValue: index + 1, total: total})}`,
 			backgroundOpacity: 'transparent',
 			children,
 			collapsable: true,
 			css,
 			focusEffect: 'static',
 			minWidth: false,
-			role: 'tab'
+			role: null
 		};
 
 		switch (orientation) {
@@ -199,6 +200,7 @@ const TabGroupBase = kind({
 					key,
 					onFocusTab,
 					sprite,
+					total: tabs.length,
 					...rest
 				};
 			} else {
@@ -236,14 +238,13 @@ const TabGroupBase = kind({
 						<GroupComponent
 							id={`${id}_tabgroup`}
 							childComponent={Tab}
-							aria-label={`${new IString($L('{total} items in total')).format({'total': tabs.length})}`}
+							aria-label={`${new IString($L('{total} items in total')).format({total: tabs.length})}`}
 							className={componentCss.tabs}
 							component={groupComponent}
 							indexProp="index"
 							itemProps={itemProps}
 							onSelect={onSelect}
 							orientation={orientation}
-							role="tablist"
 							select="radio"
 							selected={selectedIndex}
 							selectedProp="selected"

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -92,7 +92,7 @@ const TabBase = kind({
 			css,
 			focusEffect: 'static',
 			minWidth: false,
-			role: 'listitem'
+			role: 'tab'
 		};
 
 		switch (orientation) {
@@ -243,7 +243,7 @@ const TabGroupBase = kind({
 							itemProps={itemProps}
 							onSelect={onSelect}
 							orientation={orientation}
-							role="list"
+							role="tablist"
 							select="radio"
 							selected={selectedIndex}
 							selectedProp="selected"

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -89,7 +89,7 @@ const TabBase = kind({
 			css,
 			focusEffect: 'static',
 			minWidth: false,
-			role: null
+			role: 'listitem'
 		};
 
 		switch (orientation) {
@@ -236,6 +236,7 @@ const TabGroupBase = kind({
 						itemProps={itemProps}
 						onSelect={onSelect}
 						orientation={orientation}
+						role="list"
 						select="radio"
 						selected={selectedIndex}
 						selectedProp="selected"


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update audio guidance of TabLayout component
- When the focus is entered into the tabList, read out `{total} items in total`
- When the focus is moved to the other tab, read out `tab {selectedValue} of {total}` after reading the tab name

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add aria-label in TabBase.
Updated TabGroup to use aria-labelledby to read only when the focus is entered into the list

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ-1307

### Comments
