### PR TITLE
WRQ-6498: Remove LS2Request call from theme library

### DIFF
--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -8,14 +8,13 @@
 import {setDefaultTargetById} from '@enact/core/dispatcher';
 import {addAll} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
-import platform from '@enact/core/platform';
 import I18nDecorator from '@enact/i18n/I18nDecorator';
 import {Component} from 'react';
 import classNames from 'classnames';
 import {ResolutionDecorator} from '@enact/ui/resolution';
 import {FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
 import SpotlightRootDecorator, {activateInputType, getInputType as getLastInputType, setInputType} from '@enact/spotlight/SpotlightRootDecorator';
-import LS2Request from '@enact/webos/LS2Request';
+import {requestLastInputType} from '@enact/webos/lastInputType';
 import PropTypes from 'prop-types';
 
 import Skinnable from '../Skinnable';
@@ -257,19 +256,18 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		componentDidMount () {
-			if (spotlight && platform.type === 'webos') {
+			if (spotlight) {
 				activateInputType(true);
-				requestInputType = new LS2Request().send({
-					service: 'luna://com.webos.surfacemanager',
-					method: 'getLastInputType',
-					subscribe: true,
+				requestInputType = requestLastInputType({
 					onSuccess: function (res) {
-						setInputType(res.lastInputType);
+						res.lastInputType === 'key' || res.lastInputType === 'mouse' || res.lastInputType === 'touch' ?
+							setInputType(res.lastInputType) :
+							activateInputType(false)
 					},
 					onFailure: function () {
 						activateInputType(false);
 					}
-				});
+				})
 			}
 		}
 

--- a/ThemeDecorator/tests/ThemeDecorator-specs.js
+++ b/ThemeDecorator/tests/ThemeDecorator-specs.js
@@ -1,4 +1,5 @@
 import Spotlight from '@enact/spotlight';
+import {requestLastInputType} from '@enact/webos/lastInputType';
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 
@@ -59,6 +60,16 @@ describe('ThemeDecorator', () => {
 		const appRoot = screen.getByTestId('app');
 
 		expect(appRoot).not.toHaveClass('bg');
+	});
+
+	test('should not call \'requestLastInputType\' when running in a non-TV platform', () => {
+		const config = {spotlight: true};
+		const App = ThemeDecorator(config, AppRoot);
+		render(<App />);
+
+		const result = requestLastInputType({onSuccess: jest.fn(), onFailure: jest.fn()});
+
+		expect(result).toBeNull(); //Assert null return on non-TV platform
 	});
 
 	describe('AccessibilityDecorator', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Removed LS2Request call from `ThemeDecorator`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Extracted LS2Request call logic from `ThemeDecorator` and added it under `enact/webos/lastInputType`
Now `sandstone/ThemeDecorator` calls the new method instead of calling LS2Request directly


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-6498

### Comments
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com