### PR TITLE
WRQ-22257: Fixed an issues where FixedPopupPanels were always full height when in high contrast mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
     - "21"
 sudo: false
 before_install:
+    - curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-4.4.gpg --dearmor
+    - echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
     - "21"
 sudo: false
 before_install:
-    - curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-4.4.gpg --dearmor
-    - echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/PageViews` to hide dot page indicator when there is only one page
 
+### Fixed
+
+- `sandstone/FixedPopupPanels` to show the outline appropriately in high-contrast mode
+
 ## [2.9.0-alpha.3] - 2024-05-24
 
 ### Added

--- a/FixedPopupPanels/FixedPopupPanels.js
+++ b/FixedPopupPanels/FixedPopupPanels.js
@@ -36,6 +36,7 @@ const FixedPopupPanelsDecorator = compose(
 		className: 'fixedPopupPanels',
 		css,
 		noAlertRole: true,
+		noOutline: true,
 		panelArranger: BasicArranger,
 		panelType: 'fixedPopup'
 	})

--- a/FixedPopupPanels/FixedPopupPanels.module.less
+++ b/FixedPopupPanels/FixedPopupPanels.module.less
@@ -50,6 +50,10 @@
 		.viewport {
 			border-radius: @sand-fixedpopuppanels-border-radius;
 			box-shadow: @sand-fixedpopuppanels-shadow;
+			outline-color: @sand-overlay-outline-color;
+			outline-style: @sand-overlay-outline-style;
+			outline-width: @sand-overlay-outline-width;
+			outline-offset: -@sand-overlay-outline-width;
 		}
 
 		&.scrimTranslucent {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed an issues where FixedPopupPanels were always full height when in high contrast mode.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added missing styles to FixedPopupPanels and added noOutline to PopupDecorator to prevent outlines from being duplicated.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ-22257

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
