### PR TITLE
WRQ-7951: Modify big buck bunny video url.

### DIFF
--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -36,7 +36,7 @@ const renderItem = ({index, ...rest}) => {
 const VideoPlayerView = () => (
 	<div style={{width: ri.scaleToRem(1280), height: ri.scaleToRem(800)}}>
 		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
-			<source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4" />
+			<source src="http://download.blender.org/peach/trailer/trailer_1080p.ogg" type="video/ogg" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
 			<MediaControls actionGuideButtonAriaLabel="More">
 				<bottomComponents>

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -35,8 +35,8 @@ const renderItem = ({index, ...rest}) => {
 
 const VideoPlayerView = () => (
 	<div style={{width: ri.scaleToRem(1280), height: ri.scaleToRem(800)}}>
-		<VideoPlayer poster="http://media.w3.org/2010/05/bunny/poster.png" title="Downton Abbey">
-			<source src="http://download.blender.org/peach/trailer/trailer_1080p.ogg" type="video/ogg" />
+		<VideoPlayer poster="http://media.xiph.org/cosmoslaundromat/Cosmos_Laundromat_1-2k-png/14029.png" title="Cosmos Laundromat">
+			<source src="http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
 			<MediaControls actionGuideButtonAriaLabel="More">
 				<bottomComponents>

--- a/samples/qa-a11y/src/views/VideoPlayer.js
+++ b/samples/qa-a11y/src/views/VideoPlayer.js
@@ -35,7 +35,7 @@ const renderItem = ({index, ...rest}) => {
 
 const VideoPlayerView = () => (
 	<div style={{width: ri.scaleToRem(1280), height: ri.scaleToRem(800)}}>
-		<VideoPlayer poster="http://media.xiph.org/cosmoslaundromat/Cosmos_Laundromat_1-2k-png/14029.png" title="Cosmos Laundromat">
+		<VideoPlayer poster="http://media.xiph.org/cosmoslaundromat/Cosmos_Laundromat_1-2k-png/07580.png" title="Cosmos Laundromat">
 			<source src="http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4" type="video/mp4" />
 			<infoComponents>DTV REC 08:22 THX 16:9</infoComponents>
 			<MediaControls actionGuideButtonAriaLabel="More">

--- a/samples/sampler/stories/default/MediaOverlay.js
+++ b/samples/sampler/stories/default/MediaOverlay.js
@@ -10,7 +10,7 @@ const prop = {
 	textAlign: ['start', 'center', 'end'],
 	videos: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-		'Cosmos_Laundromat': 'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4',
+		'Cosmos Laundromat': 'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4',
 		VideoTest: 'http://media.w3.org/2010/05/video/movie_300.mp4',
 		// Purposefully not a video to demonstrate source error state
 		'Bad Video Source': 'https://github.com/mderrick/react-html5video'

--- a/samples/sampler/stories/default/MediaOverlay.js
+++ b/samples/sampler/stories/default/MediaOverlay.js
@@ -10,7 +10,7 @@ const prop = {
 	textAlign: ['start', 'center', 'end'],
 	videos: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-		'Big Buck Bunny': 'http://download.blender.org/peach/trailer/trailer_1080p.ogg',
+		'Cosmos_Laundromat': 'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4',
 		VideoTest: 'http://media.w3.org/2010/05/video/movie_300.mp4',
 		// Purposefully not a video to demonstrate source error state
 		'Bad Video Source': 'https://github.com/mderrick/react-html5video'

--- a/samples/sampler/stories/default/MediaOverlay.js
+++ b/samples/sampler/stories/default/MediaOverlay.js
@@ -10,7 +10,7 @@ const prop = {
 	textAlign: ['start', 'center', 'end'],
 	videos: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-		'Big Buck Bunny': 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
+		'Big Buck Bunny': 'http://download.blender.org/peach/trailer/trailer_1080p.ogg',
 		VideoTest: 'http://media.w3.org/2010/05/video/movie_300.mp4',
 		// Purposefully not a video to demonstrate source error state
 		'Bad Video Source': 'https://github.com/mderrick/react-html5video'

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -41,7 +41,7 @@ const prop = {
 	videoTitles: ['Sintel', 'Big Buck Bunny', 'VideoTest', 'Bad Video Source'],
 	videos: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-		'Big Buck Bunny': 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
+		'Big Buck Bunny': 'http://download.blender.org/peach/trailer/trailer_1080p.ogg',
 		VideoTest: 'http://media.w3.org/2010/05/video/movie_300.mp4',
 		// Purposefully not a video to demonstrate source error state
 		'Bad Video Source': 'https://github.com/mderrick/react-html5video'

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -38,17 +38,17 @@ updateDataSize(size);
 // Set up some defaults for info and controls
 const prop = {
 	moreButtonColor: ['', 'red', 'green', 'yellow', 'blue'],
-	videoTitles: ['Sintel', 'Big Buck Bunny', 'VideoTest', 'Bad Video Source'],
+	videoTitles: ['Sintel', 'Cosmos Laundromat', 'VideoTest', 'Bad Video Source'],
 	videos: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-		'Big Buck Bunny': 'http://download.blender.org/peach/trailer/trailer_1080p.ogg',
+		'Cosmos Laundromat': 'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4',
 		VideoTest: 'http://media.w3.org/2010/05/video/movie_300.mp4',
 		// Purposefully not a video to demonstrate source error state
 		'Bad Video Source': 'https://github.com/mderrick/react-html5video'
 	},
 	posters: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/poster.png',
-		'Big Buck Bunny': 'http://media.w3.org/2010/05/bunny/poster.png',
+		'Cosmos Laundromat': 'http://media.xiph.org/cosmoslaundromat/Cosmos_Laundromat_1-2k-png/14029.png',
 		VideoTest: 'http://media.w3.org/2010/05/video/poster.png',
 		'Bad Video Source': 'http://media.w3.org/2010/05/video/poster.png'
 	},

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -48,7 +48,7 @@ const prop = {
 	},
 	posters: {
 		Sintel: 'http://media.w3.org/2010/05/sintel/poster.png',
-		'Cosmos Laundromat': 'http://media.xiph.org/cosmoslaundromat/Cosmos_Laundromat_1-2k-png/14029.png',
+		'Cosmos Laundromat': 'http://media.xiph.org/cosmoslaundromat/Cosmos_Laundromat_1-2k-png/07580.png',
 		VideoTest: 'http://media.w3.org/2010/05/video/poster.png',
 		'Bad Video Source': 'http://media.w3.org/2010/05/video/poster.png'
 	},

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -21,9 +21,9 @@ class VideoSourceSwap extends Component {
 		super(props);
 
 		this.state = {
-			videoTitles: ['Big Buck Bunny', 'Sintel', 'VideoTest'],
+			videoTitles: ['Cosmos Laundromat', 'Sintel', 'VideoTest'],
 			playlist: [
-				'http://download.blender.org/peach/trailer/trailer_1080p.ogg',
+				'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4',
 				'http://media.w3.org/2010/05/sintel/trailer.mp4',
 				'http://media.w3.org/2010/05/video/movie_300.mp4'
 			],
@@ -151,10 +151,10 @@ class VideoPlayerWithfastForwardMode extends Component {
 						slowRewind: ['-1/2', '-1']
 					}}
 					ref={this.setVideoPlayer}
-					title={'Big Buck Bunny'}
+					title={'Cosmos Laundromat'}
 				>
 					<Video>
-						<source src={'http://download.blender.org/peach/trailer/trailer_1080p.ogg'} />
+						<source src={'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4'} />
 					</Video>
 					<MediaControls>
 						<Button
@@ -192,10 +192,10 @@ class VideoPlayerWithLayer extends Component {
 				<VideoPlayer
 					feedbackHideDelay={0}
 					muted
-					title={'Big Buck Bunny'}
+					title={'Cosmos Laundromat'}
 				>
 					<Video>
-						<source src={'http://download.blender.org/peach/trailer/trailer_1080p.ogg'} />
+						<source src={'http://media.xiph.org/cosmoslaundromat/Pilot_Trailer_Cosmos_Laundromat.mp4'} />
 					</Video>
 				</VideoPlayer>
 				<div style={{left: 0, top: 0, bottom: 0, width: 500, backgroundColor: "green", position: "absolute"}}>{"screen saver"}</div>

--- a/samples/sampler/stories/qa/VideoPlayer.js
+++ b/samples/sampler/stories/qa/VideoPlayer.js
@@ -23,7 +23,7 @@ class VideoSourceSwap extends Component {
 		this.state = {
 			videoTitles: ['Big Buck Bunny', 'Sintel', 'VideoTest'],
 			playlist: [
-				'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
+				'http://download.blender.org/peach/trailer/trailer_1080p.ogg',
 				'http://media.w3.org/2010/05/sintel/trailer.mp4',
 				'http://media.w3.org/2010/05/video/movie_300.mp4'
 			],
@@ -154,7 +154,7 @@ class VideoPlayerWithfastForwardMode extends Component {
 					title={'Big Buck Bunny'}
 				>
 					<Video>
-						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
+						<source src={'http://download.blender.org/peach/trailer/trailer_1080p.ogg'} />
 					</Video>
 					<MediaControls>
 						<Button
@@ -195,7 +195,7 @@ class VideoPlayerWithLayer extends Component {
 					title={'Big Buck Bunny'}
 				>
 					<Video>
-						<source src={'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4'} />
+						<source src={'http://download.blender.org/peach/trailer/trailer_1080p.ogg'} />
 					</Video>
 				</VideoPlayer>
 				<div style={{left: 0, top: 0, bottom: 0, width: 500, backgroundColor: "green", position: "absolute"}}>{"screen saver"}</div>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Dongsu Won (dongsu.won@lgepartner.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Video player does not loads 'big buck bunny' video. We need to be able to play url of video.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Modify big buck bunny video url in samples.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-7951

### Comments
'Big Buck Bunny' is changed to 'Cosmos Laundromat' as we can't find any available links for 'Big Buck Bunny' video.