### PR TITLE
WRQ-1307: Update audio guidance of TabLayout component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` with `editable` prop to complete editing when 'down' key is pressed during editing
 - `sandstone/TabLayout` to move focus from tab contents to tab menu via back key
+- `sandstone/TabLayout` to read out more details
 
 ### Fixed
 

--- a/TabLayout/RefocusDecorator.js
+++ b/TabLayout/RefocusDecorator.js
@@ -44,7 +44,7 @@ const RefocusDecorator = Wrapped => {
 
 		useEffect(() => {
 			Spotlight.set(spotlightId, {
-				navigableFilter: collapsed && orientation === 'vertical' ? getNavigableFilter(spotlightId, collapsed) : null
+				navigableFilter: collapsed && orientation !== 'horizontal' ? getNavigableFilter(spotlightId, collapsed) : null
 			});
 		}, [collapsed, orientation, spotlightId]);
 

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -3,12 +3,15 @@ import kind from '@enact/core/kind';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Group from '@enact/ui/Group';
+import IdProvider from '@enact/ui/internal/IdProvider';
 import {Cell, Layout} from '@enact/ui/Layout';
 import Toggleable from '@enact/ui/Toggleable';
+import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import {useMemo} from 'react';
 
+import $L from '../internal/$L';
 import DebounceDecorator from '../internal/DebounceDecorator';
 import Button from '../Button';
 import Skinnable from '../Skinnable';
@@ -150,6 +153,7 @@ const TabGroupBase = kind({
 		tabs: PropTypes.array.isRequired,
 		collapsed: PropTypes.bool,
 		css: PropTypes.object,
+		id: PropTypes.string,
 		onBlur: PropTypes.func,
 		onBlurList: PropTypes.func,
 		onFocus: PropTypes.func,
@@ -176,7 +180,7 @@ const TabGroupBase = kind({
 		tabsSpotlightDisabled: ({spotlightDisabled, tabs}) => spotlightDisabled || tabs.find(tab => tab && !tab.spotlightDisabled) == null
 	},
 
-	render: ({css, collapsed, noIcons, onBlur, onBlurList, onFocus, onFocusTab, onSelect, orientation, selectedIndex, spotlightId, spotlightDisabled, tabs, tabSize, tabsDisabled, tabsSpotlightDisabled, ...rest}) => {
+	render: ({css, collapsed, id, noIcons, onBlur, onBlurList, onFocus, onFocusTab, onSelect, orientation, selectedIndex, spotlightId, spotlightDisabled, tabs, tabSize, tabsDisabled, tabsSpotlightDisabled, ...rest}) => {
 		delete rest.children;
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
@@ -228,23 +232,27 @@ const TabGroupBase = kind({
 						spotlightDisabled={tabsSpotlightDisabled}
 					/>
 				) : (
-					<GroupComponent
-						childComponent={Tab}
-						className={componentCss.tabs}
-						component={groupComponent}
-						indexProp="index"
-						itemProps={itemProps}
-						onSelect={onSelect}
-						orientation={orientation}
-						role="list"
-						select="radio"
-						selected={selectedIndex}
-						selectedProp="selected"
-						spotlightId={spotlightId}
-						spotlightDisabled={spotlightDisabled}
-					>
-						{children}
-					</GroupComponent>
+					<div role="region" aria-labelledby={`${id}_tabgroup`}>
+						<GroupComponent
+							id={`${id}_tabgroup`}
+							childComponent={Tab}
+							aria-label={`${new IString($L('{total} items in total')).format({'total': tabs.length})}`}
+							className={componentCss.tabs}
+							component={groupComponent}
+							indexProp="index"
+							itemProps={itemProps}
+							onSelect={onSelect}
+							orientation={orientation}
+							role="list"
+							select="radio"
+							selected={selectedIndex}
+							selectedProp="selected"
+							spotlightId={spotlightId}
+							spotlightDisabled={spotlightDisabled}
+						>
+							{children}
+						</GroupComponent>
+					</div>
 				)}
 				{isHorizontal ? <hr className={componentCss.horizontalLine} /> : null}
 			</Component>
@@ -253,7 +261,11 @@ const TabGroupBase = kind({
 });
 
 const TabGroupDecorator = compose(
-	DebounceDecorator({cancel: 'onBlur', debounce: 'onFocusTab', delay: 300})
+	DebounceDecorator({cancel: 'onBlur', debounce: 'onFocusTab', delay: 300}),
+	IdProvider({
+		generateProp: null,
+		prefix: 'tg_'
+	})
 );
 
 // Only documenting TabGroup since base is not useful for extension as-is

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -92,7 +92,7 @@ const TabBase = kind({
 			css,
 			focusEffect: 'static',
 			minWidth: false,
-			role: 'listitem'
+			role: 'tab'
 		};
 
 		switch (orientation) {
@@ -243,7 +243,7 @@ const TabGroupBase = kind({
 							itemProps={itemProps}
 							onSelect={onSelect}
 							orientation={orientation}
-							role="list"
+							role="tablist"
 							select="radio"
 							selected={selectedIndex}
 							selectedProp="selected"

--- a/TabLayout/TabGroup.js
+++ b/TabLayout/TabGroup.js
@@ -89,7 +89,7 @@ const TabBase = kind({
 			css,
 			focusEffect: 'static',
 			minWidth: false,
-			role: null
+			role: 'listitem'
 		};
 
 		switch (orientation) {
@@ -236,6 +236,7 @@ const TabGroupBase = kind({
 						itemProps={itemProps}
 						onSelect={onSelect}
 						orientation={orientation}
+						role="list"
 						select="radio"
 						selected={selectedIndex}
 						selectedProp="selected"

--- a/TabLayout/tests/TabGroup-specs.js
+++ b/TabLayout/tests/TabGroup-specs.js
@@ -38,7 +38,7 @@ describe('TabGroup specs', () => {
 		);
 
 		const expected = 3;
-		const actual = screen.getByRole('group').children;
+		const actual = screen.getByRole('tablist').children;
 
 		expect(actual).toHaveLength(expected);
 	});
@@ -46,7 +46,7 @@ describe('TabGroup specs', () => {
 	test('should render group even if it has no tabs', () => {
 		render(<TabGroup tabs={[]} />);
 
-		const tabGroup = screen.getByRole('group');
+		const tabGroup = screen.getByRole('tablist');
 		expect(tabGroup).toBeInTheDocument();
 	});
 
@@ -140,7 +140,7 @@ describe('TabGroup specs', () => {
 			/>
 		);
 
-		await user.click(screen.getByRole('group').children[0]);
+		await user.click(screen.getByRole('tablist').children[0]);
 
 		const expected = {type: 'onTabClick'};
 		const actual = handleTabClick.mock.calls.length && handleTabClick.mock.calls[0][0];

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -5,7 +5,10 @@ import Item from '@enact/sandstone/Item';
 import {Header} from '@enact/sandstone/Panels';
 import Scroller from '@enact/sandstone/Scroller';
 import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
+import Spotlight from '@enact/spotlight';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {scaleToRem} from '@enact/ui/resolution';
+import {useCallback} from 'react';
 
 const tabsWithIcons = [
 	{title: 'Home', icon: 'home'},
@@ -27,11 +30,25 @@ const images = new Array(20).fill().map( (_, i) =>
 	/>
 );
 
+const containerSpotlightId = 'qa-a11y-tablayout-view-container';
+const Container = SpotlightContainerDecorator({}, 'div');
+
 const TabLayoutView = () => {
+	const handleExpand = useCallback(() => {
+		Spotlight.set(containerSpotlightId, {
+			restrict: 'self-first'
+		});
+	}, []);
+	const handleCollapse = useCallback(() => {
+		Spotlight.set(containerSpotlightId, {
+			restrict: 'self-only'
+		});
+	}, []);
+
 	return (
-		<>
+		<Container spotlightId={containerSpotlightId} spotlightRestrict="self-only">
 			<Header title="Sandstone TabLayout" subtitle="Basic TabLayout" />
-			<TabLayout>
+			<TabLayout onCollapse={handleCollapse} onExpand={handleExpand}>
 				<Tab
 					icon={tabsWithIcons[0].icon}
 					title={tabsWithIcons[0].title}
@@ -57,7 +74,7 @@ const TabLayoutView = () => {
 					<Item slotBefore={<Icon>playcircle</Icon>}>Single Item</Item>
 				</Tab>
 			</TabLayout>
-		</>
+		</Container>
 	);
 };
 

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -1,6 +1,6 @@
 import Button from '@enact/sandstone/Button';
 import Icon from '@enact/sandstone/Icon';
-import Image from '@enact/sandstone/Image';
+import ImageItem from '@enact/sandstone/ImageItem';
 import Item from '@enact/sandstone/Item';
 import {Header} from '@enact/sandstone/Panels';
 import Scroller from '@enact/sandstone/Scroller';
@@ -22,12 +22,15 @@ const svgGenerator = (width, height, bgColor, textColor, customText) => (
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 const images = new Array(20).fill().map( (_, i) =>
-	<Image
+	<ImageItem
+		inline
 		key={`image${i}`}
 		caption="Image"
 		src={svgGenerator(360, 240, 'd8d8d8', '6e6e6e', '360 X 240')}
-		style={{marginBottom: scaleToRem(96)}}
-	/>
+		style={{width: scaleToRem(180), height: scaleToRem(120)}}
+	>
+		{`ImageItem ${i + 1}`}
+	</ImageItem>
 );
 
 const containerSpotlightId = 'qa-a11y-tablayout-view-container';

--- a/samples/qa-a11y/src/views/TabLayout.js
+++ b/samples/qa-a11y/src/views/TabLayout.js
@@ -2,11 +2,10 @@ import Button from '@enact/sandstone/Button';
 import Icon from '@enact/sandstone/Icon';
 import ImageItem from '@enact/sandstone/ImageItem';
 import Item from '@enact/sandstone/Item';
-import {Header} from '@enact/sandstone/Panels';
+import {Panel, Header} from '@enact/sandstone/Panels';
 import Scroller from '@enact/sandstone/Scroller';
 import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
 import Spotlight from '@enact/spotlight';
-import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {scaleToRem} from '@enact/ui/resolution';
 import {useCallback} from 'react';
 
@@ -34,7 +33,6 @@ const images = new Array(20).fill().map( (_, i) =>
 );
 
 const containerSpotlightId = 'qa-a11y-tablayout-view-container';
-const Container = SpotlightContainerDecorator({}, 'div');
 
 const TabLayoutView = () => {
 	const handleExpand = useCallback(() => {
@@ -49,7 +47,7 @@ const TabLayoutView = () => {
 	}, []);
 
 	return (
-		<Container spotlightId={containerSpotlightId} spotlightRestrict="self-only">
+		<Panel spotlightId={containerSpotlightId} spotlightRestrict="self-only">
 			<Header title="Sandstone TabLayout" subtitle="Basic TabLayout" />
 			<TabLayout onCollapse={handleCollapse} onExpand={handleExpand}>
 				<Tab
@@ -77,7 +75,7 @@ const TabLayoutView = () => {
 					<Item slotBefore={<Icon>playcircle</Icon>}>Single Item</Item>
 				</Tab>
 			</TabLayout>
-		</Container>
+		</Panel>
 	);
 };
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update audio guidance of TabLayout component

- When the focus is entered into the tabList, read out `{total} items in total {tabname} tab {selectedValue} of {total}`
- When the focus is moved to the other tab, read out `tab {selectedValue} of {total}` after reading the tab name

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update role prop in TabGroup component
Update TabGroup to use aria-labelledby to read only when the focus is entered into the list

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-1307

### Comments
