### PR TITLE
WRQ-7338: Fix unknown prop warning in TabLayout

### DIFF
--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -390,6 +390,7 @@ const TabLayoutBase = kind({
 
 	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleClick, handleEnter, handleFlick, handleFocus, handleTabsTransitionEnd, index, onCollapse, onSelect, orientation, tabOrientation, tabSize, tabs, type, ...rest}) => {
 		delete rest.anchorTo;
+		delete rest.disableBackKeyNavigation;
 		delete rest.onExpand;
 		delete rest.onTabAnimationEnd;
 		delete rest.rtl;

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -356,6 +356,20 @@ describe('TabLayout specs', () => {
 		expect(actual).toMatchObject(expected);
 	});
 
+	test('should not call \'onExpand\' when \'disableBackKeyNavigation\' prop is true and pressing \'backKey\' on a tab content', () => {
+		const spy = jest.fn();
+		render(
+			<TabLayout collapsed disableBackKeyNavigation onExpand={spy} rtl={false}>
+				<Tab icon="home" title="Home">
+					<Button>Button</Button>
+				</Tab>
+			</TabLayout>
+		);
+
+		fireEvent.keyUp(screen.getByRole('button'), {keyCode: 27});
+		expect(spy).not.toHaveBeenCalled();
+	});
+
 	test('should call \'onTabAnimationEnd\' even if \'Spotlight\' is paused and pointer mode \'false\'', () => {
 		Spotlight.getPointerMode = jest.fn(() => false);
 		Spotlight.isPaused = jest.fn(() => false);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix unknown prop warning in TabLayout

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Delete `disableBackKeyNavigation` prop in render 
Add unit test case which has `disableBackKeyNavigation` prop

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-7338

### Comments
