### PR TITLE
WRQ-17933: Support QHD resolution

### DIFF
--- a/ThemeDecorator/screenTypes.json
+++ b/ThemeDecorator/screenTypes.json
@@ -2,6 +2,7 @@
 	{"name": "hd",      "pxPerRem": 16, "width": 1280, "height": 720,  "aspectRatioName": "hdtv"},
 	{"name": "fhd",     "pxPerRem": 24, "width": 1920, "height": 1080, "aspectRatioName": "hdtv"},
 	{"name": "uw-uxga", "pxPerRem": 24, "width": 2560, "height": 1080, "aspectRatioName": "cinema"},
+	{"name": "qhd",     "pxPerRem": 32, "width": 2560, "height": 1440, "aspectRatioName": "hdtv"},
 	{"name": "wqhd",    "pxPerRem": 32, "width": 3440, "height": 1440, "aspectRatioName": "cinema"},
 	{"name": "uhd",     "pxPerRem": 48, "width": 3840, "height": 2160, "aspectRatioName": "hdtv", "base": true},
 	{"name": "uhd2",    "pxPerRem": 96, "width": 7680, "height": 4320, "aspectRatioName": "hdtv"}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We need to support QHD resolution for TV.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Because TV model which needs for QHD is based on sandstone 2.7.x version, this PR is for release/2.7.x.develop branch.
I copied changed code of https://github.com/enactjs/sandstone/pull/1596

added QHD type in screenTypes.json file.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-17933

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)