### PR TITLE
WRQ-202: Implement editing items in touch mode

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -132,6 +132,7 @@ const EditableWrapper = (props) => {
 
 		lastInputDirection: null,
 
+		isDraggingItem: false,
 		isDragging: false,
 
 		// initialSelected
@@ -685,10 +686,12 @@ const EditableWrapper = (props) => {
 	}, [finalizeEditing, finalizeOrders, scrollContainerRef]);
 
 	const handleTouchMove = useCallback((ev) => {
-		// prevent scrolling by dragging
-		ev.preventDefault();
+		if (mutableRef.current.selectedItem) {
+			// prevent scrolling by dragging
+			ev.preventDefault();
+		}
 
-		if (mutableRef.current.isDragging) {
+		if (mutableRef.current.isDraggingItem) {
 			const {clientX} = ev.targetTouches[0];
 			mutableRef.current.lastMouseClientX = clientX;
 
@@ -711,15 +714,17 @@ const EditableWrapper = (props) => {
 			return;
 		}
 
-		// prevent mouse event call
-		ev.preventDefault();
-
 		if (mutableRef.current.selectedItem) {
+			// prevent mouse event call
+			ev.preventDefault();
+
 			// Finalize orders and forward `onComplete` event
 			const orders = finalizeOrders();
 			finalizeEditing(orders);
-			mutableRef.current.isDragging = false;
-		} else {
+		} else if (!mutableRef.current.isDragging) {
+			// prevent mouse event call
+			ev.preventDefault();
+
 			const targetItemNode = findItemNode(ev.target);
 			if (selectItemBy === 'press') {
 				if (targetItemNode && targetItemNode.dataset.index) {
@@ -728,6 +733,8 @@ const EditableWrapper = (props) => {
 				}
 			}
 		}
+		mutableRef.current.isDraggingItem = false;
+		mutableRef.current.isDragging = false;
 	}, [finalizeEditing, finalizeOrders, findItemNode, selectItemBy, startEditing]);
 
 	const handleDragStart = useCallback((ev) => {
@@ -735,8 +742,9 @@ const EditableWrapper = (props) => {
 		// Index of dragged item
 		const dragTagetIndex = getNextIndexFromPosition(ev.x, 0);
 
+		mutableRef.current.isDragging = true;
 		if (selectedItem && Number(selectedItem.style.order) - 1 === dragTagetIndex) {
-			mutableRef.current.isDragging = true;
+			mutableRef.current.isDraggingItem = true;
 		}
 	}, [getNextIndexFromPosition]);
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -691,7 +691,7 @@ const EditableWrapper = (props) => {
 			ev.preventDefault();
 		}
 
-		if (mutableRef.current.isDraggingItem) {
+		if (mutableRef.current.isDraggingItem && !ev.target.className.includes('Button')) {
 			const {clientX} = ev.targetTouches[0];
 			mutableRef.current.lastMouseClientX = clientX;
 
@@ -710,11 +710,15 @@ const EditableWrapper = (props) => {
 	}, [getNextIndexFromPosition, moveItems, scrollContainerHandle]);
 
 	const handleTouchEnd = useCallback((ev) => {
-		if (ev.target.className.includes('Button')) {
+		const {selectedItem} = mutableRef.current;
+		const {clientX} = ev.changedTouches[0];
+		const targetItemIndex = getNextIndexFromPosition(clientX, 0);
+
+		if (ev.target.className.includes('Button') && Number(selectedItem?.style.order) - 1 === targetItemIndex) {
 			return;
 		}
 
-		if (mutableRef.current.selectedItem) {
+		if (selectedItem) {
 			// Cancel mouse event to deselect a selected item when it is tapped
 			ev.preventDefault();
 
@@ -735,15 +739,15 @@ const EditableWrapper = (props) => {
 		}
 		mutableRef.current.isDraggingItem = false;
 		mutableRef.current.isDragging = false;
-	}, [finalizeEditing, finalizeOrders, findItemNode, selectItemBy, startEditing]);
+	}, [getNextIndexFromPosition, finalizeEditing, finalizeOrders, findItemNode, selectItemBy, startEditing]);
 
 	const handleDragStart = useCallback((ev) => {
 		const {selectedItem} = mutableRef.current;
 		// Index of dragged item
-		const dragTagetIndex = getNextIndexFromPosition(ev.x, 0);
+		const dragTagetItemIndex = getNextIndexFromPosition(ev.x, 0);
 
 		mutableRef.current.isDragging = true;
-		if (selectedItem && Number(selectedItem.style.order) - 1 === dragTagetIndex) {
+		if (selectedItem && Number(selectedItem.style.order) - 1 === dragTagetItemIndex) {
 			mutableRef.current.isDraggingItem = true;
 		}
 	}, [getNextIndexFromPosition]);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -687,7 +687,7 @@ const EditableWrapper = (props) => {
 
 	const handleTouchMove = useCallback((ev) => {
 		if (mutableRef.current.selectedItem) {
-			// prevent scrolling by dragging
+			// Prevent scrolling by dragging when item is selected
 			ev.preventDefault();
 		}
 
@@ -715,14 +715,14 @@ const EditableWrapper = (props) => {
 		}
 
 		if (mutableRef.current.selectedItem) {
-			// prevent mouse event call
+			// Cancel mouse event to deselect a selected item when it is tapped
 			ev.preventDefault();
 
 			// Finalize orders and forward `onComplete` event
 			const orders = finalizeOrders();
 			finalizeEditing(orders);
 		} else if (!mutableRef.current.isDragging) {
-			// prevent mouse event call
+			// Cancel mouse event to select a item when it is tapped
 			ev.preventDefault();
 
 			const targetItemNode = findItemNode(ev.target);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Implement move/hide/remove items in the editable scroller via touch 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add touchmove, touchend, dragstart event handler to handle items via touch
Selected items can be moved by dragging the mouse

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I think hoverToScroll feature in touch mode needs to be updated
When buttons above the item are touched, it does not highlighted

### Links
[//]: # (Related issues, references)
WRQ-202

### Comments
