### PR TITLE
WRQ-8636: Fix editable scroller to remain focus in selected item when editing complete with 4-way key in pointer mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/Scroller` with `editable` prop to handle focus properly when complete editing by 4-way key in pointer mode
 - `sandstone/VirtualList` to have proper scroll position when item with affordance is larger than scroll area
 
 ## [2.7.13] - 2023-12-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` with `editable` prop to handle focus properly when complete editing by 4-way key in pointer mode
+- `sandstone/Scroller` with `editable` prop to remain focused on the selected item when completing edit by down or enter key in pointer mode
 - `sandstone/VirtualList` to have proper scroll position when item with affordance is larger than scroll area
 
 ## [2.7.13] - 2023-12-08

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -658,8 +658,8 @@ const EditableWrapper = (props) => {
 				ev.stopPropagation(); // To prevent onCancel by CancelDecorator
 			}
 		} else {
-			mutableRef.current.lastKeyEventTargetElement = ev.target;
-			if (ev.target.getAttribute('role') === 'button') {
+			mutableRef.current.lastKeyEventTargetElement = target;
+			if (target.getAttribute('role') === 'button') {
 				return;
 			}
 		}

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -562,16 +562,17 @@ const EditableWrapper = (props) => {
 		}
 	}, [finalizeEditing, finalizeOrders, scrollContainerHandle, scrollContentRef]);
 
-	const completeEditingByKeyDown = useCallback((target) => {
+	const completeEditingByKeyDown = useCallback(() => {
 		const {selectedItem, selectedItemLabel} = mutableRef.current;
+		const focusTarget = selectedItem.children[1];
 		const orders = finalizeOrders();
 
 		selectedItem.children[1].ariaLabel = '';
 		finalizeEditing(orders);
 		if (selectItemBy === 'press') {
 			Spotlight.setPointerMode(false);
-			Spotlight.focus(target);
-			focusItem(target);
+			Spotlight.focus(focusTarget);
+			focusItem(focusTarget);
 		}
 		setTimeout(() => {
 			announceRef.current.announce(
@@ -592,7 +593,7 @@ const EditableWrapper = (props) => {
 		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
 			if (!repeat) {
 				if (selectedItem) {
-					completeEditingByKeyDown(selectedItem.children[1]);
+					completeEditingByKeyDown();
 					mutableRef.current.needToPreventEvent = true;
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
@@ -604,7 +605,7 @@ const EditableWrapper = (props) => {
 				}, holdDuration - 300);
 			}
 		} else if (is('down', keyCode) && target.getAttribute('role') !== 'button' && !repeat && selectedItem) {
-			completeEditingByKeyDown(selectedItem.children[1]);
+			completeEditingByKeyDown();
 			mutableRef.current.needToPreventEvent = true;
 		} else if (is('left', keyCode) || is('right', keyCode)) {
 			if (selectedItem) {
@@ -653,7 +654,7 @@ const EditableWrapper = (props) => {
 
 		if (is('cancel', keyCode)) {
 			if (selectedItem) {
-				completeEditingByKeyDown(target);
+				completeEditingByKeyDown();
 				ev.stopPropagation(); // To prevent onCancel by CancelDecorator
 			}
 		} else {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -566,11 +566,13 @@ const EditableWrapper = (props) => {
 		const {selectedItem, selectedItemLabel} = mutableRef.current;
 		const orders = finalizeOrders();
 
+		selectedItem.children[1].ariaLabel = '';
 		finalizeEditing(orders);
 		if (selectItemBy === 'press') {
+			Spotlight.setPointerMode(false);
+			Spotlight.focus(target);
 			focusItem(target);
 		}
-		selectedItem.children[1].ariaLabel = '';
 		setTimeout(() => {
 			announceRef.current.announce(
 				selectedItemLabel + $L('Movement completed'),
@@ -590,7 +592,7 @@ const EditableWrapper = (props) => {
 		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
 			if (!repeat) {
 				if (selectedItem) {
-					completeEditingByKeyDown(target);
+					completeEditingByKeyDown(selectedItem.children[1]);
 					mutableRef.current.needToPreventEvent = true;
 				} else if (selectItemBy === 'press') {
 					startEditing(targetItemNode);
@@ -602,7 +604,7 @@ const EditableWrapper = (props) => {
 				}, holdDuration - 300);
 			}
 		} else if (is('down', keyCode) && target.getAttribute('role') !== 'button' && !repeat && selectedItem) {
-			completeEditingByKeyDown(target);
+			completeEditingByKeyDown(selectedItem.children[1]);
 			mutableRef.current.needToPreventEvent = true;
 		} else if (is('left', keyCode) || is('right', keyCode)) {
 			if (selectedItem) {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In the editable scroller, when an item is selected and the pointer hovers next item and then completes editing mode with 4-way key, the focus needs to remain with the selected item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Manually focus on selected item

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-8636

### Comments
