### PR TITLE
WRQ-3732: Fixed Scroller with editable prop to complete editing when focus is leaving by 5-way key on pointer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` with `editable` to complete editing when focus is leaving by 5-way key on pointer mode
+- `sandstone/Scroller` with `editable` to complete editing when focus left by 5-way key in pointer mode
 
 ## [2.7.12] - 2023-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` with `editable` to complete editing when focus is leaving by 5-way key on pointer mode
+
 ## [2.7.12] - 2023-10-23
 
 ### Fixed
@@ -30,7 +36,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Panels.Header` to not show `slotAfter` in incorrect position at first rendering when `centered` is given
-- `sandstone/Scroller` to read out properly when `editable` is given 
+- `sandstone/Scroller` to read out properly when `editable` is given
 
 ## [2.7.8] - 2023-08-31
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -4,9 +4,9 @@ import {is} from '@enact/core/keymap';
 import {usePublicClassNames} from '@enact/core/usePublicClassNames';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getContainersForNode} from '@enact/spotlight/src/container';
-import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
+import {getTargetByDirectionFromElement, getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import Accelerator from '@enact/spotlight/Accelerator';
-import {getLastPointerPosition, setPointerMode} from '@enact/spotlight/src/pointer';
+import {getLastPointerPosition, getPointerMode, setPointerMode} from '@enact/spotlight/src/pointer';
 import {Announce} from '@enact/ui/AnnounceDecorator';
 import Touchable from '@enact/ui/Touchable';
 import classNames from 'classnames';
@@ -669,6 +669,33 @@ const EditableWrapper = (props) => {
 			mutableRef.current.needToPreventEvent = false;
 		}
 	}, [finalizeEditing, finalizeOrders, focusItem, selectItemBy]);
+
+	const handleGlobalKeyDownCapture = useCallback((ev) => {
+		if (getPointerMode() && !scrollContainerRef.current.contains(Spotlight.getCurrent()) && mutableRef.current.selectedItem) {
+			const {keyCode} = ev;
+			const position = getLastPointerPosition();
+			const nextTarget = getTargetByDirectionFromPosition(getDirection(keyCode), position, mutableRef.current.spotlightId);
+
+			if (!scrollContainerRef.current.contains(nextTarget)) {
+				const orders = finalizeOrders();
+				finalizeEditing(orders);
+			}
+		}
+	}, [finalizeEditing, finalizeOrders, scrollContainerRef]);
+
+	useLayoutEffect(() => {
+		const available = typeof document === 'object';
+
+		if (available) {
+			document.addEventListener('keydown', handleGlobalKeyDownCapture, {capture: true});
+		}
+
+		return () => {
+			if (available) {
+				document.removeEventListener('keydown', handleGlobalKeyDownCapture, {capture: true});
+			}
+		};
+	}, [handleGlobalKeyDownCapture]);
 
 	useEffect(() => {
 		if (mutableRef.current.nextSpotlightRect !== null) {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -619,6 +619,7 @@ const EditableWrapper = (props) => {
 
 				// Check if focus leaves scroll container.
 				if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {
+					setPointerMode(false);
 					Spotlight.move(getDirection(keyCode));
 
 					const orders = finalizeOrders();

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -674,11 +674,14 @@ const EditableWrapper = (props) => {
 		if (getPointerMode() && !scrollContainerRef.current.contains(Spotlight.getCurrent()) && mutableRef.current.selectedItem) {
 			const {keyCode} = ev;
 			const position = getLastPointerPosition();
-			const nextTarget = getTargetByDirectionFromPosition(getDirection(keyCode), position, mutableRef.current.spotlightId);
+			const direction = getDirection(keyCode);
+			if (direction) {
+				const nextTarget = getTargetByDirectionFromPosition(direction, position, mutableRef.current.spotlightId);
 
-			if (!scrollContainerRef.current.contains(nextTarget)) {
-				const orders = finalizeOrders();
-				finalizeEditing(orders);
+				if (!scrollContainerRef.current.contains(nextTarget)) {
+					const orders = finalizeOrders();
+					finalizeEditing(orders);
+				}
 			}
 		}
 	}, [finalizeEditing, finalizeOrders, scrollContainerRef]);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In all conditions below met, focus is moving out of an editable scroller but editing mode is not completed and a selected item is kept selected;
- The editable scroller is editing mode
- An item is selected
- Pointer mode
- No item or buttons are focused by pointer
- A user press 'enter' ('OK')

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed an editable scroller logic to complete editing when the condition is detected.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-3732

### Comments
