### PR TITLE
WRQ-8044: Focus on Body Text partially in Scroller with audio guidance ON

### DIFF
--- a/samples/qa-a11y/src/views/Scroller.js
+++ b/samples/qa-a11y/src/views/Scroller.js
@@ -2,17 +2,73 @@
 
 import Scroller from '@enact/sandstone/Scroller';
 import ToggleButton from '@enact/sandstone/SwitchItem';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import Spottable from '@enact/spotlight/Spottable';
 import Layout, {Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
-import {useState} from 'react';
+import LS2Request from '@enact/webos/LS2Request';
+import {useEffect, useState} from 'react';
+
+import css from './Scroller.module.less';
 
 const ScrollerView = () => {
+	const [audioGuidance, setAudioGuidance] = useState(false);
 	const [native, setNative] = useState(true);
 	const [customAriaLabel, setCustomAriaLabel] = useState(false);
 	const scrollMode = native ? 'native' : 'translate';
 
+	useEffect( () => {
+		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
+			new LS2Request().send({
+				service: 'luna://com.webos.settingsservice/',
+				method: 'getSystemSettings',
+				parameters: {
+					category: 'option',
+					keys: ['audioGuidance']
+				},
+				onSuccess: (res) => {
+					setAudioGuidance(res.settings.audioGuidance === 'on');
+				}
+			});
+		}
+	}, []);
+
 	const handleChangeJSNativeButton = () => setNative(!native);
 	const handleChangeAriaLabelButton = () => setCustomAriaLabel(!customAriaLabel);
+
+	const bodyText = [
+		'Foo', 'Bar', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar',
+		'Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.',
+		'Foo', 'Bar', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar',
+		'Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.',
+		'Foo', 'Bar', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar',
+		'Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.',
+		'Foo', 'Bar', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar', 'Boom boom pow',
+		'Foo', 'Bar',
+		'Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.'
+	];
+
+	const Container = SpotlightContainerDecorator('div');
+	const SpottableDiv = Spottable('div');
 
 	return (
 		<Layout orientation="vertical">
@@ -32,31 +88,13 @@ const ScrollerView = () => {
 			</Cell>
 			<Cell
 				component={Scroller}
-				focusableScrollbar="byEnter"
+				focusableScrollbar={audioGuidance ? true : "byEnter"}
 				scrollMode={scrollMode}
 				verticalScrollThumbAriaLabel={customAriaLabel ? 'This is vertical scroll thumb' : null}
 				horizontalScrollThumbAriaLabel={customAriaLabel ? 'This is horizontal scroll thumb' : null}
 			>
 				<div style={{width: ri.scaleToRem(6000)}}>
-					Foo<br />Bar<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />
-					Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. <br />Foo<br />Bar<br />Bar<br />
-					Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />
-					Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. <br />Foo<br />Bar<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />
-					Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />
-					Foo<br />Bar<br />Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. <br />Foo<br />Bar<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />
-					Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow<br />Foo<br />Bar<br />Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
-					Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow. Boom boom pow.
+					{audioGuidance ? <Container>{bodyText.map((x) => <SpottableDiv className={css.focusableBodyText}>{x}<br /></SpottableDiv>)}</Container> : bodyText.map((x) => <>{x}<br /></>)}
 				</div>
 			</Cell>
 		</Layout>

--- a/samples/qa-a11y/src/views/Scroller.module.less
+++ b/samples/qa-a11y/src/views/Scroller.module.less
@@ -1,0 +1,9 @@
+@import "~@enact/sandstone/styles/colors.less";
+@import "~@enact/sandstone/styles/mixins.less";
+
+.focusableBodyText {
+    .focus({
+        background-color: @sand-scroll-focusablebody-focus-bg-color;
+        opacity: 1;   
+    });
+}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We will add a new feature that partially focuses on body text in Scroller.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When audio guidance is off, whole body text gets focus as before.
When audio guidance is on, body text is splited into several parts and each part gets focus as a spottable element.
TTS will read the text of focused part only.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-8004

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)