### PR TITLE
WRQ-3732: Fixed Scroller with editable prop to complete editing when focus is leaving by 5-way key on pointer mode

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -623,6 +623,7 @@ const EditableWrapper = (props) => {
 
 				// Check if focus leaves scroll container.
 				if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {
+					setPointerMode(false);
 					Spotlight.move(getDirection(keyCode));
 
 					const orders = finalizeOrders();

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -6,6 +6,7 @@ import Spotlight, {getDirection} from '@enact/spotlight';
 import {getContainersForNode} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import Accelerator from '@enact/spotlight/Accelerator';
+import {useSpotlightContainer} from '@enact/spotlight/SpotlightContainerDecorator';
 import {getLastPointerPosition, setPointerMode} from '@enact/spotlight/src/pointer';
 import {Announce} from '@enact/ui/AnnounceDecorator';
 import Touchable from '@enact/ui/Touchable';
@@ -133,7 +134,10 @@ const EditableWrapper = (props) => {
 		lastInputDirection: null,
 
 		// initialSelected
-		initialSelected: editable?.initialSelected
+		initialSelected: editable?.initialSelected,
+
+		// onLeaveContainer handler
+		handleLeaveContainer: null
 	});
 	const announceRef = useRef({});
 
@@ -797,6 +801,25 @@ const EditableWrapper = (props) => {
 		});
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+	useEffect(() => {
+		mutableRef.current.handleLeaveContainer = () => {
+			const orders = finalizeOrders();
+			finalizeEditing(orders);
+		};
+	}, [finalizeOrders, finalizeEditing]);
+
+	const {attributes: spotlightContainerAttributes, ...spotlightContainerProps} = useSpotlightContainer({
+		id: mutableRef.current.spotlightId + '_editable',
+		restrict: 'none',
+		containerConfig: {
+			onLeaveContainer: () => {
+				if (mutableRef.current.handleLeaveContainer) {
+					mutableRef.current.handleLeaveContainer();
+				}
+			}
+		}
+	});
+
 	return (
 		<TouchableDiv
 			holdConfig={holdConfig}
@@ -808,6 +831,8 @@ const EditableWrapper = (props) => {
 			onMouseDown={handleMouseDown}
 			onMouseMove={handleMouseMove}
 			ref={wrapperRef}
+			{...spotlightContainerProps}
+			{...spotlightContainerAttributes}
 		>
 			{children}
 			<Announce key="editable-wrapper-announce" ref={announceRef} />


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In all conditions below met, focus is moving out of an editable scroller but editing mode is not completed and a selected item is kept selected;
- The editable scroller is editing mode
- An item is selected
- Pointer mode
- No item or buttons are focused by pointer
- A user press 'enter' ('OK')

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed an editable scroller logic to complete editing when the condition is detected.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-3732

### Comments
