### PR TITLE
WRQ-6835: Fix editable scroller qa-sampler to not show label of items…

### DIFF
--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -269,6 +269,7 @@ export const EditableIcon = (args) => {
 											{...item.iconItemProps}
 											aria-label={`Icon ${item.index}`}
 											className={css.editableIconItem}
+											css={css}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
 											onClick={action('onClickItem')}
 											onFocus={onFocusItem}

--- a/samples/sampler/stories/qa/IconItem.module.less
+++ b/samples/sampler/stories/qa/IconItem.module.less
@@ -64,6 +64,11 @@
 			&:focus {
 				transform: none;
 			}
+			&.labelOnFocus:focus {
+				.labelContainer {
+					display: none;
+				}
+			}
 		}
 
 		.iconItem {

--- a/samples/sampler/stories/qa/IconItem.module.less
+++ b/samples/sampler/stories/qa/IconItem.module.less
@@ -71,6 +71,12 @@
 			}
 		}
 
+		&.selected .editableIconItem.labelOnFocus {
+			.label, .labelContainer {
+				display: block;
+			}
+		}
+
 		.iconItem {
 			width: 312px;
 			height: 240px;

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -411,6 +411,7 @@ export const WithEditableScroller = (args) => {
 											spotlightId={`item_${index}`}
 											aria-label={`Icon ${item.index}`}
 											className={css.editableIconItem}
+											css={css}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
 											onClick={action('onClickItem')}
 											onFocus={onFocusItem}

--- a/samples/sampler/stories/qa/Panels.module.less
+++ b/samples/sampler/stories/qa/Panels.module.less
@@ -56,6 +56,11 @@
 			&:focus {
 				transform: none;
 			}
+			&.labelOnFocus:focus {
+				.labelContainer {
+					display: none;
+				}
+			}
 		}
 
 		.iconItem {

--- a/samples/sampler/stories/qa/Panels.module.less
+++ b/samples/sampler/stories/qa/Panels.module.less
@@ -63,6 +63,12 @@
 			}
 		}
 
+		&.selected .editableIconItem.labelOnFocus {
+			.label, .labelContainer {
+				display: block;
+			}
+		}
+
 		.iconItem {
 			width: 312px;
 			height: 240px;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix IconItem, Panels qa-sampler to not show labels of items of the scroller while moving a selected item 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix sampler module.less files to add `display:none` property to labelContainer when the item is focused

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-6835

### Comments
