### PR TITLE
WRQ-171: Fix `VirtualList` to have proper scroll position when item with affordance is larger than scroll area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` with `editable` to complete editing when focus left by 5-way key in pointer mode
+- `sandstone/VirtualList` to have proper scroll position when item with affordance is larger than scroll area
 
 ## [2.7.12] - 2023-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/VirtualList` to have proper scroll position when item with affordance is larger than scroll area
 
-### Fixed
-
 ## [2.7.13] - 2023-12-08
 
 ### Changed

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -205,6 +205,7 @@ const useSpottable = (props, instances) => {
 					index: nextIndex,
 					stickTo,
 					offset: (allowAffordance && stickTo === 'end') ? ri.scale(affordanceSize) : 0,
+					disallowNegativeOffset: true,
 					animate: !(isWrapped && wrap === 'noAnimation'),
 					focus: snapToCenter
 				});
@@ -262,7 +263,7 @@ const useSpottable = (props, instances) => {
 		const {pageScroll, direction} = props;
 		const {state: {numOfItems}, primary} = scrollContentHandle.current;
 		const allowAffordance = !(noAffordance || direction === 'horizontal');
-		const offsetToClientEnd = Math.max(0, primary.clientSize - primary.gridSize - (!allowAffordance ? 0 : ri.scale(affordanceSize))); // TBD
+		const offsetToClientEnd = Math.max(0, primary.clientSize - primary.gridSize - (!allowAffordance ? 0 : ri.scale(affordanceSize)));
 		const focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 		const offsetToCenter = snapToCenter ? (primary.clientSize / 2 - primary.gridSize / 2) : 0;
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -262,7 +262,7 @@ const useSpottable = (props, instances) => {
 		const {pageScroll, direction} = props;
 		const {state: {numOfItems}, primary} = scrollContentHandle.current;
 		const allowAffordance = !(noAffordance || direction === 'horizontal');
-		const offsetToClientEnd = primary.clientSize - primary.gridSize - (!allowAffordance ? 0 : ri.scale(affordanceSize));
+		const offsetToClientEnd = Math.max(0, primary.clientSize - primary.gridSize - (!allowAffordance ? 0 : ri.scale(affordanceSize))); // TBD
 		const focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 		const offsetToCenter = snapToCenter ? (primary.clientSize / 2 - primary.gridSize / 2) : 0;
 

--- a/tests/ui/specs/VirtualList/VirtualGridList/VirtualGridListPage.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/VirtualGridListPage.js
@@ -5,13 +5,14 @@ const listItemSelector = '.enact_ui_VirtualList_VirtualList_listItem';
 const scrollableSelector = '.enact_ui_useScroll_useScroll_scroll';
 const scrollbarSelector = '.useScroll_ScrollbarTrack_scrollbarTrack';
 const scrollThumbSelector = '.useScroll_ScrollbarTrack_thumb';
+const scrolledElementNativeSelector = '.enact_ui_VirtualList_VirtualList_virtualList';
+const scrolledElementTranslateSelector = '.enact_ui_VirtualList_VirtualList_content';
 
 class VirtualGridListPage extends Page {
 
 	constructor () {
 		super();
 		this.title = 'VirtualGridList Test';
-
 	}
 
 	async open (layout = '', urlExtra) {
@@ -89,6 +90,24 @@ class VirtualGridListPage extends Page {
 		}, scrollbarSelector, index);
 
 	}
+
+
+	async getScrollPositionNative () {
+		const el = await element(scrolledElementNativeSelector, browser);
+		return el.getProperty('scrollTop');
+	}
+
+	async getScrollPositionTranslate () {
+		const el = await element(scrolledElementTranslateSelector, browser);
+		const style = await el.getAttribute('style');
+		const matched = style.match(/transform: translate3d\(0px, (-*[0-9]+)px, 0px\)/);
+		if (matched) {
+			return Number.parseInt(matched[1]);
+		} else {
+			return 0;
+		}
+	}
+
 
 	async item (id) {
 		return await element(`#${typeof id === 'number' ? `item${id}` : id}`, browser);

--- a/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-QWTC-13709-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/With5-way/VirtualGridList-QWTC-13709-specs.js
@@ -1,0 +1,102 @@
+const {expectFocusedItem} = require('../../VirtualList-utils');
+const Page = require('../VirtualGridListPage');
+
+describe('Scroll via 5-way when clientSize is smaller than itemSize plus affordance (QWTC-13709)', function () {
+	beforeEach(async function () {
+		await Page.open();
+	});
+
+	it('Should not scroll to abnormal position by 5-way navigation)', async function () {
+		const scrollAnimationTimeout = 500;
+
+		// Set minHeight to 1300 to make itemSize + affordance bigger than viewport
+		await Page.inputMinHeight.moveTo();
+		await Page.spotlightSelect();
+		await Page.backSpace();
+		await Page.backSpace();
+		await Page.backSpace();
+		await Page.numPad(1);
+		await Page.numPad(3);
+		await Page.numPad(0);
+		await Page.numPad(0);
+		await Page.spotlightDown();
+
+		// check the first item
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(0);
+		expect(await Page.getScrollPositionNative()).to.be.equal(0);
+
+		// move right to check if unexpected scrolling occurs
+		await Page.spotlightRight();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(1);
+		expect(await Page.getScrollPositionNative()).to.be.equal(0);
+
+		// move down to check if the scroll position is updated correctly
+		await Page.spotlightDown();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(6);
+		expect(await Page.getScrollPositionNative()).to.be.equal(740);
+
+		// move left to check if unexpected scrolling occurs
+		await Page.spotlightLeft();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(5);
+		expect(await Page.getScrollPositionNative()).to.be.equal(740);
+
+		// move up to check if the scroll position is updated correctly
+		await Page.spotlightUp();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(0);
+		expect(await Page.getScrollPositionNative()).to.be.equal(0);
+	});
+
+	it('Should not scroll to abnormal position by 5-way navigation with translate mode)', async function () {
+		const scrollAnimationTimeout = 1000;
+
+		// Set translate mode
+		await Page.buttonModeChange.moveTo();
+		await Page.spotlightSelect();
+
+		// Set minHeight to 1300 to make itemSize + affordance bigger than viewport
+		await Page.inputMinHeight.moveTo();
+		await Page.spotlightSelect();
+		await Page.backSpace();
+		await Page.backSpace();
+		await Page.backSpace();
+		await Page.numPad(1);
+		await Page.numPad(3);
+		await Page.numPad(0);
+		await Page.numPad(0);
+		await Page.spotlightDown();
+
+		// check the first item
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(0);
+		expect(await Page.getScrollPositionTranslate()).to.be.equal(0);
+
+		// move right to check if unexpected scrolling occurs
+		await Page.spotlightRight();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(1);
+		expect(await Page.getScrollPositionTranslate()).to.be.equal(0);
+
+		// move down to check if the scroll position is updated correctly
+		await Page.spotlightDown();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(6);
+		expect(await Page.getScrollPositionTranslate()).to.be.equal(-740);
+
+		// move left to check if unexpected scrolling occurs
+		await Page.spotlightLeft();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(5);
+		expect(await Page.getScrollPositionTranslate()).to.be.equal(-740);
+
+		// move up to check if the scroll position is updated correctly
+		await Page.spotlightUp();
+		await Page.delay(scrollAnimationTimeout);
+		await expectFocusedItem(0);
+		expect(await Page.getScrollPositionTranslate()).to.be.equal(0);
+	});
+});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In a vertical virtual grid list, scroll position for a focused item could be incorrect by 5-way navigation when the scrolling area (client height) is larger than the item height but is smaller than the item height with affordance.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The case was a sort of gray area in a viewpoint of position calculation. Normally layout is based on the item size, but the scroll position is counting also affordance. This condition makes a negative offset on calculation so that an item's top part is cut off.
The intention of the internal calculation allows only 0 or positive offset, so fixed this issue by limiting any negative offset.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-171

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)