### PR TITLE
WRQ-188: Fix the coordinateCoefficient logic on ltr

### DIFF
--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -288,7 +288,7 @@ const useSpottable = (props, instances) => {
 		const
 			{rtl} = props,
 			// For Chrome 85+ or Safari that use negative coordinate system for RTL
-			coordinateCoefficient = rtl && (platform.chrome < 85) ? 1 : -1,
+			coordinateCoefficient = rtl && (platform.chrome >= 85) ? -1 : 1,
 			{clientWidth} = scrollContentHandle.current.scrollBounds,
 			rtlDirection = rtl ? -1 : 1,
 			{left: containerLeft} = scrollContentNode.getBoundingClientRect(),

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -288,7 +288,7 @@ const useSpottable = (props, instances) => {
 		const
 			{rtl} = props,
 			// For Chrome 85+ or Safari that use negative coordinate system for RTL
-			coordinateCoefficient = rtl && (platform.chrome >= 85) ? -1 : 1,
+			coordinateCoefficient = rtl && !(platform.chrome < 85) ? -1 : 1,
 			{clientWidth} = scrollContentHandle.current.scrollBounds,
 			rtlDirection = rtl ? -1 : 1,
 			{left: containerLeft} = scrollContentNode.getBoundingClientRect(),


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed reversed the logic for determining the coordinateCoefficient on ltr. Horizontal scroller doesn't scroll with 5-way key in LTR locale.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-188

### Comments
This PR is a hoxfix for #1559

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>