### PR TITLE
WRQ-17937: Add `fullContents` prop in PageViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - Support for QHD displays
-- `sandstone/PageViews` prop `fullContents`
+- `sandstone/PageViews` prop `fullContents` to allow contents of the page to use the entire area
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - Support for QHD displays
-- `sandstone/PageViews` prop `fullContents` to allow contents of the page to use the entire area
+- `sandstone/PageViews` prop `fullContents` to maximize its contents area
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - Support for QHD displays
+- `sandstone/PageViews` prop `fullContents`
 
 ### Fixed
 

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -69,7 +69,7 @@ const PageViewsBase = kind({
 
 		/**
 		 * When `true`, maximize its contents area.
-		 *  
+		 *
 		 * @type {Boolean}
 		 * @public
 		 */

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -68,10 +68,9 @@ const PageViewsBase = kind({
 		componentRef: EnactPropTypes.ref,
 
 		/**
-		 * When `true`, the contents of the page use the entire area
-		 *
+		 * When `true`, maximize its contents area.
+		 *  
 		 * @type {Boolean}
-		 * @default false
 		 * @public
 		 */
 		fullContents: PropTypes.bool,
@@ -193,7 +192,7 @@ const PageViewsBase = kind({
 			return `${pageHint} ${children?.[index]?.props['aria-label'] || ''}`;
 		},
 		className: ({fullContents, pageIndicatorType, styler}) => {
-			return styler.append({full: fullContents}, pageIndicatorType);
+			return styler.append({fullContents}, pageIndicatorType);
 		},
 		renderPrevButton: ({index, onPrevClick, navigationButtonOffset}) => {
 			const isPrevButtonVisible = index !== 0;
@@ -288,7 +287,7 @@ const PageViewsBase = kind({
 
 		return (
 			<div role="region" aria-labelledby={`pageViews_index_${index}`} ref={componentRef} {...rest}>
-				{!fullContents && pageIndicatorType === 'dot' ? <div>{steps}</div> : null}
+				{!fullContents && pageIndicatorType === 'dot' ? steps : null}
 				<Column aria-label={ariaLabel} className={css.contentsArea} id={`pageViews_index_${index}`} >
 					{fullContents ?
 						<>
@@ -303,7 +302,7 @@ const PageViewsBase = kind({
 						</Row>
 					}
 				</Column>
-				{!fullContents && pageIndicatorType === 'number' ? <div>{steps}</div> : null}
+				{!fullContents && pageIndicatorType === 'number' ? steps : null}
 			</div>
 		);
 	}

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -68,7 +68,7 @@ const PageViewsBase = kind({
 		componentRef: EnactPropTypes.ref,
 
 		/**
-		 * When `true`, the contents of the page use the full area
+		 * When `true`, the contents of the page use the entire area
 		 * 
 		 * @type {Boolean}
 		 * @default false

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -69,7 +69,7 @@ const PageViewsBase = kind({
 
 		/**
 		 * When `true`, the contents of the page use the entire area
-		 * 
+		 *
 		 * @type {Boolean}
 		 * @default false
 		 * @public
@@ -290,18 +290,18 @@ const PageViewsBase = kind({
 			<div role="region" aria-labelledby={`pageViews_index_${index}`} ref={componentRef} {...rest}>
 				{!fullContents && pageIndicatorType === 'dot' ? <div>{steps}</div> : null}
 				<Column aria-label={ariaLabel} className={css.contentsArea} id={`pageViews_index_${index}`} >
-					{fullContents ? 
+					{fullContents ?
 						<>
 							<Row className={css.horizontalLayout}>{renderViewManager}</Row>
 							<Row className={css.navButtonContainer}>{pageIndicatorType === 'dot' ? renderPrevButton : null}<Cell />{pageIndicatorType === 'dot' ? renderNextButton : null}</Row>
 							{steps}
-						</> : 
+						</> :
 						<Row className={css.horizontalLayout}>
 							{pageIndicatorType === 'dot' ? renderPrevButton : null}
 							{renderViewManager}
 							{pageIndicatorType === 'dot' ? renderNextButton : null}
 						</Row>
-					}	
+					}
 				</Column>
 				{!fullContents && pageIndicatorType === 'number' ? <div>{steps}</div> : null}
 			</div>

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -68,6 +68,15 @@ const PageViewsBase = kind({
 		componentRef: EnactPropTypes.ref,
 
 		/**
+		 * When `true`, the contents of the page use the full area
+		 * 
+		 * @type {Boolean}
+		 * @default false
+		 * @public
+		 */
+		fullContents: PropTypes.bool,
+
+		/**
 		 * Index of the active page.
 		 *
 		 * @type {Number}
@@ -183,23 +192,45 @@ const PageViewsBase = kind({
 			const pageHint = new IString($L('Page {current} out of {total}')).format({current: index + 1, total: totalIndex});
 			return `${pageHint} ${children?.[index]?.props['aria-label'] || ''}`;
 		},
-		className: ({pageIndicatorType, styler}) => {
-			return styler.append(pageIndicatorType);
+		className: ({fullContents, pageIndicatorType, styler}) => {
+			return styler.append({full: fullContents}, pageIndicatorType);
 		},
-		prevNavigationButton: ({index, onPrevClick, navigationButtonOffset}) => {
+		renderPrevButton: ({index, onPrevClick, navigationButtonOffset}) => {
 			const isPrevButtonVisible = index !== 0;
+			const navigationButtonStyle = {
+				top: typeof navigationButtonOffset === 'number' ? (navigationButtonOffset) : null
+			};
 			return (
 				<Cell className={css.navButton} shrink>
-					{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} style={{top: typeof navigationButtonOffset === 'number' ? (navigationButtonOffset) : null}} /> : null}
+					{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} style={navigationButtonStyle} /> : null}
 				</Cell>
 			);
 		},
-		nextNavigationButton: ({index, onNextClick, totalIndex, navigationButtonOffset}) => {
+		renderNextButton: ({onNextClick, index, totalIndex, navigationButtonOffset}) => {
 			const isNextButtonVisible = index < totalIndex - 1;
-
+			const navigationButtonStyle = {
+				top: typeof navigationButtonOffset === 'number' ? (navigationButtonOffset) : null
+			};
 			return (
 				<Cell className={css.navButton} shrink>
-					{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} style={{top: typeof navigationButtonOffset === 'number' ? (navigationButtonOffset) : null}} /> : null}
+					{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} style={navigationButtonStyle} /> : null}
+				</Cell>
+			);
+		},
+		renderViewManager: ({arranger, index, noAnimation, onTransition, onWillTransition, reverseTransition, children}) => {
+			return (
+				<Cell
+					arranger={arranger}
+					className={css.viewManager}
+					component={ViewManager}
+					duration={400}
+					index={index}
+					noAnimation={noAnimation}
+					onTransition={onTransition}
+					onWillTransition={onWillTransition}
+					reverseTransition={reverseTransition}
+				>
+					{children}
 				</Cell>
 			);
 		},
@@ -207,8 +238,8 @@ const PageViewsBase = kind({
 			const isPrevButtonVisible = index !== 0;
 			const isNextButtonVisible = index < totalIndex - 1;
 			return (
-				<div>
-					{pageIndicatorType === 'dot' ?
+				<>
+					{pageIndicatorType !== 'number' ?
 						<Row className={css.steps}>
 							<Steps
 								current={index + 1}
@@ -228,55 +259,51 @@ const PageViewsBase = kind({
 								{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowsmallright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} size="small" /> : null}
 							</Cell>
 						</Row>}
-				</div>
+				</>
 			);
 		}
 	},
 	render: ({
 		'aria-label': ariaLabel,
-		arranger,
-		children,
 		componentRef,
+		fullContents,
 		index,
-		nextNavigationButton,
-		noAnimation,
-		onTransition,
-		onWillTransition,
 		pageIndicatorType,
-		prevNavigationButton,
-		reverseTransition,
 		steps,
+		renderPrevButton,
+		renderNextButton,
+		renderViewManager,
 		...rest
 	}) => {
-
+		delete rest.arranger;
+		delete rest.children;
 		delete rest.componentRef;
+		delete rest.noAnimation;
+		delete rest.onTransition;
 		delete rest.onNextClick;
 		delete rest.onPrevClick;
+		delete rest.onWillTransition;
+		delete rest.reverseTransition;
 		delete rest.totalIndex;
 
 		return (
 			<div role="region" aria-labelledby={`pageViews_index_${index}`} ref={componentRef} {...rest}>
-				{pageIndicatorType === 'dot' ? steps : null}
+				{!fullContents && pageIndicatorType === 'dot' ? <div>{steps}</div> : null}
 				<Column aria-label={ariaLabel} className={css.contentsArea} id={`pageViews_index_${index}`} >
-					<Row className={css.horizontalLayout}>
-						{pageIndicatorType === 'dot' ? prevNavigationButton : null}
-						<Cell
-							arranger={arranger}
-							className={css.viewManager}
-							component={ViewManager}
-							duration={400}
-							index={index}
-							noAnimation={noAnimation}
-							onTransition={onTransition}
-							onWillTransition={onWillTransition}
-							reverseTransition={reverseTransition}
-						>
-							{children}
-						</Cell>
-						{pageIndicatorType === 'dot' ? nextNavigationButton : null}
-					</Row>
+					{fullContents ? 
+						<>
+							<Row className={css.horizontalLayout}>{renderViewManager}</Row>
+							<Row className={css.navButtonContainer}>{pageIndicatorType === 'dot' ? renderPrevButton : null}<Cell />{pageIndicatorType === 'dot' ? renderNextButton : null}</Row>
+							{steps}
+						</> : 
+						<Row className={css.horizontalLayout}>
+							{pageIndicatorType === 'dot' ? renderPrevButton : null}
+							{renderViewManager}
+							{pageIndicatorType === 'dot' ? renderNextButton : null}
+						</Row>
+					}	
 				</Column>
-				{pageIndicatorType === 'number' ? steps : null}
+				{!fullContents && pageIndicatorType === 'number' ? <div>{steps}</div> : null}
 			</div>
 		);
 	}

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -34,11 +34,31 @@
 		height: 132px;
 	}
 
-	.contentsArea, .viewManager{
+	&.full .steps {
+		position: absolute;
+		align-self: center;
+		bottom: 0px;
+		height: 132px;
+	}
+
+	.contentsArea {
+		position: relative;
+		overflow: hidden;
+	}
+
+	.viewManager {
 		overflow: hidden;
 	}
 
 	.horizontalLayout {
 		height: 100%;
 	}
+}
+
+.navButtonContainer {
+	overflow: hidden;
+	z-index: 10;
+	top: ~"calc(50% - " (@sand-button-height+12)/2 ~")";
+	position: absolute;
+	width: 100%;
 }

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -21,7 +21,7 @@
 	}
 
 	&.number .steps {
-		height: 252px;
+		min-height: 252px;
 		.pageNumber {
 			width: 126px;
 		}
@@ -31,14 +31,14 @@
 	}
 
 	&.dot .steps {
-		height: 132px;
+		min-height: 132px;
 	}
 
-	&.full .steps {
+	&.fullContents .steps {
 		position: absolute;
 		align-self: center;
 		bottom: 0px;
-		height: 132px;
+		min-height: 132px;
 	}
 
 	.contentsArea {
@@ -58,7 +58,7 @@
 .navButtonContainer {
 	overflow: hidden;
 	z-index: 10;
-	top: ~"calc(50% - " (@sand-button-height+12)/2 ~")";
+	top: ~"calc(50% - " (@sand-button-height + 12) / 2 ~")";
 	position: absolute;
 	width: 100%;
 }

--- a/samples/sampler/stories/default/PageViews.js
+++ b/samples/sampler/stories/default/PageViews.js
@@ -1,11 +1,13 @@
 import {BasicArranger} from '@enact/sandstone/internal/Panels';
 import {PageViews} from '@enact/sandstone/PageViews';
 import Item from '@enact/sandstone/Item';
-import {select} from '@enact/storybook-utils/addons/controls';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
+import {boolean, select} from '@enact/storybook-utils/addons/controls';
 import {Cell, Row, Column} from '@enact/ui/Layout';
 
 PageViews.displayName = 'PageViews';
 
+const Config = mergeComponentMetadata('PageViews', PageViews);
 const propOptions = {
 	pageIndicatorType: ['dot', 'number']
 };
@@ -16,9 +18,9 @@ export default {
 };
 
 export const _PageViews = (args) => (
-	<PageViews arranger={BasicArranger} pageIndicatorType={args['pageIndicatorType']}>
+	<PageViews arranger={BasicArranger} fullContents={args['fullContents']} pageIndicatorType={args['pageIndicatorType']}>
 		<PageViews.Page aria-label="This is a description for page 1">
-			<div style={{padding: '24px'}}>
+			<div style={{padding: '24px', width: '50%'}}>
 				<Item>Item 1</Item>
 				<Item>Item 2</Item>
 			</div>
@@ -57,12 +59,15 @@ export const _PageViews = (args) => (
 			</div>
 		</PageViews.Page>
 		<PageViews.Page>
-			This is page 4
+			<div style={{height: '100%', backgroundColor: 'grey'}}>
+				This is page 4
+			</div>
 		</PageViews.Page>
 	</PageViews>
 );
 
-select('pageIndicatorType', _PageViews, propOptions.pageIndicatorType, 'dot');
+boolean('fullContents', _PageViews, Config, false);
+select('pageIndicatorType', _PageViews, propOptions.pageIndicatorType, Config, 'dot');
 
 _PageViews.storyName = 'PageViews';
 _PageViews.parameters = {

--- a/tests/screenshot/apps/components/PageViews.js
+++ b/tests/screenshot/apps/components/PageViews.js
@@ -28,6 +28,10 @@ const BaseTests = [
 		wrapper: {full: true}
 	},
 	{
+		component: <Panel><Header title="title of panel" subtitle="subtitle of panel" /><PageViews fullContents index={2}>{PageComponents}</PageViews></Panel>,
+		wrapper: {full: true}
+	},
+	{
 		component: <Panel><Header title="title of panel" subtitle="subtitle of panel" /><PageViews pageIndicatorType="number" index={0}>{PageComponents}</PageViews></Panel>,
 		wrapper: {full: true}
 	},


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
By adding the `fullContents` prop in PageViews component, make contents of the page to fit into the PageViews component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `fullContents` prop 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-17937

### Comments
