### PR TITLE
WRQ-2288: Apply large screen mode to sampler

### DIFF
--- a/samples/sampler/.storybook/preview.js
+++ b/samples/sampler/.storybook/preview.js
@@ -48,6 +48,18 @@ const skins = {
 	'Light': 'light'
 };
 
+const screenScale = {
+	'1': 1,
+	'1.2': 1.2,
+	'1.4': 1.4,
+	'1.6': 1.6,
+	'1.8': 1.8,
+	'2': 2,
+	'3': 3,
+	'4': 4,
+	'5': 5
+};
+
 configureActions();
 
 if (process.env.STORYBOOK_APPLY_GA_COOKIEBANNER) {
@@ -91,6 +103,7 @@ export const globalTypes = {
 	'large text': getBooleanType('large text'),
 	'high contrast': getBooleanType('high contrast'),
 	'focus ring':getBooleanType('focus ring'),
+	'screen scale': getObjectType('screen scale', 1, screenScale),
 	'skin': getObjectType('skin', 'neutral', skins),
 	'background': getObjectType('background', 'default', backgrounds),
 	'debug aria': getBooleanType('debug aria'),

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -43,10 +43,7 @@ const PanelsBase = kind({
 
 const Theme = ThemeDecorator({overlay: false}, PanelsBase);
 
-const StorybookDecorator = (story, config = {}) => {
-	// Executing `story` here allows the story controls to register and render before the global variable below.
-	const sample = story();
-
+const StorybookDecorator = (Story, config = {}) => {
 	const {globals} = config;
 
 	const componentName = config.kind.replace(/^([^/]+)\//, '');
@@ -74,13 +71,14 @@ const StorybookDecorator = (story, config = {}) => {
 			textSize={JSON.parse(globals['large text']) ? 'large' : 'normal'}
 			focusRing={JSON.parse(globals['focus ring'])}
 			highContrast={JSON.parse(globals['high contrast'])}
+			screenScale={JSON.parse(globals['screen scale'])}
 			style={{
 				'--sand-env-background': globals.background === 'default' ? '' : globals.background
 			}}
 			skin={globals.skin}
 			{...hasProps ? config.parameters.props : null}
 		>
-			{sample}
+			<Story />
 		</Theme>
 	);
 };


### PR DESCRIPTION

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a requirement for large screen mode(before large text) for a11y.
Since the purpose is to increase the screen magnification, the name large screen mode was used.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Receives the screen scale value from global and applies it to the sampler.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Changed the way story is called. Decorator should be called first, followed by story.
refer to : https://github.com/storybookjs/storybook/issues/11852
### Links
[//]: # (Related issues, references)
WRQ-2288

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
