### PR TITLE
WRQ-4796: Add comment to Dropdown qa-a11y sample

### DIFF
--- a/samples/qa-a11y/src/views/Dropdown.js
+++ b/samples/qa-a11y/src/views/Dropdown.js
@@ -67,7 +67,7 @@ const DropdownView = () => (
 			</Dropdown>
 			<br />
 			<Dropdown
-				alt="Aria-lablelled with Placeholder and title"
+				alt="Aria-lablelled with Placeholder and title (Should not read title and Placeholder)"
 				aria-label="This is a Label."
 				placeholder="Placeholder"
 				title="Title"
@@ -76,7 +76,7 @@ const DropdownView = () => (
 			</Dropdown>
 			<br />
 			<Dropdown
-				alt="Aria-lablelled and Disabled with Placeholder and title"
+				alt="Aria-lablelled and Disabled with Placeholder and title (Should not read title and Placeholder)"
 				aria-label="This is a Label."
 				disabled
 				placeholder="Placeholder"
@@ -106,6 +106,7 @@ const DropdownView = () => (
 
 		<Section className={appCss.marginTop} title="Aria-labelled Dropdown based on selected option's aria-label">
 			<A11yDropdown
+				alt="Aria-labelled with Placeholder, Title and Aria-labelled Options (Should not read title and Placeholder)"
 				aria-label="This is a Label."
 				placeholder="Placeholder"
 				title="Title"


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In qa-a11y Dropdown sample, there are samples that the aria-label and title are both set. We add a guide on how to read out these samples. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add comment to the qa-a11y dropdown sample that when aria-label and title are both given, only aria-label of dropdown will be read out

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-4796

### Comments
