### PR TITLE
WRQ-6220: Fixed `VirtualList` to show the focused item properly when switching from pointer mode to 5-way mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/VirtualList` to show the focused item properly when switching from pointer mode to 5-way mode
+
 ## [2.8.0] - 2024-02.07
 
 ### Fixed

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -195,7 +195,7 @@ const useEventKey = (props, instances, context) => {
 								directions.left && column === 0 ||
 								directions.right && (!focusableScrollbar || !isScrollbarVisible) && (column === dimensionToExtent - 1 || index === dataSize - 1 && row === 0);
 
-							/* istanbul ignore if */
+							/* istanbul ignore next */
 							if (isLeaving) {
 								if (repeat) { // if focus is about to leave items by holding down an arrowy key
 									ev.preventDefault();
@@ -224,6 +224,7 @@ const useEventKey = (props, instances, context) => {
 			} else if (isPageUp(keyCode) || isPageDown(keyCode)) {
 				handlePageUpDownKeyDown();
 			} else if (isPointerHide(keyCode)) {
+				/* istanbul ignore next */
 				mutableRef.current.pointerHideTimeStamp = ev.timeStamp;
 			}
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
If there is no navigable target when switching from pointer mode to 5-way mode on a partially visible focused item, the focus remains on the focused item, but the item still does not show its whole content as there is no scrolling.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to re-focus only when no focus moving by switching from pointer mode to 5-way mode, so that a scrolling occurs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-6220

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
