### PR TITLE
WRQ-5388: [POC] Input with useWhisper API

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -292,6 +292,7 @@ const InputPopupBase = kind({
 		title: PropTypes.string,
 
 		transcriptText: PropTypes.string,
+		setTranscriptText: PropTypes.func,
 
 		/**
 		 * Type of the input.
@@ -332,13 +333,6 @@ const InputPopupBase = kind({
 	},
 
 	handlers: {
-		onRecording: (ev, {recording, startRecording, stopRecording}) => {
-			if (!recording) {
-				startRecording();
-			} else {
-				stopRecording();
-			}
-		},
 		onShow: handle(
 			forwardCustom('onShow'),
 			(ev, {type}) => !type.includes('number'),
@@ -397,6 +391,9 @@ const InputPopupBase = kind({
 		recording,
 		size,
 		subtitle,
+		startRecording,
+		stopRecording,
+		setTranscriptText,
 		title,
 		transcriptText,
 		type,
@@ -476,33 +473,26 @@ const InputPopupBase = kind({
 									numberInputField={numberInputField}
 									noSubmitButton={noSubmitButton}
 								/> :
-								<>
-									<InputField
-										{...inputProps}
-										className={classnames(css.textField, spotlightDefaultClass)}
-										css={css}
-										disabled={recording}
-										maxLength={maxLength}
-										minLength={minLength}
-										size={size}
-										autoFocus
-										type={type}
-										defaultValue={defaultValue || value}
-										placeholder={placeholder}
-										onBeforeChange={onBeforeChange}
-										onKeyDown={onInputKeyDown}
-										recording={recording}
-										spotlightId={inputFieldSpotlightId}
-										transcriptText={transcriptText}
-									/>
-									<Button
-										size="small"
-										backgroundOpacity="transparent"
-										selected={recording}
-										onClick={onRecording}
-										icon="voice"
-									/>
-								</>
+								<InputField
+									{...inputProps}
+									className={classnames(css.textField, spotlightDefaultClass)}
+									css={css}
+									maxLength={maxLength}
+									minLength={minLength}
+									size={size}
+									autoFocus
+									type={type}
+									defaultValue={defaultValue || value}
+									placeholder={placeholder}
+									onBeforeChange={onBeforeChange}
+									onKeyDown={onInputKeyDown}
+									recording={recording}
+									setTranscriptText={setTranscriptText}
+									startRecording={startRecording}
+									stopRecording={stopRecording}
+									spotlightId={inputFieldSpotlightId}
+									transcriptText={transcriptText}
+								/>
 							}
 						</Cell>
 						<Cell shrink className={css.buttonArea}>{children}</Cell>

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -224,6 +224,8 @@ const InputPopupBase = kind({
 		 */
 		onOpenPopup: PropTypes.func,
 
+		onRecording: PropTypes.func,
+
 		/**
 		 * Opens the popup.
 		 *
@@ -257,6 +259,8 @@ const InputPopupBase = kind({
 		 */
 		popupType: PropTypes.oneOf(['fullscreen', 'overlay']),
 
+		recording: PropTypes.bool,
+
 		/**
 		 * Size of the input field.
 		 *
@@ -265,6 +269,9 @@ const InputPopupBase = kind({
 		 * @public
 		 */
 		size: PropTypes.oneOf(['small', 'large']),
+
+		startRecording: PropTypes.func,
+		stopRecording: PropTypes.func,
 
 		/**
 		 * Subtitle below the title of popup.
@@ -283,6 +290,8 @@ const InputPopupBase = kind({
 		 * @public
 		 */
 		title: PropTypes.string,
+
+		transcriptText: PropTypes.string,
 
 		/**
 		 * Type of the input.
@@ -323,6 +332,13 @@ const InputPopupBase = kind({
 	},
 
 	handlers: {
+		onRecording: (ev, {recording, startRecording, stopRecording}) => {
+			if (!recording) {
+				startRecording();
+			} else {
+				stopRecording();
+			}
+		},
 		onShow: handle(
 			forwardCustom('onShow'),
 			(ev, {type}) => !type.includes('number'),
@@ -369,6 +385,7 @@ const InputPopupBase = kind({
 		numberInputField,
 		onBeforeChange,
 		onClose,
+		onRecording,
 		onNumberComplete,
 		onInputKeyDown,
 		onShow,
@@ -377,9 +394,11 @@ const InputPopupBase = kind({
 		popupAriaLabel,
 		popupClassName,
 		popupType,
+		recording,
 		size,
 		subtitle,
 		title,
+		transcriptText,
 		type,
 		value,
 		maxLength,
@@ -457,21 +476,33 @@ const InputPopupBase = kind({
 									numberInputField={numberInputField}
 									noSubmitButton={noSubmitButton}
 								/> :
-								<InputField
-									{...inputProps}
-									className={classnames(css.textField, spotlightDefaultClass)}
-									css={css}
-									maxLength={maxLength}
-									minLength={minLength}
-									size={size}
-									autoFocus
-									type={type}
-									defaultValue={defaultValue || value}
-									placeholder={placeholder}
-									onBeforeChange={onBeforeChange}
-									onKeyDown={onInputKeyDown}
-									spotlightId={inputFieldSpotlightId}
-								/>
+								<>
+									<InputField
+										{...inputProps}
+										className={classnames(css.textField, spotlightDefaultClass)}
+										css={css}
+										disabled={recording}
+										maxLength={maxLength}
+										minLength={minLength}
+										size={size}
+										autoFocus
+										type={type}
+										defaultValue={defaultValue || value}
+										placeholder={placeholder}
+										onBeforeChange={onBeforeChange}
+										onKeyDown={onInputKeyDown}
+										recording={recording}
+										spotlightId={inputFieldSpotlightId}
+										transcriptText={transcriptText}
+									/>
+									<Button
+										size="small"
+										backgroundOpacity="transparent"
+										selected={recording}
+										onClick={onRecording}
+										icon="voice"
+									/>
+								</>
 							}
 						</Cell>
 						<Cell shrink className={css.buttonArea}>{children}</Cell>

--- a/Input/InputField.js
+++ b/Input/InputField.js
@@ -194,6 +194,8 @@ const InputFieldBase = kind({
 		 */
 		placeholder: PropTypes.string,
 
+		recording: PropTypes.bool,
+
 		/**
 		 * Indicates the content's text direction is right-to-left.
 		 *
@@ -210,6 +212,8 @@ const InputFieldBase = kind({
 		 * @public
 		 */
 		size: PropTypes.oneOf(['small', 'large']),
+
+		transcriptText: PropTypes.string,
 
 		/**
 		 * The type of input.
@@ -280,7 +284,14 @@ const InputFieldBase = kind({
 			}
 		},
 		// ensure we have a value so the internal <input> is always controlled
-		value: ({value}) => typeof value === 'number' ? value : (value || '')
+		value: ({value, transcriptText, recording}) => {
+			if (recording) {
+				value = (value || '') + (transcriptText || '');
+			} else {
+				value = value || transcriptText;
+			}
+			return (value);
+		}
 	},
 
 	render: ({css, dir, disabled, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {

--- a/samples/sampler/stories/default/Input.js
+++ b/samples/sampler/stories/default/Input.js
@@ -39,7 +39,7 @@ export const _Input = (args) => {
 		apiKey: "AZURE_OPENAI_API_KEY",
 		// removeSilence: true,
 		streaming: true,
-		timeSlice: 20_000,
+		timeSlice: 10_000,
 		whisperConfig: {
 			language: 'ko'
 		}
@@ -71,13 +71,7 @@ export const _Input = (args) => {
 	};
 
 	useEffect(() => {
-		if (recording) {
-			setTranscriptText('');
-		}
-	}, [recording]);
-
-	useEffect(() => {
-		setTranscriptText(t => (t + ' ' + (transcript.text || '')));
+		setTranscriptText(transcript.text);
 	}, [transcript.text]);
 
 	// Numeric specific props
@@ -105,6 +99,7 @@ export const _Input = (args) => {
 			<Input
 				{...propOptions}
 				recording={recording}
+				setTranscriptText={setTranscriptText}
 				startRecording={startRecording}
 				stopRecording={stopRecording}
 				transcriptText={transcriptText}

--- a/samples/sampler/stories/default/Input.js
+++ b/samples/sampler/stories/default/Input.js
@@ -1,7 +1,11 @@
+// import {useWhisper} from '@chengsokdara/use-whisper';
+import {useWhisper} from '../../../../../use-whisper/src';
 import Input, {InputBase, InputPopup, InputPopupBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, range, select, text} from '@enact/storybook-utils/addons/controls';
+
+import {useEffect, useState} from 'react';
 
 Input.displayName = 'Input';
 const Config = mergeComponentMetadata('Input', InputPopupBase, InputBase, Input);
@@ -22,6 +26,25 @@ export default {
 };
 
 export const _Input = (args) => {
+	const [transcriptText, setTranscriptText] = useState('');
+	const {
+		recording,
+		speaking,
+		transcribing,
+		transcript,
+		pauseRecording,
+		startRecording,
+		stopRecording
+	} = useWhisper({
+		apiKey: "AZURE_OPENAI_API_KEY",
+		// removeSilence: true,
+		streaming: true,
+		timeSlice: 20_000,
+		whisperConfig: {
+			language: 'ko'
+		}
+	});
+
 	const propOptions = {
 		// Actions
 		onBeforeChange: action('onBeforeChange'),
@@ -47,6 +70,16 @@ export const _Input = (args) => {
 		backButtonAriaLabel: args['backButtonAriaLabel']
 	};
 
+	useEffect(() => {
+		if (recording) {
+			setTranscriptText('');
+		}
+	}, [recording]);
+
+	useEffect(() => {
+		setTranscriptText(t => (t + ' ' + (transcript.text || '')));
+	}, [transcript.text]);
+
 	// Numeric specific props
 	if (propOptions.type === 'number' || propOptions.type === 'passwordnumber') {
 		propOptions.numberInputField = args['numberInputField'];
@@ -69,7 +102,13 @@ export const _Input = (args) => {
 
 	return (
 		<div>
-			<Input {...propOptions} />
+			<Input
+				{...propOptions}
+				recording={recording}
+				startRecording={startRecording}
+				stopRecording={stopRecording}
+				transcriptText={transcriptText}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
useWhisper is a React Hook for OpenAI Whisper API with speech recorder, real-time transcription and silence removal built-in.
We'd like to research if we can adopt this hook into the Enact Input component.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Made a demo on Sandston sampler Input.
If you click the mic button, recording starts and trascript text displays in input every 20 seconds.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
This requires useWhisper API, OpenAI API Key, and OpenAI Endpoint.
Editing transcript text has not been developed properly yet.
Should choose just one of key input or transcribing for now.
It will be nice to enable editing transcript text later.

### Links
[//]: # (Related issues, references)
WRQ-5388

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)