### PR TITLE
WRQ-25442: Fixed Editable Scroller to blur the focused item properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Scroller` `editable.blurItemFuncRef` prop to provide a function for blurring the focused item
+
 ## [2.9.0-beta.1] - 2024-06-17
 
 ### Added

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -1,6 +1,7 @@
 import {forwardCustom} from '@enact/core/handle';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';
+import {platform} from '@enact/core/platform';
 import {usePublicClassNames} from '@enact/core/usePublicClassNames';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getContainersForNode} from '@enact/spotlight/src/container';
@@ -139,6 +140,9 @@ const EditableWrapper = (props) => {
 
 		isDraggingItem: false,
 		isDragging: false,
+
+		// Flag for determining the key pressed from pointer mode
+		pressedKeyFromPointer: false,
 
 		// initialSelected
 		initialSelected: editable?.initialSelected
@@ -686,21 +690,35 @@ const EditableWrapper = (props) => {
 		}
 	}, [completeEditingByKeyDown]);
 
-	const handleGlobalKeyDownCapture = useCallback((ev) => {
-		if (getPointerMode() && !scrollContainerRef.current.contains(Spotlight.getCurrent()) && (mutableRef.current.selectedItem || mutableRef.current.focusedItem)) {
-			const {keyCode} = ev;
-			const position = getLastPointerPosition();
-			const direction = getDirection(keyCode);
-			if (direction) {
-				const nextTarget = getTargetByDirectionFromPosition(direction, position, mutableRef.current.spotlightId);
+	const finalizeForPointerHide = useCallback((keyCode) => {
+		const position = getLastPointerPosition();
+		const direction = getDirection(keyCode);
 
-				if (!scrollContainerRef.current.contains(nextTarget)) {
-					const orders = finalizeOrders();
-					finalizeEditing(orders);
-				}
+		if (direction) {
+			const nextTarget = getTargetByDirectionFromPosition(direction, position, mutableRef.current.spotlightId);
+
+			if (!scrollContainerRef.current.contains(nextTarget)) {
+				const orders = finalizeOrders();
+				finalizeEditing(orders);
 			}
 		}
 	}, [finalizeEditing, finalizeOrders, scrollContainerRef]);
+
+	const handleGlobalKeyDownCapture = useCallback(({keyCode}) => {
+		if (getPointerMode() && !scrollContainerRef.current.contains(Spotlight.getCurrent()) && (mutableRef.current.selectedItem || mutableRef.current.focusedItem)) {
+			if (platform.type === 'webos') {
+				// Set the flag when the key is from the pointer mode
+				if (is('pointerHide', keyCode)) {
+					mutableRef.current.pressedKeyFromPointer = true;
+				}
+			} else {
+				finalizeForPointerHide(keyCode);
+			}
+		} else if (mutableRef.current.pressedKeyFromPointer) {
+			mutableRef.current.pressedKeyFromPointer = false;
+			finalizeForPointerHide(keyCode);
+		}
+	}, [finalizeForPointerHide, scrollContainerRef]);
 
 	const handleTouchMove = useCallback((ev) => {
 		if (mutableRef.current.selectedItem) {

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -89,6 +89,7 @@ export const EditableIcon = (args) => {
 	const hideItem = useRef();
 	const showItem = useRef();
 	const focusItem = useRef();
+	const blurItem = useRef();
 	const divRef = useRef();
 	const mutableRef = useRef({
 		hideIndex: null,
@@ -144,6 +145,12 @@ export const EditableIcon = (args) => {
 	const onFocusItem = useCallback((ev) => {
 		if (focusItem.current) {
 			focusItem.current(ev.target);
+		}
+	}, []);
+
+	const onMouseLeaveItem = useCallback((ev) => {
+		if (blurItem.current) {
+			blurItem.current(ev.target);
 		}
 	}, []);
 
@@ -239,6 +246,7 @@ export const EditableIcon = (args) => {
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
 							showItemFuncRef: showItem,
+							blurItemFuncRef: blurItem,
 							focusItemFuncRef: focusItem,
 							initialSelected: mutableRef.current.initialSelected,
 							selectItemBy: 'press'
@@ -259,7 +267,15 @@ export const EditableIcon = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
+									<div
+										aria-label={`Icon ${item.index}`}
+										className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})}
+										data-index={item.index}
+										disabled={item.iconItemProps['disabled'] || item.hidden}
+										key={item.index}
+										onMouseLeave={onMouseLeaveItem}
+										style={{order: index + 1}}
+									>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -235,6 +235,7 @@ export const EditableList = (args) => {
 	const hideItem = useRef();
 	const showItem = useRef();
 	const focusItem = useRef();
+	const blurItem = useRef();
 	const divRef = useRef();
 	const mutableRef = useRef({
 		hideIndex: null
@@ -280,6 +281,12 @@ export const EditableList = (args) => {
 		}
 	}, []);
 
+	const onMouseLeaveItem = useCallback((ev) => {
+		if (blurItem.current) {
+			blurItem.current(ev.target);
+		}
+	}, []);
+
 	const handleComplete = useCallback((ev) => {
 		const {orders, hideIndex} = ev;
 		mutableRef.current.hideIndex = hideIndex;
@@ -322,6 +329,7 @@ export const EditableList = (args) => {
 							removeItemFuncRef: removeItem,
 							hideItemFuncRef: hideItem,
 							showItemFuncRef: showItem,
+							blurItemFuncRef: blurItem,
 							focusItemFuncRef: focusItem,
 							selectItemBy: 'press'
 						}}
@@ -341,7 +349,14 @@ export const EditableList = (args) => {
 						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})} aria-label={`Image ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+									<div
+										aria-label={`Image ${item.index}`}
+										className={classNames(css.itemWrapper, {[css.hidden]: item.disabled})}
+										data-index={item.index}
+										key={item.index}
+										onMouseLeave={onMouseLeaveItem}
+										style={{order: index + 1}}
+									>
 										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
 											{item.disabled ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.disabled ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In edit mode, the focused item in Editable Scroller seems not properly blurred when the pointer leaves the item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The problem here is that there is `focusItemRef` to focus the IconItem by pointer but there is no way to blur it when the pointer leaves. Since we are manually adding `.focused` class by function.
So I added `blurItemRef` to get the function to blur the item and call it when the pointer leaves the item container.
If I call the function when the IconItem gets blurred, there is no way to select the additional button showing above (e.g. remove button).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I found the remove buttons of focused item remained when pressing 'up' key from the pointer resides in the empty space like below. So I added the condition to `handleGlobalKeyDownCapture` to make sure those icons are not showing.
![image](https://github.com/enactjs/sandstone/assets/5037429/cd43ae6b-4bcb-4527-a52b-673ae908279a)
This PR is the same modification with https://github.com/enactjs/sandstone/pull/1628 based on `develop` branch.

### Links
[//]: # (Related issues, references)
WRQ-25442

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)