### PR TITLE
WRQ-7995: Clean up unnecessary code to cancel back key behavior by app scenarios

### DIFF
--- a/TabLayout/TabLayout.js
+++ b/TabLayout/TabLayout.js
@@ -143,14 +143,6 @@ const TabLayoutBase = kind({
 		}),
 
 		/**
-		 * Disable back key behavior which moves focus from tab contents to tab menu
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		disableBackKeyNavigation: PropTypes.bool,
-
-		/**
 		 * The currently selected tab.
 		 *
 		 * @type {Number}
@@ -292,7 +284,7 @@ const TabLayoutBase = kind({
 			const tabLayoutContentRef = document.querySelector(`[data-spotlight-id='${spotlightId}'] .${componentCss.content}`);
 
 			if (forwardWithPrevent('onKeyUp', ev, props) && is('cancel')(keyCode)) {
-				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !props.disableBackKeyNavigation && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
+				if ((type === 'popup' && popupPanelRef?.contains(target) && popupPanelRef?.dataset.index === '0') || (type === 'normal' && !Spotlight.getPointerMode() && tabLayoutContentRef?.contains(target))) {
 					if (collapsed) {
 						forward('onExpand', ev, props);
 					}
@@ -390,7 +382,6 @@ const TabLayoutBase = kind({
 
 	render: ({children, collapsed, css, 'data-spotlight-id': spotlightId, dimensions, handleClick, handleEnter, handleFlick, handleFocus, handleTabsTransitionEnd, index, onCollapse, onSelect, orientation, tabOrientation, tabSize, tabs, type, ...rest}) => {
 		delete rest.anchorTo;
-		delete rest.disableBackKeyNavigation;
 		delete rest.onExpand;
 		delete rest.onTabAnimationEnd;
 		delete rest.rtl;

--- a/TabLayout/tests/TabLayout-specs.js
+++ b/TabLayout/tests/TabLayout-specs.js
@@ -356,10 +356,15 @@ describe('TabLayout specs', () => {
 		expect(actual).toMatchObject(expected);
 	});
 
-	test('should not call \'onExpand\' when \'disableBackKeyNavigation\' prop is true and pressing \'backKey\' on a tab content', () => {
+	test('should not call \'onExpand\' when preventDefault is called in onKeyUp handler when pressing \'backKey\' on a tab content', () => {
 		const spy = jest.fn();
+		const handleKeyUp = (ev) => {
+			if (ev.keyCode === 27) {
+				ev.preventDefault();
+			}
+		};
 		render(
-			<TabLayout collapsed disableBackKeyNavigation onExpand={spy} rtl={false}>
+			<TabLayout collapsed onKeyUp={handleKeyUp} onExpand={spy} rtl={false}>
 				<Tab icon="home" title="Home">
 					<Button>Button</Button>
 				</Tab>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Temporal code to cancel back key behavior of TabLayout remains even app developers don't need it as they can handle the case with a normal onKeyUp handler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed unnecessary code.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-7995

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
