### PR TITLE
WRQ-19324: Fix `ContextualPopupDecorator` and `DropdownList` to add sibling DOM node using WithRef instead of adding sibling DOM node manually.

### DIFF
--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -11,6 +11,7 @@ import {on, off} from '@enact/core/dispatcher';
 import {handle, forProp, forKey, forward, forwardCustom, stop} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
+import {WithRef} from '@enact/core/internal/WithRef';
 import {extractAriaProps} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Spotlight, {getDirection} from '@enact/spotlight';
@@ -81,6 +82,7 @@ const ContextualPopupContainer = SpotlightContainerDecorator(
 
 const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {noArrow, noSkin, openProp} = config;
+	const WrappedWithRef = WithRef(Wrapped);
 
 	return class extends Component {
 		static displayName = 'ContextualPopupDecorator';
@@ -559,10 +561,11 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		positionContextualPopup = () => {
-			if (this.containerNode && this.clientSiblingRef?.current?.previousElementSibling) {
+			if (this.containerNode && this.clientSiblingRef?.current) {
 				const containerNode = this.containerNode.getBoundingClientRect();
-				const {top, left, bottom, right, width, height} = this.clientSiblingRef.current.previousElementSibling.getBoundingClientRect();
+				const {top, left, bottom, right, width, height} = this.clientSiblingRef.current.getBoundingClientRect();
 				const clientNode = {top, left, bottom, right, width, height};
+
 				clientNode.left = this.props.rtl ? window.innerWidth - right : left;
 				clientNode.right = this.props.rtl ? window.innerWidth - left : right;
 
@@ -715,8 +718,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			let holeBounds;
-			if (this.clientSiblingRef?.current?.previousElementSibling && holepunchScrim) {
-				holeBounds = this.clientSiblingRef.current.previousElementSibling.getBoundingClientRect();
+			if (this.clientSiblingRef?.current && holepunchScrim) {
+				holeBounds = this.clientSiblingRef.current.getBoundingClientRect();
 			}
 
 			delete rest.direction;
@@ -760,10 +763,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 							</ContextualPopupContainer>
 						</Fragment>
 					</FloatingLayer>
-					<>
-						<Wrapped {...rest} />
-						<div style={{display: 'none'}} ref={this.clientSiblingRef} />
-					</>
+					<WrappedWithRef {...rest} outermostRef={this.clientSiblingRef} referrerName="ContextualPopup" />
 				</div>
 			);
 		}

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -2,6 +2,7 @@ import kind from '@enact/core/kind';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
+import {WithRef} from '@enact/core/internal/WithRef';
 import Spotlight from '@enact/spotlight';
 import IdProvider from '@enact/ui/internal/IdProvider';
 import ri from '@enact/ui/resolution';
@@ -177,6 +178,8 @@ const ReadyState = {
 };
 
 const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
+	const WrappedWithRef = WithRef(Wrapped);
+
 	return class extends Component {
 		static displayName = 'DropdownListSpotlightDecorator';
 
@@ -289,7 +292,8 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 
 		handleFocus = (ev) => {
 			const current = ev.target;
-			const dropdownListNode = this.clientSiblingRef?.current?.previousElementSibling;
+			const dropdownListNode = this.clientSiblingRef?.current;
+
 			if (this.state.ready === ReadyState.DONE && !Spotlight.getPointerMode() &&
 				current.dataset['index'] != null && dropdownListNode.contains(current)
 			) {
@@ -308,10 +312,7 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 			delete props.handleSpotlightPause;
 
 			return (
-				<>
-					<Wrapped {...props} onFocus={this.handleFocus} scrollTo={this.setScrollTo} />
-					<div style={{display: 'none'}} ref={this.clientSiblingRef} />
-				</>
+				<WrappedWithRef {...props} onFocus={this.handleFocus} outermostRef={this.clientSiblingRef} referrerName="DropdownList" scrollTo={this.setScrollTo} />
 			);
 		}
 	};


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When migrate with the enact(https://github.com/enactjs/enact/commit/33c27d5040459063bc13901d0cc76e0fb3a8731d), DOM structure of `ContextualPopupDecorator` has two dummy `div` which caused the contextual popup's position to be calculated incorrectly.
No invalid DOM structure was found in `DropdownList`, but we also fix DropdownList.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix `ContextualPopupDecorator` and `DropdownList` to use WithRef to add sibling DOM node. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-19324

### Comments
