### PR TITLE
WRQ-9560: Fix scrolling by pageup/down key by preventing default behavior

### DIFF
--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -307,6 +307,9 @@ const pointerTracker = (ev) => {
 
 const pageKeyHandler = (ev) => {
 	const {keyCode} = ev;
+	if (isPageUp(keyCode) || isPageDown(keyCode) || (keyCode === 35) || (keyCode === 36)) {
+		ev.preventDefault();
+	}
 
 	if (Spotlight.getPointerMode() && !Spotlight.getCurrent() && (isPageUp(keyCode) || isPageDown(keyCode))) {
 		const


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scrolling by pageup/down key shows different behavior depending on pointer focus in some cases.
- scroll behaviors vary depending on if you click inside the component after first entry or not
- scroll distance is longer than expected if pointer is out of the component
- scroll does not work if pointer is out of 'Scroller' component (Windows Firefox only)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This issue occurs because of default behavior of scrolling by pageup/down.
But we use handlers `pageKeyHandler`, `scrollByPageOnPoinerMode` and `scrollByPage` when pressed pageup/down key,
and there's code not to scroll if pointer is out of the component in handler function.
So scrolling when pointer is out of component is wrong behavior.
I prevented default behavior when pressed pageup/down key.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-9560

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)