### PR TITLE
WRQ-11247: Added fontScale prop for large text mode scale values

### DIFF
--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -55,6 +55,11 @@ const defaultConfig = /** @lends sandstone/ThemeDecorator.ThemeDecorator.default
 	disableFullscreen: false,
 
 	/**
+	 * Font scale for large text mode.
+	 */
+	fontScale: 1,
+
+	/**
 	 * Enables a floating layer for popup components.
 	 *
 	 * If not applied, app will be responsible for applying the decorator.
@@ -169,7 +174,7 @@ const defaultConfig = /** @lends sandstone/ThemeDecorator.ThemeDecorator.default
  * @public
  */
 const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
-	const {accessible, ri, i18n, spotlight, float, noAutoFocus, overlay,
+	const {accessible, ri, i18n, spotlight, float, fontScale, noAutoFocus, overlay,
 		skin, disableFullscreen, rootId} = config;
 
 	// Apply classes depending on screen type (overlay / fullscreen)
@@ -182,7 +187,7 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 	let App = Wrapped;
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
-	if (ri) App = ResolutionDecorator(ri, App);
+	if (ri) App = ResolutionDecorator({...ri, fontScale}, App);
 	if (i18n) {
 		// Apply the @enact/i18n decorator around the font decorator so the latter will update the
 		// font stylesheet when the locale changes

--- a/samples/sampler/.storybook/preview.js
+++ b/samples/sampler/.storybook/preview.js
@@ -98,7 +98,7 @@ export const parameters = {
 export const globalTypes = {
 	'locale': getObjectType('locale', 'en-US', locales),
 	'large text': getBooleanType('large text'),
-	'font scale': getObjectType('font scale', '1', fontScales),
+	'font scale': getObjectType('font scale', 1, fontScales),
 	'high contrast': getBooleanType('high contrast'),
 	'skin': getObjectType('skin', 'neutral', skins),
 	'background': getObjectType('background', 'default', backgrounds),

--- a/samples/sampler/.storybook/preview.js
+++ b/samples/sampler/.storybook/preview.js
@@ -48,6 +48,15 @@ const skins = {
 	'Light': 'light'
 };
 
+const fontScales = {
+	'1': 1,
+	'1.2': 1.2,
+	'1.4': 1.4,
+	'1.6': 1.6,
+	'1.8': 1.8,
+	'2': 2
+};
+
 configureActions();
 
 if (process.env.STORYBOOK_APPLY_GA_COOKIEBANNER) {
@@ -89,13 +98,14 @@ export const parameters = {
 export const globalTypes = {
 	'locale': getObjectType('locale', 'en-US', locales),
 	'large text': getBooleanType('large text'),
+	'font scale': getObjectType('font scale', '1', fontScales),
 	'high contrast': getBooleanType('high contrast'),
 	'skin': getObjectType('skin', 'neutral', skins),
 	'background': getObjectType('background', 'default', backgrounds),
 	'debug aria': getBooleanType('debug aria'),
 	'debug layout': getBooleanType('debug layout'),
 	'debug spotlight': getBooleanType('debug spotlight'),
-	'debug sprites': getBooleanType('debug sprites')
+	'debug sprites': getBooleanType('debug sprites'),
 };
 
 export const decorators = [ThemeEnvironment];

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -71,6 +71,7 @@ const StorybookDecorator = (story, config = {}) => {
 			title={componentName === config.name ? `${config.kind}`.replace(/\//g, ' ').trim() : `${componentName} ${config.name}`}
 			description={hasInfoText ? config.parameters.info.text : null}
 			locale={globals.locale}
+			fontScale={JSON.parse(globals['font scale'])}
 			textSize={JSON.parse(globals['large text']) ? 'large' : 'normal'}
 			highContrast={JSON.parse(globals['high contrast'])}
 			style={{


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a requirement for large text mode for a11y.
I have modified the app (including sampler) to review the screen when large text is applied.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added the fontScale prop to ThemeDecorator so that i can adjust the scale in the app.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-11247

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
