### PR TITLE
WRQ-18041: Fix TabLayout to move focus to the tab menu when it is in panels 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/TabLayout` to move focus properly by 5-way directional key when it is in Panels
+
 ## [2.9.0-alpha.2] - 2024-04-22
 
 ### Added

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -273,12 +273,13 @@ const TabLayoutBase = kind({
 
 				Spotlight.set(spotlightId, {navigableFilter: null});
 				const nextTarget = getTargetByDirectionFromElement(direction, target);
+				const isNextTargetInTabs = nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget);				
 				Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
 
-				if (!document.querySelector(`.${componentCss.tabs}`).contains(nextTarget) && Spotlight.move(direction)) {
+				if (!isNextTargetInTabs && Spotlight.move(direction)) {
 					ev.stopPropagation();
 				} else if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
-					if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
+					if (isNextTargetInTabs) {
 						forward('onExpand', ev, props);
 					}
 				}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -273,7 +273,7 @@ const TabLayoutBase = kind({
 
 				Spotlight.set(spotlightId, {navigableFilter: null});
 				const nextTarget = getTargetByDirectionFromElement(direction, target);
-				const isNextTargetInTabs = nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget);				
+				const isNextTargetInTabs = nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget);
 				Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
 
 				if (!isNextTargetInTabs && Spotlight.move(direction)) {

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -270,13 +270,14 @@ const TabLayoutBase = kind({
 			if (forwardWithPrevent('onKeyDown', ev, props) && direction && collapsed && orientation === 'vertical' && document.querySelector(`[data-spotlight-id='${spotlightId}']`).contains(target) && target.tagName !== 'INPUT') {
 				Spotlight.setPointerMode(false);
 				ev.preventDefault();
-				if (Spotlight.move(direction)) {
+
+				Spotlight.set(spotlightId, {navigableFilter: null});
+				const nextTarget = getTargetByDirectionFromElement(direction, target);
+				Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
+
+				if (!document.querySelector(`.${componentCss.tabs}`).contains(nextTarget) && Spotlight.move(direction)) {
 					ev.stopPropagation();
 				} else if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
-					Spotlight.set(spotlightId, {navigableFilter: null});
-					const nextTarget = getTargetByDirectionFromElement(direction, target);
-					Spotlight.set(spotlightId, {navigableFilter: getNavigableFilter(spotlightId, collapsed)});
-
 					if (nextTarget && document.querySelector(`.${componentCss.tabs}`).contains(nextTarget)) {
 						forward('onExpand', ev, props);
 					}

--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -278,10 +278,8 @@ const TabLayoutBase = kind({
 
 				if (!isNextTargetInTabs && Spotlight.move(direction)) {
 					ev.stopPropagation();
-				} else if (document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
-					if (isNextTargetInTabs) {
-						forward('onExpand', ev, props);
-					}
+				} else if (isNextTargetInTabs && document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`).contains(target)) {
+					forward('onExpand', ev, props);
 				}
 			} else if (is('enter')(keyCode) && !collapsed && document.querySelector(`[data-spotlight-id='${spotlightId}-tabs-expanded']`).contains(target) && target.tagName !== 'INPUT') {
 				ev.stopPropagation();

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -3,7 +3,7 @@ import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import {InputField} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
-import {Panel, Header} from '@enact/sandstone/Panels';
+import Panels, {Panel, Header} from '@enact/sandstone/Panels';
 import {Scroller} from '@enact/sandstone/Scroller';
 import TabLayout, {TabLayoutBase, Tab} from '@enact/sandstone/TabLayout';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
@@ -474,3 +474,28 @@ export const WithInputField = () => {
 };
 
 WithInputField.storyName = 'With InputField';
+
+export const InPanels = () => {
+	return (
+		<Panels index={1} noCloseButton>
+			<Panel />
+			<Panel>
+				<Header title="Header Title" />
+				<TabLayout>
+					<Tab icon="home" title="Tab 0">
+						<Item>First Item</Item>
+						<Item>Second Item</Item>
+
+					</Tab>
+					<Tab icon="gear" title="Tab 1">
+						<BodyText>
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+						</BodyText>
+					</Tab>
+				</TabLayout>
+			</Panel>
+		</Panels>
+	);
+};
+
+InPanels.storyName = 'in Panels';

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -3,7 +3,7 @@ import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import {InputField} from '@enact/sandstone/Input';
 import Item from '@enact/sandstone/Item';
-import Panels, {Panel, Header} from '@enact/sandstone/Panels';
+import {Panel, Header} from '@enact/sandstone/Panels';
 import {Scroller} from '@enact/sandstone/Scroller';
 import TabLayout, {TabLayoutBase, Tab} from '@enact/sandstone/TabLayout';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
@@ -474,28 +474,3 @@ export const WithInputField = () => {
 };
 
 WithInputField.storyName = 'With InputField';
-
-export const InPanels = () => {
-	return (
-		<Panels index={1} noCloseButton>
-			<Panel />
-			<Panel>
-				<Header title="Header Title" />
-				<TabLayout>
-					<Tab icon="home" title="Tab 0">
-						<Item>First Item</Item>
-						<Item>Second Item</Item>
-
-					</Tab>
-					<Tab icon="gear" title="Tab 1">
-						<BodyText>
-							Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-						</BodyText>
-					</Tab>
-				</TabLayout>
-			</Panel>
-		</Panels>
-	);
-};
-
-InPanels.storyName = 'in Panels';

--- a/tests/ui/apps/TabLayout/WithPanelsHeader/TabLayoutWithPanelsHeader-View.js
+++ b/tests/ui/apps/TabLayout/WithPanelsHeader/TabLayoutWithPanelsHeader-View.js
@@ -1,0 +1,30 @@
+import Item from '../../../../../Item/Item';
+import {Panels, Panel, Header} from '../../../../../Panels';
+import TabLayout from '../../../../../TabLayout/TabLayout';
+import ThemeDecorator from '../../../../../ThemeDecorator/ThemeDecorator';
+
+const App = (props) => {
+	return <div {...props}>
+		<Panels index={1}>
+			<Panel />
+			<Panel>
+				<Header title="title" />
+				<TabLayout
+					id="tabLayout"
+					orientation="vertical"
+				>
+					<TabLayout.Tab title="Tab1" icon="home">
+						<Item id="item1">Item 1</Item>
+						<Item id="item2">Item 2</Item>
+					</TabLayout.Tab>
+					<TabLayout.Tab title="Tab2" icon="gear">
+						<Item>Item</Item>
+						<Item>Item</Item>
+					</TabLayout.Tab>
+				</TabLayout>
+			</Panel>
+		</Panels>
+	</div>;
+};
+
+export default ThemeDecorator(App);

--- a/tests/ui/specs/TabLayout/WithPanelsHeader/TabLayoutWithPanelsHeader-specs.js
+++ b/tests/ui/specs/TabLayout/WithPanelsHeader/TabLayoutWithPanelsHeader-specs.js
@@ -1,0 +1,19 @@
+const Page = require('../TabLayoutPage');
+
+describe('TabLayout', function () {
+	beforeEach(async function ()  {
+		await Page.open('WithPanelsHeader');
+	});
+
+	describe('With Panels Header', function () {
+		it('shoiuld spot tab instead of button in Header', async function () {
+			// Focus item1 in Tab 1 contents.
+			await Page.spotlightRight();
+			expect(await $('#item1').isFocused()).to.be.true();
+			// 5-way Left.
+			await Page.spotlightLeft();
+			// Spotlight is on the Tab 1 button.
+			expect(await (await Page.tabLayout.tabItems())[0].isFocused()).to.be.true();
+		});
+	});
+});

--- a/tests/ui/specs/TabLayout/WithPanelsHeader/TabLayoutWithPanelsHeader-specs.js
+++ b/tests/ui/specs/TabLayout/WithPanelsHeader/TabLayoutWithPanelsHeader-specs.js
@@ -6,7 +6,7 @@ describe('TabLayout', function () {
 	});
 
 	describe('With Panels Header', function () {
-		it('shoiuld spot tab instead of button in Header', async function () {
+		it('should spot tab instead of button in Header', async function () {
 			// Focus item1 in Tab 1 contents.
 			await Page.spotlightRight();
 			expect(await $('#item1').isFocused()).to.be.true();


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The reported issue is that when the `TabLayout` is in `Panels` and move focus from the tab contents via 5-way key, focus moved to the button located in `Header` rather than the tab menu.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
navigableFilter in TabLayout/RefocusDecorator filters tab menu buttons and makes to return the button in Header as the nextSpot item when calling Spotlight.move(direction) in the onKeyDown handler.
In this commit, we check the nextSpot item without setting filter by using `getTargetByDirectionFromElement`. And if the next spot is located in tab menu, make focus to be moved by spotlight`s default onKeyDown handler after the tab menu is expanded. 


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-18041

### Comments
