### PR TITLE
WRQ-15803: TransferList enhancements (reset buttons, delete function, same list item move)

### DIFF
--- a/TransferList/ButtonList.js
+++ b/TransferList/ButtonList.js
@@ -17,6 +17,7 @@ const ButtonList = ({
 	firstListMinCapacity,
 	handleRemoveItems,
 	handleRemoveSelected,
+	handleRestoreLists,
 	moveIntoFirstSelected,
 	moveIntoSecondSelected,
 	moveOnSpotlight,
@@ -83,14 +84,23 @@ const ButtonList = ({
 						tooltipPosition="right middle"
 					/>
 					<TooltipButton
+						disabled={disabled || !selectedItems.length}
+						icon="circle"
+						iconOnly
+						onClick={handleRemoveSelected}
+						size="small"
+						tooltipText="deselect"
+						tooltipPosition="right middle"
+					/>
+					<TooltipButton
 						disabled={disabled}
 						icon="refresh"
 						iconOnly
-						onClick={handleRemoveSelected}
+						onClick={handleRestoreLists}
 						onSpotlightDown={orientation === 'horizontal' ? handleSpotlightBounds : null}
 						onSpotlightRight={orientation === 'vertical' ? handleSpotlightBounds : null}
 						size="small"
-						tooltipText="deselect"
+						tooltipText="restore lists"
 						tooltipPosition="right middle"
 					/>
 				</> : ''
@@ -139,6 +149,14 @@ ButtonList.propTypes = {
 	 * @private
 	 */
 	handleRemoveSelected: PropTypes.func,
+
+	/**
+	 * A function that restores elements from both lists.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	handleRestoreLists: PropTypes.func,
 
 	/**
 	 * A function that moves all the selected items into the first list.

--- a/TransferList/ButtonList.js
+++ b/TransferList/ButtonList.js
@@ -89,8 +89,8 @@ const ButtonList = ({
 						iconOnly
 						onClick={handleRemoveSelected}
 						size="small"
-						tooltipText="deselect"
 						tooltipPosition="right middle"
+						tooltipText="deselect"
 					/>
 					<TooltipButton
 						disabled={disabled}
@@ -100,8 +100,8 @@ const ButtonList = ({
 						onSpotlightDown={orientation === 'horizontal' ? handleSpotlightBounds : null}
 						onSpotlightRight={orientation === 'vertical' ? handleSpotlightBounds : null}
 						size="small"
-						tooltipText="restore lists"
 						tooltipPosition="right middle"
+						tooltipText="restore lists"
 					/>
 				</> : ''
 			}

--- a/TransferList/TransferList.js
+++ b/TransferList/TransferList.js
@@ -489,7 +489,7 @@ const TransferListBase = kind({
 			const isListCapacityExceeded = checkListsCapacity('first', firstListCopy, listsCapacity, secondListCopy, selectedItems);
 			if (isListCapacityExceeded && (list !== 'first')) return;
 
-			setSelectedItemsPosition(dragOverElement, startElementIndex, startElementList, firstListCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems);
+			setSelectedItemsPosition(dragOverElement, startElementIndex, startElementList, firstListCopy, noMultipleSelect, list === 'first', selectedItems, setPosition, setSelectedItems);
 			// Check if we are dropping on the same list with touch events
 			if (list === 'first') {
 				// Check if the selected item is already present in the selected items array
@@ -516,7 +516,7 @@ const TransferListBase = kind({
 			const isListCapacityExceeded = checkListsCapacity('second', firstListCopy, listsCapacity, secondListCopy, selectedItems);
 			if (isListCapacityExceeded && (list !== 'second')) return;
 
-			setSelectedItemsPosition(dragOverElement, startElementIndex, startElementList, secondListCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems);
+			setSelectedItemsPosition(dragOverElement, startElementIndex, startElementList, secondListCopy, noMultipleSelect, list === 'second', selectedItems, setPosition, setSelectedItems);
 			// In case of dropping items into the same list with touch events
 			if (list === 'second') {
 				// Check if the selected item is already present in the selected items array
@@ -558,8 +558,13 @@ const TransferListBase = kind({
 				handleScroll();
 
 				if (position === null) return;
+				let scrollTo;
+				if (!position.sameList) {
+					scrollTo = position.list === 'first' ? scrollToRefSecond : scrollToRefFirst;
+				} else {
+					scrollTo = position.list === 'first' ? scrollToRefFirst : scrollToRefSecond;
+				}
 
-				const scrollTo = position.list === 'first' ? scrollToRefSecond : scrollToRefFirst;
 				scrollTo.current({index: position.index});
 
 				setPosition(null);
@@ -704,11 +709,11 @@ const TransferListBase = kind({
 			// Check if we are dropping on the same list
 			if (list === 'second') {
 				// Set new position for the items after the drop action
-				setSelectedItemsPosition(dragOverElement, index, list, secondListCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems);
+				setSelectedItemsPosition(dragOverElement, index, list, secondListCopy, noMultipleSelect, true, selectedItems, setPosition, setSelectedItems);
 				rearrangeLists(secondListCopy, secondListCopy, index, list, dragOverElement.current, setSecondListLocal, setSecondListLocal, secondListOperation);
 			} else {
 				// Set new position for the items after the drop action
-				setSelectedItemsPosition(dragOverElement, index, list, firstListCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems);
+				setSelectedItemsPosition(dragOverElement, index, list, firstListCopy, noMultipleSelect, false, selectedItems, setPosition, setSelectedItems);
 				rearrangeLists(firstListCopy, secondListCopy, index, list, dragOverElement.current, setFirstListLocal, setSecondListLocal, firstListOperation);
 			}
 		}, [dragendEventListenerFunction, firstListLocal, firstListMinCapacity, firstListOperation, noMultipleSelect, rearrangeLists, secondListLocal, secondListOperation, selectedItems, secondListMaxCapacity]);
@@ -736,11 +741,11 @@ const TransferListBase = kind({
 			// Check if we are dropping on the same list
 			if (list === 'first') {
 				// Set new position for the items after the drop action
-				setSelectedItemsPosition(dragOverElement, index, list, firstListCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems);
+				setSelectedItemsPosition(dragOverElement, index, list, firstListCopy, noMultipleSelect, true, selectedItems, setPosition, setSelectedItems);
 				rearrangeLists(firstListCopy, firstListCopy, index, list, dragOverElement.current, setFirstListLocal, setFirstListLocal, firstListOperation);
 			} else {
 				// Set new position for the items after the drop action
-				setSelectedItemsPosition(dragOverElement, index, list, secondListCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems);
+				setSelectedItemsPosition(dragOverElement, index, list, secondListCopy, noMultipleSelect, false, selectedItems, setPosition, setSelectedItems);
 				rearrangeLists(secondListCopy, firstListCopy, index, list, dragOverElement.current, setSecondListLocal, setFirstListLocal, secondListOperation);
 			}
 		}, [dragendEventListenerFunction, firstListLocal, firstListOperation, firstListOrderFixed, firstListMaxCapacity, noMultipleSelect, rearrangeLists, secondListLocal, secondListMinCapacity, secondListOperation, selectedItems]);

--- a/TransferList/utils.js
+++ b/TransferList/utils.js
@@ -81,38 +81,6 @@ export const performSelectAllOperation = (concatList, currentList, listOperation
 	setSelectedItems([]);
 };
 
-// Rearrange items in the same list
-export const rearrangeList = (dragOverElementIndex, isAbove, itemIndex, list, listName, setNewList) => {
-	const draggedItem = list[itemIndex];
-	// Determines the position for the item if it is dropped above the hovered item
-	const elementAbove = dragOverElementIndex < itemIndex ? dragOverElementIndex : dragOverElementIndex - 1;
-	// Determines the position for the item if it is dropped below the hovered item
-	const elementBelow = dragOverElementIndex > itemIndex ? dragOverElementIndex : dragOverElementIndex + 1;
-	// Determines the exact position for the dropped item
-	const elementPosition = isAbove ? elementAbove : elementBelow;
-
-	// Removes item from its list
-	list.splice(itemIndex, 1);
-	// Add the item on the new position
-	list.splice(elementPosition, 0, draggedItem);
-	setNewList(list);
-};
-
-// Check if we are dropping on the same list
-export const checkForSameList = (currentListForDrop, dragOverElement, index, isAboveDropPosition, list, listCopy, selectedItems, setListLocal, setPosition, removeBorder = null) => {
-	if (list === currentListForDrop) {
-		const listPosition = list === 'first' ? 'second' : 'first';
-		setPosition({index: (selectedItems.length + parseInt(dragOverElement.current)) - 2, list: listPosition});
-
-		rearrangeList(dragOverElement.current, isAboveDropPosition.current, index, listCopy, list, setListLocal);
-
-		if (removeBorder) removeBorder();
-		return true;
-	}
-
-	return false;
-};
-
 // If the state is externally controlled, use the provided functions
 export const setItemsState = (setFirstList, setFirstListLocal, setSecondList, setSecondListLocal, setSelectedItems, tempFirst, tempSecond, tempSelected) => {
 	if (setFirstList !== null && setSecondList !== null) {
@@ -126,7 +94,7 @@ export const setItemsState = (setFirstList, setFirstListLocal, setSecondList, se
 };
 
 // Set new position for the items after the drop action
-export const setSelectedItemsPosition = (dragOverElement, index, list, listCopy, noMultipleSelect, selectedItems, setPosition, setSelectedItems) => {
+export const setSelectedItemsPosition = (dragOverElement, index, list, listCopy, noMultipleSelect, sameList, selectedItems, setPosition, setSelectedItems) => {
 	// Check if the selected item is already present in the selected items array
 	const potentialIndex = selectedItems.findIndex((pair) => pair.element === listCopy[index] && pair.list === list);
 
@@ -143,5 +111,5 @@ export const setSelectedItemsPosition = (dragOverElement, index, list, listCopy,
 		setSelectedItems(selectedListCopy);
 	}
 
-	setPosition({index: ((selectedItems.length / 2) + parseInt(dragOverElement.current)) - 2, list: list});
+	setPosition({index: ((selectedItems.length / 2) + parseInt(dragOverElement.current)) - 2, list: list, sameList: sameList});
 };

--- a/samples/sampler/stories/default/TransferList.js
+++ b/samples/sampler/stories/default/TransferList.js
@@ -37,7 +37,7 @@ boolean('disabled', _TransferList, Config, false);
 boolean('firstListOrderFixed', _TransferList, Config, false);
 number('firstListMinCapacity', _TransferList, Config);
 number('firstListMaxCapacity', _TransferList, Config);
-select('firstListOperation', _TransferList, ['copy', 'delete', 'move'], Config, 'copy');
+select('firstListOperation', _TransferList, ['copy', 'move'], Config, 'copy');
 number('itemSize', _TransferList, Config, 201);
 select('listComponent', _TransferList, ['VirtualList', 'VirtualGridList'], Config, 'VirtualList');
 boolean('moveElementOnSpotlightDirections', _TransferList, Config, false);
@@ -45,7 +45,7 @@ boolean('noMultipleSelect', _TransferList, Config, false);
 select('orientation', _TransferList, ['horizontal', 'vertical'], Config, 'horizontal');
 number('secondListMinCapacity', _TransferList, Config);
 number('secondListMaxCapacity', _TransferList, Config);
-select('secondListOperation', _TransferList, ['copy', 'delete', 'move'], Config, 'copy');
+select('secondListOperation', _TransferList, ['copy', 'move'], Config, 'copy');
 boolean('showSelectionOrder', _TransferList, Config, false);
 
 _TransferList.storyName = 'TransferList';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I replaced the reset button with 2 buttons. One deselects the currently selected items and one resets the entire lists.
I changed the delete functionality to only work with the delete button.
I changed the lists to handle multiple items move on the same list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I had to remove the delete list operation because it was unintuitive to use. In order to delete an element using it, you needed to drop it on the other list. It is better to remove items by dragging them over the delete icon button, or by selecting them and pressing that button.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-15803

### Comments
