### PR TITLE
WRQ-4089: Update audio guidance of Slider component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Changed
 
 - `sandstone/Scroller` with `editable` prop to complete editing when 'down' key is pressed during editing
+- `sandstone/Slider` to read out more details
 - `sandstone/TabLayout` to move focus from tab contents to tab menu via back key
 
 ## [2.7.12] - 2023-10-23

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -2,6 +2,7 @@ import {forward, forwardCustom} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import platform from '@enact/core/platform';
 import Pause from '@enact/spotlight/Pause';
+import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
 import {Component, createRef} from 'react';
 
@@ -94,12 +95,12 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		getValueText () {
-			const {'aria-valuetext': ariaValueText, min, orientation, value = min} = this.props;
+			const {'aria-valuetext': ariaValueText, max, min, orientation, value = min} = this.props;
 			const {useHintText} = this.state;
 
 			const valueText = (ariaValueText != null) ? ariaValueText : value;
-			const verticalHint = `${valueText} ${$L('change a value with up down button')}`;
-			const horizontalHint = `${valueText} ${$L('change a value with left right button')}`;
+			const verticalHint = `${new IString($L('From {startValue} to {lastValue}')).format({startValue: min, lastValue: max})} ${valueText} ${$L('change a value with up down button')}`;
+			const horizontalHint = `${new IString($L('From {startValue} to {lastValue}')).format({startValue: min, lastValue: max})} ${valueText} ${$L('change a value with left right button')}`;
 
 			if (useHintText) {
 				return orientation === 'horizontal' ? horizontalHint : verticalHint;

--- a/Slider/tests/Slider-specs.js
+++ b/Slider/tests/Slider-specs.js
@@ -51,7 +51,7 @@ describe('Slider', () => {
 		const slider = screen.getByRole('slider');
 
 		const expectedAttribute = 'aria-valuetext';
-		const expectedValue = '0 change a value with left right button';
+		const expectedValue = 'From 0 to 100 0 change a value with left right button';
 
 		expect(slider).toHaveAttribute(expectedAttribute, expectedValue);
 	});
@@ -61,7 +61,7 @@ describe('Slider', () => {
 		const slider = screen.getByRole('slider');
 
 		const expectedAttribute = 'aria-valuetext';
-		const expectedValue = '0 change a value with up down button';
+		const expectedValue = 'From 0 to 100 0 change a value with up down button';
 
 		expect(slider).toHaveAttribute(expectedAttribute, expectedValue);
 	});

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -72,7 +72,7 @@ const WizardPanelsBase = kind({
 		 * Hint string read when focusing the close button.
 		 *
 		 * @type {String}
-		 * @default 'Exit quick guide'
+		 * @default 'Exit Quick Guide'
 		 * @private
 		 */
 		closeButtonAriaLabel: PropTypes.string,
@@ -379,7 +379,7 @@ const WizardPanelsBase = kind({
 		closeButton: ({closeButtonAriaLabel, onClose, totalPanels}) => {
 			return (
 				totalPanels ? <Button
-					aria-label={closeButtonAriaLabel == null ? $L('Exit quick guide') : closeButtonAriaLabel}
+					aria-label={closeButtonAriaLabel == null ? $L('Exit Quick Guide') : closeButtonAriaLabel}
 					className={css.close}
 					icon="closex"
 					onClick={onClose}

--- a/WizardPanels/tests/WizardPanels-specs.js
+++ b/WizardPanels/tests/WizardPanels-specs.js
@@ -839,7 +839,7 @@ describe('WizardPanel Specs', () => {
 				const actual = buttons.length;
 
 				expect(actual).toBe(expected);
-				expect(buttons[0]).toHaveAttribute('aria-label', 'Exit quick guide');
+				expect(buttons[0]).toHaveAttribute('aria-label', 'Exit Quick Guide');
 				expect(buttons[1]).toHaveAttribute('aria-label', 'Previous');
 			}
 		);
@@ -861,7 +861,7 @@ describe('WizardPanel Specs', () => {
 				const actual = buttons.length;
 
 				expect(actual).toBe(expected);
-				expect(buttons[0]).toHaveAttribute('aria-label', 'Exit quick guide');
+				expect(buttons[0]).toHaveAttribute('aria-label', 'Exit Quick Guide');
 				expect(buttons[1]).toHaveAttribute('aria-label', 'Next');
 			}
 		);
@@ -1038,7 +1038,7 @@ describe('WizardPanel Specs', () => {
 					</WizardPanels>
 				);
 
-				const closeButton = screen.getByLabelText('Exit quick guide');
+				const closeButton = screen.getByLabelText('Exit Quick Guide');
 				const expected = {type: 'onClose'};
 
 				await user.click(closeButton);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update audio guidance of Slider component
- When focusing on the thumb, read out `From {startValue} to {lastValue} {value} Change a value with up down button` or `From {startValue} to {lastValue} {value} Change a value with left right button`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update aria-valuetext of the Slider component

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The aria-label of WizardPanels is updated to $L('Exit Quick Guide') in this PR because the UX guide is updated.

### Links
[//]: # (Related issues, references)
WRQ-4089

### Comments

