### PR TITLE
WRQ-8429: Fixed back button not to work when disabled is set to true on input component

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -363,6 +363,7 @@ const InputPopupBase = kind({
 		children,
 		css,
 		defaultValue,
+		disabled,
 		inputFieldSpotlightId,
 		noBackButton,
 		noSubmitButton,
@@ -395,6 +396,7 @@ const InputPopupBase = kind({
 			});
 		}
 		const id = `inputPopup`;
+		const openPopup = !disabled && open;
 		const ariaLabelledBy = popupAriaLabel ? null : `${id}_title ${id}_subtitle`;
 		const inputProps = extractInputFieldProps(rest);
 		const numberMode = (numberInputField !== 'field') && (type === 'number' || type === 'passwordnumber');
@@ -427,7 +429,7 @@ const InputPopupBase = kind({
 					className={popupClassName}
 					noAlertRole
 					noAnimation
-					open={open}
+					open={openPopup}
 					role="region"
 				>
 					{popupType === 'fullscreen' ? backButton : null}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I have solved an issue where the back button does not work when you change disabled to true after entering the input popup from the input sampler.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I modified the popup to close when disabled is true while the popup is open. This is the same behavior as dropdown.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I thought of three ways to solve the issue.
That is, making the back button work independently of the popup, disabling the back button, and closing the popup.


### Links
[//]: # (Related issues, references)
WRQ-8429

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)