### PR TITLE
WRQ-2636: Fixed Scroller with editable to rearrange items properly when moving pointer very fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Scroller` with `editable` prop to complete editing when 'down' key is pressed during editing
 - `sandstone/TabLayout` to move focus from tab contents to tab menu via back key
 
+### Fixed
+
+- `sandstone/Scroller` with `editable` prop to rearrange items properly when moving pointer very fast
+
 ## [2.7.12] - 2023-10-23
 
 ### Fixed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -113,8 +113,8 @@ const EditableWrapper = (props) => {
 		// Position for restoring focus after removing item
 		nextSpotlightRect: null,
 
-		// Last move direction
-		lastMoveDirection: null,
+		// Move direction from the starting position to the current position
+		moveDirection: null,
 
 		// Last mouse position
 		lastMouseClientX: null,
@@ -151,7 +151,7 @@ const EditableWrapper = (props) => {
 		mutableRef.current.focusedItem = null;
 		mutableRef.current.selectedItem = null;
 		mutableRef.current.selectedItemLabel = '';
-		mutableRef.current.lastMoveDirection = null;
+		mutableRef.current.moveDirection = null;
 		mutableRef.current.prevToIndex = null;
 		mutableRef.current.initialSelected = null;
 		wrapperRef.current.style.setProperty('--selected-item-offset', '0px');
@@ -161,7 +161,7 @@ const EditableWrapper = (props) => {
 
 	// Finalize the order
 	const finalizeOrders = useCallback(() => {
-		const {fromIndex, lastMoveDirection, prevToIndex, rearrangedItems, selectedItem} = mutableRef.current;
+		const {fromIndex, moveDirection, prevToIndex, rearrangedItems, selectedItem} = mutableRef.current;
 		let orders = Array.from({length: dataSize}, (_, i) => i + 1);
 
 		if (rearrangedItems.length > 0) {
@@ -171,17 +171,17 @@ const EditableWrapper = (props) => {
 			rearrangedItems.forEach((item) => {
 				const order = Number(item.style.order);
 				selectedOrder = order;
-				item.style.order = order - lastMoveDirection;
+				item.style.order = order - moveDirection;
 				item.classList.remove(componentCss.rearrangedTransform, componentCss.rearranged);
 
-				if (lastMoveDirection > 0) {
+				if (moveDirection > 0) {
 					changedOrder.push(order);
 				} else {
 					changedOrder.unshift(order);
 				}
 			});
 
-			if (lastMoveDirection > 0) {
+			if (moveDirection > 0) {
 				changedOrder.push(Number(selectedItem.style.order));
 			} else {
 				changedOrder.unshift(Number(selectedItem.style.order));
@@ -319,17 +319,17 @@ const EditableWrapper = (props) => {
 	}, []);
 
 	// Add rearranged items
-	const addRearrangedItems = useCallback(({moveDirection, toIndex}) => {
-		// Set the moveDirection to css variable
+	const addRearrangedItems = useCallback(({currentMoveDirection, toIndex}) => {
+		// Set the currentMoveDirection to css variable
 		const {rtl} = scrollContainerHandle.current;
-		wrapperRef.current.style.setProperty('--move-direction', moveDirection * (rtl ? -1 : 1));
+		wrapperRef.current.style.setProperty('--move-direction', currentMoveDirection * (rtl ? -1 : 1));
 
 		const {fromIndex, rearrangedItems, selectedItem} = mutableRef.current;
-		const getNextElement = (item) => moveDirection > 0 ? item.nextElementSibling : item.previousElementSibling;
+		const getNextElement = (item) => currentMoveDirection > 0 ? item.nextElementSibling : item.previousElementSibling;
 		let sibling = getNextElement(selectedItem);
 		let lastRearrangedItem;
-		let start = moveDirection > 0 ? toIndex : fromIndex;
-		let end = moveDirection > 0 ? fromIndex : toIndex;
+		let start = currentMoveDirection > 0 ? toIndex : fromIndex;
+		let end = currentMoveDirection > 0 ? fromIndex : toIndex;
 
 		while (start > end && sibling) {
 			sibling?.classList.add(componentCss.rearranged, componentCss.rearrangedTransform);
@@ -347,7 +347,7 @@ const EditableWrapper = (props) => {
 			readOutCurrentPosition(lastRearrangedItem.ariaLabel || lastRearrangedItem.textContent);
 		}
 
-		mutableRef.current.lastMoveDirection = moveDirection;
+		mutableRef.current.moveDirection = currentMoveDirection;
 
 	}, [readOutCurrentPosition, scrollContainerHandle]);
 
@@ -374,7 +374,7 @@ const EditableWrapper = (props) => {
 		if (selectedItem) {
 			// Bail out when index is out of scope
 			if (toIndex < mutableRef.current.hideIndex && toIndex >= 0) {
-				const {fromIndex, itemWidth, lastMoveDirection, prevToIndex, rearrangedItems} = mutableRef.current;
+				const {fromIndex, itemWidth, moveDirection, prevToIndex, rearrangedItems} = mutableRef.current;
 
 				// Set the selected item's offset to css variable
 				const offset = (toIndex - fromIndex) * itemWidth;
@@ -383,19 +383,19 @@ const EditableWrapper = (props) => {
 				// If the current toIndex is new,
 				if (toIndex !== prevToIndex) {
 					// Determine the direction of move from the latest from index
-					const moveDirection = Math.sign(toIndex - prevToIndex);
+					const currentMoveDirection = Math.sign(toIndex - prevToIndex);
 					// If the direction is changed and there are rearranged items, we remove them first.
-					if (lastMoveDirection && moveDirection !== lastMoveDirection && rearrangedItems.length > 0) {
-						const numToRemove = moveDirection > 0 ? toIndex - prevToIndex : prevToIndex - toIndex;
+					if (moveDirection && currentMoveDirection !== moveDirection && rearrangedItems.length > 0) {
+						const numToRemove = currentMoveDirection > 0 ? toIndex - prevToIndex : prevToIndex - toIndex;
 						const needToAddItems = numToRemove > rearrangedItems.length;
 						removeRearrangedItems(numToRemove);
 
 						// When there's jump, meaning, numToRemove is bigger than 0, we need to add an item
 						if (needToAddItems) {
-							addRearrangedItems({moveDirection, toIndex});
+							addRearrangedItems({currentMoveDirection, toIndex});
 						}
 					} else {
-						addRearrangedItems({moveDirection, toIndex});
+						addRearrangedItems({currentMoveDirection, toIndex});
 					}
 
 					mutableRef.current.prevToIndex = toIndex;
@@ -521,8 +521,8 @@ const EditableWrapper = (props) => {
 		// Coordinate calculation in RTL locales is not supported in chrome below 85
 		const scrollContentOffset = scrollContentRef.current.scrollLeft * (rtl ? -1 : 1) - centeredOffset;
 		const clientXFromContent = (rtl ? bodyWidth - x : x) + scrollContentOffset;
-		const moveDirection = (itemWidth * (prevToIndex + 0.5) < clientXFromContent) ? 1 : -1; // 1: To next index , -1: To prev index
-		const moveTolerance = itemWidth * tolerance * moveDirection;
+		const direction = (itemWidth * (prevToIndex + 0.5) < clientXFromContent) ? 1 : -1; // 1: To next index , -1: To prev index
+		const moveTolerance = itemWidth * tolerance * direction;
 
 		return Math.floor((clientXFromContent - moveTolerance) / itemWidth);
 	}, [scrollContainerHandle, scrollContentRef]);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -387,10 +387,11 @@ const EditableWrapper = (props) => {
 					// If the direction is changed and there are rearranged items, we remove them first.
 					if (lastMoveDirection && moveDirection !== lastMoveDirection && rearrangedItems.length > 0) {
 						const numToRemove = moveDirection > 0 ? toIndex - prevToIndex : prevToIndex - toIndex;
+						const needToAddItems = numToRemove > rearrangedItems.length;
 						removeRearrangedItems(numToRemove);
 
 						// When there's jump, meaning, numToRemove is bigger than 0, we need to add an item
-						if (numToRemove > rearrangedItems.length) {
+						if (needToAddItems) {
 							addRearrangedItems({moveDirection, toIndex});
 						}
 					} else {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a user moves a pointer left and right very fast while editing the order of items, sometimes the order of items is broken so that some items look duplicated.

The condition to make a bug happen;
- Select one item to move.
- Move the selected item very fast to one direction so that mousemove event occurs one across multiple items
- Move the selected item very fast to the opposite direction so that mousemove event occurs one across multiple items


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The cause of this unexpected behavior is a bug of our logic to check how many items should be rearranged while the selected item is moving back and forth. So, I fixed the condition to check desired counts without the bug.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ-2636

### Comments
