### PR TITLE
WRQ-19328: Fix React 18.3 warnings in sandstone

### DIFF
--- a/PageViews/PageViewsRouter.js
+++ b/PageViews/PageViewsRouter.js
@@ -29,7 +29,7 @@ function PageViewsRouter (Wrapped) {
 		children,
 		componentRef,
 		'data-spotlight-id': spotlightId,
-		index,
+		index = 0,
 		onTransition,
 		onWillTransition,
 		rtl,
@@ -123,10 +123,6 @@ function PageViewsRouter (Wrapped) {
 		 * @private
 		 */
 		rtl: PropTypes.bool
-	};
-
-	PageViewsProvider.defaultProps = {
-		index: 0
 	};
 
 	return PageViewsProvider;

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -53,7 +53,45 @@ let scrollerId = 0;
  * @ui
  * @public
  */
-let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
+let Scroller = (props) => {
+	const {
+		'aria-label': ariaLabel,
+		'data-spotlight-container-disabled': spotlightContainerDisabled = false,
+		cbScrollTo = nop,
+		direction = 'both',
+		fadeOut = false,
+		focusableScrollbar = false,
+		horizontalScrollbar = 'auto',
+		hoverToScroll,
+		noScrollByDrag = false,
+		noScrollByWheel = false,
+		onScroll = nop,
+		onScrollStart = nop,
+		onScrollStop = nop,
+		overscrollEffectOn: {arrowKey = false, drag = true, pageKey = false, track = false, wheel = true} = {},
+		scrollMode = 'native',
+		verticalScrollbar = 'auto',
+		...rest
+	} = props;
+
+	const scrollerProps = {
+		spotlightContainerDisabled,
+		cbScrollTo,
+		direction,
+		fadeOut,
+		focusableScrollbar,
+		horizontalScrollbar,
+		noScrollByDrag,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		overscrollEffectOn: {arrowKey, drag, pageKey, track, wheel},
+		scrollMode,
+		verticalScrollbar,
+		...rest
+	};
+
 	const id = `scroller_${++scrollerId}_content`;
 
 	// Hooks
@@ -71,7 +109,7 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 		horizontalScrollbarProps,
 		verticalScrollbarProps,
 		hoverToScrollProps
-	} = useScroll({...rest, scrollToContentContainerOnFocus: true});
+	} = useScroll({...scrollerProps, scrollToContentContainerOnFocus: true});
 
 	const {
 		className,
@@ -82,19 +120,19 @@ let Scroller = ({'aria-label': ariaLabel, hoverToScroll, ...rest}) => {
 		editableWrapperProps,
 		focusableBodyProps,
 		themeScrollContentProps
-	} = useThemeScroller(rest, {...scrollContentProps, className: classnames(className, scrollContentProps.className)}, id, isHorizontalScrollbarVisible, isVerticalScrollbarVisible);
+	} = useThemeScroller(scrollerProps, {...scrollContentProps, className: classnames(className, scrollContentProps.className)}, id, isHorizontalScrollbarVisible, isVerticalScrollbarVisible);
 
-	const {children, direction, editable} = rest;
+	const {children, editable} = scrollerProps;
 
 	// To apply spotlight navigableFilter, SpottableDiv should be in scrollContainer.
-	const ScrollBody = rest.focusableScrollbar === 'byEnter' ? SpottableDiv : Fragment;
+	const ScrollBody = scrollerProps.focusableScrollbar === 'byEnter' ? SpottableDiv : Fragment;
 
 	// Render
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>
 			<ScrollContentWrapper {...scrollContainerProps} {...scrollContentWrapperRest}>
 				<ScrollBody {...focusableBodyProps}>
-					{rest.focusableScrollbar ? <ScrollbarPlaceholder /> : null}
+					{scrollerProps.focusableScrollbar ? <ScrollbarPlaceholder /> : null}
 					<UiScrollerBasic {...themeScrollContentProps} aria-label={ariaLabel} id={id} ref={scrollContentHandle}>
 						{(editable && direction === 'horizontal') ?
 							<EditableWrapper {...editableWrapperProps} /> :
@@ -451,29 +489,6 @@ Scroller = Skinnable(
 		)
 	)
 );
