### PR TITLE
WRQ-7224: Fixed `Scroller` to stop propagation of 'keyup' event when back key moves focus inside a scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller` with `editable` prop to remain focused on the selected item when completing edit by down or enter key in pointer mode
+- `sandstone/Scroller` not to forward `onBack` handler of `sandstone/Panels` when focus moves from scroll thumb to BodyText via back key
 - `sandstone/VirtualList` to have proper scroll position when item with affordance is larger than scroll area
 
 ## [2.7.13] - 2023-12-08

--- a/Scroller/tests/Scroller-specs.js
+++ b/Scroller/tests/Scroller-specs.js
@@ -108,17 +108,17 @@ describe('Scroller', () => {
 
 				const scroller = screen.getByTestId(id);
 				const scrollBody = scroller.children.item(0);
-				const virticalScrollbar = screen.getByLabelText("scroll up or down with up down button press ok button to read text");
+				const verticalScrollbar = screen.getByLabelText("scroll up or down with up down button press ok button to read text");
 
 				const expected = "spottable";
 
 				// dispatching key event to increase code coverage
-				focus(virticalScrollbar);
-				pressDownKey(virticalScrollbar);
-				pressEnterKey(virticalScrollbar);
+				focus(verticalScrollbar);
+				pressDownKey(verticalScrollbar);
+				pressEnterKey(verticalScrollbar);
 
 				expect(scrollBody).toHaveClass(expected);
-				expect(virticalScrollbar).toHaveClass(expected);
+				expect(verticalScrollbar).toHaveClass(expected);
 			}
 		);
 
@@ -138,12 +138,12 @@ describe('Scroller', () => {
 
 				const scroller = screen.getByTestId(id);
 				const scrollBody = scroller.children.item(0);
-				const virticalScrollbar = screen.getByLabelText("scroll up or down with up down button");
+				const verticalScrollbar = screen.getByLabelText("scroll up or down with up down button");
 
 				const expected = "spottable";
 
 				expect(scrollBody).not.toHaveClass(expected);
-				expect(virticalScrollbar).toHaveClass(expected);
+				expect(verticalScrollbar).toHaveClass(expected);
 			}
 		);
 	});

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -22,6 +22,7 @@ const
 
 const getFocusableBodyProps = (scrollContainerRef, contentId, isScrollbarVisible) => {
 	let spotlightId = scrollContainerRef.current && scrollContainerRef.current.dataset.spotlightId;
+	let consumeKeyUpTarget = null;
 
 	const setNavigableFilter = ({filterTarget}) => {
 		spotlightId = scrollContainerRef.current && scrollContainerRef.current.dataset.spotlightId;
@@ -62,8 +63,8 @@ const getFocusableBodyProps = (scrollContainerRef, contentId, isScrollbarVisible
 		};
 	};
 
-	const consumeEventWithFocus = (ev) => {
-		const {target} = ev;
+	const consumeEventKeyDownWithFocus = (ev) => {
+		const {keyCode, target} = ev;
 		let nextTarget;
 
 		if (isBody(target)) {
@@ -82,6 +83,7 @@ const getFocusableBodyProps = (scrollContainerRef, contentId, isScrollbarVisible
 			// Enter or Cancel key on scroll thumb.
 			// Scroll body get focus.
 			nextTarget = target.closest(`.${css.focusableBody}`);
+			consumeKeyUpTarget = isCancel(keyCode) && nextTarget || null;
 		}
 
 		if (nextTarget) {
@@ -89,6 +91,14 @@ const getFocusableBodyProps = (scrollContainerRef, contentId, isScrollbarVisible
 			ev.preventDefault();
 			ev.nativeEvent.stopImmediatePropagation();
 		}
+	};
+
+	const consumeEventKeyUp = (ev) => {
+		const {keyCode, target} = ev;
+		if (isCancel(keyCode) && target === consumeKeyUpTarget) {
+			ev.nativeEvent.stopImmediatePropagation();
+		}
+		consumeKeyUpTarget = null;
 	};
 
 	return {
@@ -106,7 +116,10 @@ const getFocusableBodyProps = (scrollContainerRef, contentId, isScrollbarVisible
 		onKeyDown: handle(
 			forward('onKeyDown'),
 			adaptEvent(getNavigableFilterTarget, setNavigableFilter),
-			consumeEventWithFocus
+			consumeEventKeyDownWithFocus
+		),
+		onKeyUp: handle(
+			consumeEventKeyUp
 		),
 		setNavigableFilter
 	};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a user press back key on a scroll thumb of a scroller with focusableScrollbar that is rendered inside FixedPopupPanels, Scroller moves focus to the scroll body and FixedPopupPanels forwards 'onBack' event to app at the same time. So, the app changes a view to show up another panel. After all, a user feels the scroll body is flashing.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Moving focus to the scroll body is essential in a11y support to read out its contents. Also, there should be a chance to focus the scroll body if there are spottable elements inside the body. To accomplish this goal, 'onBack' event derived from keyup needs to be prevented from dispatching when Scroller catch back key input derived from keydown.
So, fixed `Scroller` to consume a keyup event too when it needs to consume keydown event.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-7224

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
