### PR TITLE
WRQ-25442: Fixed Editable Scroller to blur the focused item properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Scroller` `editable.blurItemFuncRef` prop to provide a function for blurring the focused item
+
 ## [2.7.16] - 2024-05-13
 
 ### Added

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -30,7 +30,7 @@ const TouchableDiv = Touchable('div');
  *  It has an event object contains `orders` array which app can use for repopulate items.
  * @property {Function|Object} [blurItemFuncRef] Obtains a reference to `blurItem` function.
  *  If you would like to remove `focused` CSS class to an item, you can get the reference to `blurItem` function via `useRef`.
- * `blurItem` function need to be called with an item node when an item is blurred.
+ * `blurItem` function needs to be called with an item node when an item is blurred.
  * @property {Boolean} [centered] Centers the contents of the scroller.
  * @property {Object} [css] Customizes the component by mapping the supplied collection of CSS class names to the
  *  corresponding internal elements and states of this component.
@@ -41,7 +41,7 @@ const TouchableDiv = Touchable('div');
  * * `focused` - The focused item class
  * @property {Function|Object} [focusItemFuncRef] Obtains a reference to `focusItem` function.
  *  If you would like to use `focused` CSS class to an item, you can get the reference to `focusItem` function via `useRef`.
- * `focusItem` function need to be called with an item node when an item is focused.
+ * `focusItem` function needs to be called with an item node when an item is focused.
  * @property {Function|Object} [hideItemFuncRef] Obtains a reference to `hideItem` function.
  *  If you would like to hide an item, you can get the reference to `hideItem` function via `useRef`.
  * @property {Function|Object} [removeItemFuncRef] Obtains a reference to `removeItem` function.

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -28,6 +28,9 @@ const TouchableDiv = Touchable('div');
  * @memberof sandstone/Scroller
  * @property {Function} onComplete The callback function called when editing is finished.
  *  It has an event object contains `orders` array which app can use for repopulate items.
+ * @property {Function|Object} [blurItemFuncRef] Obtains a reference to `blurItem` function.
+ *  If you would like to remove `focused` CSS class to an item, you can get the reference to `blurItem` function via `useRef`.
+ * `blurItem` function need to be called with an item node when an item is blurred.
  * @property {Boolean} [centered] Centers the contents of the scroller.
  * @property {Object} [css] Customizes the component by mapping the supplied collection of CSS class names to the
  *  corresponding internal elements and states of this component.
@@ -51,6 +54,7 @@ const TouchableDiv = Touchable('div');
  */
 const EditableShape = PropTypes.shape({
 	onComplete: PropTypes.func.isRequired,
+	blurItemFuncRef: EnactPropTypes.ref,
 	centered: PropTypes.bool,
 	css: PropTypes.object,
 	focusItemFuncRef: EnactPropTypes.ref,
@@ -87,6 +91,7 @@ const EditableWrapper = (props) => {
 	const hideItemFuncRef = editable?.hideItemFuncRef;
 	const showItemFuncRef = editable?.showItemFuncRef;
 	const focusItemFuncRef = editable?.focusItemFuncRef;
+	const blurItemFuncRef = editable?.blurItemFuncRef;
 	const mergedCss = usePublicClassNames({componentCss, customCss, publicClassNames: true});
 
 	const dataSize = children?.length;
@@ -249,6 +254,15 @@ const EditableWrapper = (props) => {
 			mutableRef.current.focusedItem = itemNode;
 			mutableRef.current.focusedItem?.classList.add(customCss.focused);
 			mutableRef.current.prevToIndex = Number(itemNode.style.order) - 1;
+		}
+	}, [customCss.focused, findItemNode]);
+
+	const blurItem = useCallback((target) => {
+		const itemNode = findItemNode(target);
+		if (itemNode && !mutableRef.current.selectedItem) {
+			mutableRef.current.focusedItem?.classList.remove(customCss.focused);
+			mutableRef.current.focusedItem = null;
+			mutableRef.current.prevToIndex = null;
 		}
 	}, [customCss.focused, findItemNode]);
 
@@ -667,7 +681,7 @@ const EditableWrapper = (props) => {
 	}, [completeEditingByKeyDown]);
 
 	const handleGlobalKeyDownCapture = useCallback((ev) => {
-		if (getPointerMode() && !scrollContainerRef.current.contains(Spotlight.getCurrent()) && mutableRef.current.selectedItem) {
+		if (getPointerMode() && !scrollContainerRef.current.contains(Spotlight.getCurrent()) && (mutableRef.current.selectedItem || mutableRef.current.focusedItem)) {
 			const {keyCode} = ev;
 			const position = getLastPointerPosition();
 			const direction = getDirection(keyCode);
@@ -757,6 +771,12 @@ const EditableWrapper = (props) => {
 			focusItemFuncRef.current = focusItem;
 		}
 	}, [focusItem, focusItemFuncRef]);
+
+	useLayoutEffect(() => {
+		if (blurItemFuncRef) {
+			blurItemFuncRef.current = blurItem;
+		}
+	}, [blurItem, blurItemFuncRef]);
 
 	useEffect(() => {
 		// addEventListener to moveItems while scrolled

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -89,6 +89,7 @@ export const EditableIcon = (args) => {
 	const hideItem = useRef();
 	const showItem = useRef();
 	const focusItem = useRef();
+	const blurItem = useRef();
 	const divRef = useRef();
 	const mutableRef = useRef({
 		hideIndex: null,
@@ -144,6 +145,12 @@ export const EditableIcon = (args) => {
 	const onFocusItem = useCallback((ev) => {
 		if (focusItem.current) {
 			focusItem.current(ev.target);
+		}
+	}, []);
+
+	const onMouseLeaveItem = useCallback((ev) => {
+		if (blurItem.current) {
+			blurItem.current(ev.target);
 		}
 	}, []);
 
@@ -239,6 +246,7 @@ export const EditableIcon = (args) => {
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
 							showItemFuncRef: showItem,
+							blurItemFuncRef: blurItem,
 							focusItemFuncRef: focusItem,
 							initialSelected: mutableRef.current.initialSelected,
 							selectItemBy: 'press'
@@ -259,7 +267,15 @@ export const EditableIcon = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
+									<div
+										aria-label={`Icon ${item.index}`}
+										className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})}
+										data-index={item.index}
+										disabled={item.iconItemProps['disabled'] || item.hidden}
+										key={item.index}
+										onMouseLeave={onMouseLeaveItem}
+										style={{order: index + 1}}
+									>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -235,6 +235,7 @@ export const EditableList = (args) => {
 	const hideItem = useRef();
 	const showItem = useRef();
 	const focusItem = useRef();
+	const blurItem = useRef();
 	const divRef = useRef();
 	const mutableRef = useRef({
 		hideIndex: null
@@ -280,6 +281,12 @@ export const EditableList = (args) => {
 		}
 	}, []);
 
+	const onMouseLeaveItem = useCallback((ev) => {
+		if (blurItem.current) {
+			blurItem.current(ev.target);
+		}
+	}, []);
+
 	const handleComplete = useCallback((ev) => {
 		const {orders, hideIndex} = ev;
 		mutableRef.current.hideIndex = hideIndex;
@@ -322,6 +329,7 @@ export const EditableList = (args) => {
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
 							showItemFuncRef: showItem,
+							blurItemFuncRef: blurItem,
 							focusItemFuncRef: focusItem,
 							selectItemBy: 'press'
 						}}
@@ -341,7 +349,14 @@ export const EditableList = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div
+										aria-label={`Image ${item.index}`}
+										className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})}
+										data-index={item.index}
+										key={item.index}
+										onMouseLeave={onMouseLeaveItem}
+										style={{order: index + 1}}
+									>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In edit mode, the focused item in Editable Scroller seems not properly blurred when the pointer leaves the item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The problem here is that there is `focusItemRef` to focus the IconItem by pointer but there is no way to blur it when the pointer leaves. Since we are manually adding `.focused` class by function.
So I added `blurItemRef` to get the function to blur the item and call it when the pointer leaves the item container.
If I call the function when the IconItem gets blurred, there is no way to select the additional button showing above (e.g. remove button).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I found the remove buttons of focused item remained when pressing 'up' key from the pointer resides in the empty space like below. So I added the condition to `handleGlobalKeyDownCapture` to make sure those icons are not showing.
![image](https://github.com/enactjs/sandstone/assets/5037429/cd43ae6b-4bcb-4527-a52b-673ae908279a)

### Links
[//]: # (Related issues, references)
WRQ-25442

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)