-
-Scroller.defaultProps = {
-	'data-spotlight-container-disabled': false,
-	cbScrollTo: nop,
-	direction: 'both',
-	fadeOut: false,
-	focusableScrollbar: false,
-	horizontalScrollbar: 'auto',
-	noScrollByDrag: false,
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	overscrollEffectOn: {
-		arrowKey: false,
-		drag: true,
-		pageKey: false,
-		track: false,
-		wheel: true
-	},
-	scrollMode: 'native',
-	verticalScrollbar: 'auto'
-};
 
 export default Scroller;
 export {

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -75,7 +75,7 @@ let Scroller = (props) => {
 	} = props;
 
 	const scrollerProps = {
-		spotlightContainerDisabled,
+		'data-spotlight-container-disabled': spotlightContainerDisabled,
 		cbScrollTo,
 		direction,
 		fadeOut,

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -58,8 +58,8 @@ import componentCss from './Slider.module.less';
  * @ui
  * @public
  */
-const SliderBase = (props) => {
-	const {active, className, css, disabled, focused, keyFrequency, showAnchor, ...rest} = props;
+const SliderBase = ({activateOnSelect = false, active = false, className, css, disabled = false, focused, keyFrequency = [1], max = 100, min = 0, showAnchor, step = 1, wheelInterval = 0, ...rest}) => {
+	const props = {activateOnSelect, active, disabled, keyFrequency, max, min, step, wheelInterval, ...rest};
 
 	validateSteppedOnce(p => p.knobStep, {
 		component: 'Slider',
@@ -67,7 +67,7 @@ const SliderBase = (props) => {
 		valueName: 'max'
 	})(props);
 
-	const step = validateSteppedOnce(p => p.step, {
+	const validatedStep = validateSteppedOnce(p => p.step, {
 		component: 'Slider',
 		valueName: 'max'
 	})(props);
@@ -162,11 +162,13 @@ const SliderBase = (props) => {
 			className={componentClassName}
 			css={mergedCss}
 			disabled={disabled}
+			max={max}
+			min={min}
 			progressBarComponent={
 				<ProgressBar css={mergedCss} />
 			}
 			ref={ref}
-			step={step}
+			step={validatedStep}
 			tooltipComponent={
 				<ComponentOverride
 					component={tooltip}
@@ -401,17 +403,6 @@ SliderBase.propTypes = /** @lends sandstone/Slider.SliderBase.prototype */ {
 	 * @public
 	 */
 	wheelInterval: PropTypes.number
-};
-
-SliderBase.defaultProps = {
-	activateOnSelect: false,
-	active: false,
-	disabled: false,
-	keyFrequency: [1],
-	max: 100,
-	min: 0,
-	step: 1,
-	wheelInterval: 0
 };
 
 /**

--- a/Sprite/Sprite.js
+++ b/Sprite/Sprite.js
@@ -201,26 +201,13 @@ const SpriteBase = kind({
 		width: PropTypes.number
 	},
 
-	defaultProps: {
-		columns: 1,
-		duration: 1000,
-		height: 120,
-		iterations: Infinity,
-		offsetLeft: 0,
-		offsetTop: 0,
-		orientation: 'horizontal',
-		paused: false,
-		rows: 1,
-		width: 120
-	},
-
 	styles: {
 		css,
 		className: 'sprite'
 	},
 
 	computed: {
-		style: ({offsetTop, offsetLeft, rows, columns, height, width, style}) => ({
+		style: ({offsetTop = 0, offsetLeft = 0, rows = 1, columns = 1, height = 120, width = 120, style}) => ({
 			...style,
 			'--sand-sprite-offset-top': scaleToRem(offsetTop),
 			'--sand-sprite-offset-left': scaleToRem(offsetLeft),
@@ -232,17 +219,17 @@ const SpriteBase = kind({
 	},
 
 	render: ({
-		columns,
-		duration,
-		height,
-		iterations,
+		columns = 1,
+		duration = 1000,
+		height = 120,
+		iterations = Infinity,
 		onSpriteAnimation,
-		orientation,
-		paused,
-		rows,
+		orientation = 'horizontal',
+		paused = false,
+		rows = 1,
 		stopped,
 		src,
-		width,
+		width = 120,
 		...rest
 	}) => {
 		delete rest.offsetTop;
@@ -309,7 +296,7 @@ const SpriteBase = kind({
 						{
 							easing: `steps(${frameCount}, end)`,
 							duration,
-							iterations
+							iterations: iterations || Infinity
 						}
 					);
 

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -32,7 +32,49 @@ const nop = () => {};
  * @ui
  * @public
  */
-let VirtualList = ({itemSize, hoverToScroll, ...rest}) => {
+let VirtualList = (props) => {
+	const {
+		'data-spotlight-container-disabled': spotlightContainerDisabled = false,
+		cbScrollTo = nop,
+		direction = 'vertical',
+		horizontalScrollbar = 'auto',
+		hoverToScroll,
+		itemSize,
+		noAffordance = false,
+		noScrollByDrag = false,
+		noScrollByWheel = false,
+		onScroll = nop,
+		onScrollStart = nop,
+		onScrollStop = nop,
+		overscrollEffectOn: {arrowKey = false, drag = true, pageKey = false, track = false, wheel = true} = {},
+		pageScroll = false,
+		role = 'list',
+		scrollMode = 'native',
+		verticalScrollbar = 'auto',
+		wrap = false,
+		...rest
+	} = props;
+
+	const virtualListProps = {
+		spotlightContainerDisabled,
+		cbScrollTo,
+		direction,
+		horizontalScrollbar,
+		noAffordance,
+		noScrollByDrag,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		overscrollEffectOn: {arrowKey, drag, pageKey, track, wheel},
+		pageScroll,
+		role,
+		scrollMode,
+		verticalScrollbar,
+		wrap,
+		...rest
+	};
+
 	const itemSizeProps = itemSize && itemSize.minSize ?
 		{
 			itemSize: itemSize.minSize,
@@ -43,7 +85,7 @@ let VirtualList = ({itemSize, hoverToScroll, ...rest}) => {
 		};
 
 	warning(
-		!itemSizeProps.itemSizes || !rest.cbScrollTo,
+		!itemSizeProps.itemSizes || !cbScrollTo,
 		'VirtualList with `minSize` in `itemSize` prop does not support `cbScrollTo` prop'
 	);
 
@@ -64,7 +106,7 @@ let VirtualList = ({itemSize, hoverToScroll, ...rest}) => {
 		horizontalScrollbarProps,
 		verticalScrollbarProps,
 		hoverToScrollProps
-	} = useScroll({...rest, ...itemSizeProps});
+	} = useScroll({...virtualListProps, ...itemSizeProps});
 
 	const {
 		className,
@@ -488,31 +530,6 @@ VirtualList = Skinnable(
 	)
 );
 
-VirtualList.defaultProps = {
-	'data-spotlight-container-disabled': false,
-	cbScrollTo: nop,
-	direction: 'vertical',
-	horizontalScrollbar: 'auto',
-	noAffordance: false,
-	noScrollByDrag: false,
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	overscrollEffectOn: {
-		arrowKey: false,
-		drag: true,
-		pageKey: false,
-		track: false,
-		wheel: true
-	},
-	pageScroll: false,
-	role: 'list',
-	scrollMode: 'native',
-	verticalScrollbar: 'auto',
-	wrap: false
-};
-
 /**
  * A Sandstone-styled scrollable and spottable virtual grid list component.
  *
@@ -522,7 +539,48 @@ VirtualList.defaultProps = {
  * @ui
  * @public
  */
-let VirtualGridList = ({hoverToScroll, ...rest}) => {
+let VirtualGridList = (props) => {
+	const {
+		'data-spotlight-container-disabled': spotlightContainerDisabled = false,
+		cbScrollTo = nop,
+		direction = 'vertical',
+		horizontalScrollbar = 'auto',
+		hoverToScroll,
+		noAffordance = false,
+		noScrollByDrag = false,
+		noScrollByWheel = false,
+		onScroll = nop,
+		onScrollStart = nop,
+		onScrollStop = nop,
+		overscrollEffectOn: {arrowKey = false, drag = true, pageKey = false, track = false, wheel = true} = {},
+		pageScroll = false,
+		role = 'list',
+		scrollMode = 'native',
+		verticalScrollbar = 'auto',
+		wrap = false,
+		...rest
+	} = props;
+
+	const virtualGridListProps = {
+		spotlightContainerDisabled,
+		cbScrollTo,
+		direction,
+		horizontalScrollbar,
+		noAffordance,
+		noScrollByDrag,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		overscrollEffectOn: {arrowKey, drag, pageKey, track, wheel},
+		pageScroll,
+		role,
+		scrollMode,
+		verticalScrollbar,
+		wrap,
+		...rest
+	};
+
 	const {
 		// Variables
 		scrollContentWrapper: ScrollContentWrapper,
@@ -538,7 +596,7 @@ let VirtualGridList = ({hoverToScroll, ...rest}) => {
 		horizontalScrollbarProps,
 		verticalScrollbarProps,
 		hoverToScrollProps
-	} = useScroll(rest);
+	} = useScroll(virtualGridListProps);
 
 	const {
 		className,
@@ -966,31 +1024,6 @@ VirtualGridList = Skinnable(
 		)
 	)
 );
-
-VirtualGridList.defaultProps = {
-	'data-spotlight-container-disabled': false,
-	cbScrollTo: nop,
-	direction: 'vertical',
-	horizontalScrollbar: 'auto',
-	noAffordance: false,
-	noScrollByDrag: false,
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	overscrollEffectOn: {
-		arrowKey: false,
-		drag: true,
-		pageKey: false,
-		track: false,
-		wheel: true
-	},
-	pageScroll: false,
-	role: 'list',
-	scrollMode: 'native',
-	verticalScrollbar: 'auto',
-	wrap: false
-};
 
 export default VirtualList;
 export {

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -56,7 +56,7 @@ let VirtualList = (props) => {
 	} = props;
 
 	const virtualListProps = {
-		spotlightContainerDisabled,
+		'data-spotlight-container-disabled': spotlightContainerDisabled,
 		cbScrollTo,
 		direction,
 		horizontalScrollbar,
@@ -562,7 +562,7 @@ let VirtualGridList = (props) => {
 	} = props;
 
 	const virtualGridListProps = {
-		spotlightContainerDisabled,
+		'data-spotlight-container-disabled': spotlightContainerDisabled,
 		cbScrollTo,
 		direction,
 		horizontalScrollbar,

--- a/internal/Panels/PanelsRouter.js
+++ b/internal/Panels/PanelsRouter.js
@@ -48,12 +48,12 @@ const PanelsRouter = hoc(defaultConfig, (config, Wrapped) => {
 		children,
 		componentRef,
 		'data-spotlight-id': spotlightId,
-		index,
+		index = 0,
 		onTransition,
 		onWillTransition,
 		rtl,
-		subtitle,
-		title,
+		subtitle = '',
+		title = '',
 		...rest
 	}) => {
 		const [panel, setPanel] = useState(null);
@@ -207,12 +207,6 @@ const PanelsRouter = hoc(defaultConfig, (config, Wrapped) => {
 		* @private
 		*/
 		title: PropTypes.string
-	};
-
-	PanelsProvider.defaultProps = {
-		index: 0,
-		subtitle: '',
-		title: ''
 	};
 
 	return PanelsProvider;

--- a/internal/Panels/useAutoFocus.js
+++ b/internal/Panels/useAutoFocus.js
@@ -49,7 +49,7 @@ function useAutoFocus ({autoFocus = 'last-focused', hideChildren}) {
 
 const AutoFocusDecorator = hoc((config, Wrapped) => {
 	// eslint-disable-next-line no-shadow
-	function AutoFocusDecorator ({autoFocus, componentRef, hideChildren, ...rest}) {
+	function AutoFocusDecorator ({autoFocus = 'last-focused', componentRef, hideChildren, ...rest}) {
 		const hook = useAutoFocus({autoFocus, hideChildren});
 		const ref = useChainRefs(componentRef, hook);
 
@@ -60,10 +60,6 @@ const AutoFocusDecorator = hoc((config, Wrapped) => {
 		autoFocus: PropTypes.string,
 		componentRef: EnactPropTypes.ref,
 		hideChildren: PropTypes.bool
-	};
-
-	AutoFocusDecorator.defaultProps = {
-		autoFocus: 'last-focused'
 	};
 
 	return AutoFocusDecorator;

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -98,7 +98,7 @@ const PickerBase = (props) => {
 
 	const {
 		'aria-valuetext': ariaValueText,
-		changedBy,
+		changedBy = 'enter',
 		children,
 		css: customCss,
 		disabled,
@@ -109,11 +109,11 @@ const PickerBase = (props) => {
 		min,
 		onChange,
 		onSpotlightDisappear,
-		orientation,
+		orientation = 'horizontal',
 		reverse,
-		spotlightDisabled,
-		step,
-		value,
+		spotlightDisabled = false,
+		step = 1,
+		value = 0,
 		width,
 		wrap,
 		...rest
@@ -437,7 +437,7 @@ const PickerBase = (props) => {
 	}, [changedBy, joined, orientation, pressed, props, width]);
 
 	const calcValueText = useCallback(() => {
-		const {accessibilityHint} = props;
+		const {accessibilityHint = ''} = props;
 		let valueTextVariable = value;
 
 		// Sometimes this.props.value is not equal to node text content. For example, when `PM`
@@ -457,7 +457,7 @@ const PickerBase = (props) => {
 	}, [children, index, props, value]);
 
 	const calcButtonLabel = useCallback((next, valueTextProp) => {
-		const {decrementAriaLabel, incrementAriaLabel} = props;
+		const {decrementAriaLabel, incrementAriaLabel, type = 'string'} = props;
 		const titleText = props.title ? props.title + ' ' : '';
 		let label;
 		if (orientation === 'vertical') {
@@ -470,7 +470,7 @@ const PickerBase = (props) => {
 			return titleText + label;
 		}
 
-		if (props.type === 'number') {
+		if (type === 'number') {
 			return titleText + `${valueTextProp} ${next ? $L('press ok button to increase the value') : $L('press ok button to decrease the value')}`;
 		} else {
 			return titleText + `${valueTextProp} ${next ? $L('next item') : $L('previous item')}`;
@@ -1019,16 +1019,6 @@ PickerBase.propTypes = /** @lends sandstone/internal/Picker.Picker.prototype */ 
 	 * @public
 	 */
 	wrap: PropTypes.bool
-};
-
-PickerBase.defaultProps = {
-	accessibilityHint: '',
-	changedBy: 'enter',
-	orientation: 'horizontal',
-	spotlightDisabled: false,
-	step: 1,
-	type: 'string',
-	value: 0
 };
 
 const Picker = IdProvider(

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -88,7 +88,8 @@ const useThemeScrollbar = (props) => {
  * @ui
  * @private
  */
-const ScrollbarBase = memo((props) => {
+const ScrollbarBase = memo(({css = componentCss, minThumbSize = 120, vertical = true, ...rest}) => {
+	const props = {css, minThumbSize, vertical, ...rest};
 	const {
 		restProps,
 		scrollbarProps,
@@ -149,12 +150,6 @@ ScrollbarBase.propTypes = /** @lends sandstone/useScroll.Scrollbar.prototype */ 
 	 * @public
 	 */
 	vertical: PropTypes.bool
-};
-
-ScrollbarBase.defaultProps = {
-	css: componentCss,
-	minThumbSize: 120,
-	vertical: true
 };
 
 /**

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -306,7 +306,6 @@ const useScroll = (props) => {
 		{
 			className,
 			'data-spotlight-container': spotlightContainer,
-			'data-spotlight-container-disabled': spotlightContainerDisabled,
 			'data-spotlight-id': spotlightId,
 			'data-webos-voice-disabled': voiceDisabled,
 			'data-webos-voice-focused': voiceFocused,
@@ -318,6 +317,7 @@ const useScroll = (props) => {
 			noAffordance,
 			scrollMode,
 			snapToCenter,
+			spotlightContainerDisabled,
 			style,
 			verticalScrollThumbAriaLabel,
 			...rest

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -306,6 +306,7 @@ const useScroll = (props) => {
 		{
 			className,
 			'data-spotlight-container': spotlightContainer,
+			'data-spotlight-container-disabled': spotlightContainerDisabled,
 			'data-spotlight-id': spotlightId,
 			'data-webos-voice-disabled': voiceDisabled,
 			'data-webos-voice-focused': voiceFocused,
@@ -317,7 +318,6 @@ const useScroll = (props) => {
 			noAffordance,
 			scrollMode,
 			snapToCenter,
-			spotlightContainerDisabled,
 			style,
 			verticalScrollThumbAriaLabel,
 			...rest


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In React 19, `defaultProps` in function components will be removed. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `defaultProps` for function components and replaced them with ES6 default parameters.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-19328

### Comments
