### PR TITLE
WRQ-9559: Fix scrolling by holding pageup/down key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - node
+    - 21
 sudo: false
 before_install:
     - sudo apt-get update

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -262,7 +262,6 @@ const useEventKey = (props, instances, context) => {
 		const {keyCode, repeat} = ev;
 
 		forward('onKeyDown', ev, props);
-		ev.preventDefault();
 
 		spottable.current.animateOnFocus = true;
 
@@ -308,21 +307,25 @@ const pointerTracker = (ev) => {
 const pageKeyHandler = (ev) => {
 	const {keyCode} = ev;
 
-	if (Spotlight.getPointerMode() && !Spotlight.getCurrent() && (isPageUp(keyCode) || isPageDown(keyCode))) {
-		const
-			{x, y} = lastPointer,
-			elem = document.elementFromPoint(x, y);
+	if (isPageUp(keyCode) || isPageDown(keyCode)) {
+		ev.preventDefault();
 
-		if (elem) {
-			for (const [key, value] of scrollers) {
-				if (utilDOM.containsDangerously(value, elem)) {
-					/* To handle page keys in nested scrollable components,
-					 * break the loop only when `scrollByPageOnPointerMode` returns `true`.
-					 * This approach assumes that an inner scrollable component is
-					 * mounted earlier than an outer scrollable component.
-					 */
-					if (key.scrollByPageOnPointerMode(ev)) {
-						break;
+		if (Spotlight.getPointerMode() && !Spotlight.getCurrent()) {
+			const
+				{x, y} = lastPointer,
+				elem = document.elementFromPoint(x, y);
+
+			if (elem) {
+				for (const [key, value] of scrollers) {
+					if (utilDOM.containsDangerously(value, elem)) {
+						/* To handle page keys in nested scrollable components,
+						 * break the loop only when `scrollByPageOnPointerMode` returns `true`.
+						 * This approach assumes that an inner scrollable component is
+						 * mounted earlier than an outer scrollable component.
+						 */
+						if (key.scrollByPageOnPointerMode(ev)) {
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scrolling by holding pageup/down key works / does not work case by case.
- Pointer mode
  - holding pageup/down key works if pointer is out of the component.
  - holding pageup/down key does not work if pointer is in the component.
- Key mode
  - holding pageup/down key does not work in macOS WebKIt (Safari). (It works in other environments)

We need to fix for all cases to show same behavior.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Scrolling by holding pageup/down key occurs because of default behavior of browser.
But default behavior varies from browser to browser, so we can't make scroll works if default behavior is not to scroll.
To match scroll behavior of all cases, I prevented default behavior when pressed pageup/down key.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-9559

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)