### PR TITLE
WRQ-24170: Fixed VirtualGridList qa sampler by passing args as a prop

### DIFF
--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -119,13 +119,17 @@ class MyVirtualList extends Component {
 					direction="vertical"
 					itemRenderer={this.renderItem}
 					itemSize={{minWidth: ri.scale(570), minHeight: ri.scale(156)}}
-					key={select('scrollMode', prop.scrollModeOption, Config)}
-					scrollMode={select('scrollMode', prop.scrollModeOption, Config)}
+					key={this.props.args['scrollMode']}
+					scrollMode={this.props.args['scrollMode']}
 				/>
 			</div>
 		);
 	}
 }
+
+MyVirtualList.propTypes = {
+	args: PropTypes.array
+};
 
 class ButtonAndVirtualGridList extends Component {
 	constructor (props) {
@@ -136,7 +140,7 @@ class ButtonAndVirtualGridList extends Component {
 	}
 
 	renderPopup = (rest) => {
-		return <MyVirtualList {...rest} closePopup={this.closePopup} />;
+		return <MyVirtualList {...rest} closePopup={this.closePopup} args={this.props.args} />;
 	};
 
 	openPopup = () => {
@@ -166,6 +170,7 @@ class ButtonAndVirtualGridList extends Component {
 }
 
 ButtonAndVirtualGridList.propTypes = {
+	args: PropTypes.array,
 	rtl: PropTypes.bool
 };
 
@@ -221,7 +226,7 @@ HorizontalVirtualGridList.parameters = {
 	propTables: [Config]
 };
 
-export const WithButtonSpotlightGoesToCorrectTarget = () => <ButtonAndVirtualGridListSamples />;
+export const WithButtonSpotlightGoesToCorrectTarget = (args) => <ButtonAndVirtualGridListSamples args={args} />;
 
 WithButtonSpotlightGoesToCorrectTarget.storyName = 'with Button, Spotlight goes to correct target';
 WithButtonSpotlightGoesToCorrectTarget.parameters = {
@@ -229,6 +234,8 @@ WithButtonSpotlightGoesToCorrectTarget.parameters = {
 		hideNoControlsWarning: true
 	}
 };
+
+select('scrollMode', WithButtonSpotlightGoesToCorrectTarget, prop.scrollModeOption, Config);
 
 export const HorizontalSquaredVirtualGridList = (args) => (
 	<VirtualGridList

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -134,14 +134,13 @@ MyVirtualList.propTypes = {
 class ButtonAndVirtualGridList extends Component {
 	constructor (props) {
 		super(props);
-		this.scrollMode = props.scrollMode;
 		this.state = {
 			isPopup: false
 		};
 	}
 
 	renderPopup = (rest) => {
-		return <MyVirtualList {...rest} closePopup={this.closePopup} scrollMode={this.scrollMode} />;
+		return <MyVirtualList {...rest} closePopup={this.closePopup} scrollMode={this.props.scrollMode} />;
 	};
 
 	openPopup = () => {

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -84,6 +84,11 @@ const ContextualPopupButton = ContextualPopupDecorator(Button);
 let lastIndex = 0;
 
 class MyVirtualList extends Component {
+	constructor (props) {
+		super();
+		this.scrollMode = props.scrollMode;
+
+	}
 	componentDidMount () {
 		this.scrollTo({index: lastIndex, animate: false, focus: true});
 	}
@@ -110,6 +115,7 @@ class MyVirtualList extends Component {
 	render () {
 		let props = {...this.props};
 		delete props.closePopup;
+		delete props.scrollMode;
 
 		return (
 			<div {...props} style={{width: ri.scaleToRem(1830), height: ri.scaleToRem(1200)}}>
@@ -119,8 +125,8 @@ class MyVirtualList extends Component {
 					direction="vertical"
 					itemRenderer={this.renderItem}
 					itemSize={{minWidth: ri.scale(570), minHeight: ri.scale(156)}}
-					key={this.props.args['scrollMode']}
-					scrollMode={this.props.args['scrollMode']}
+					key={this.scrollMode}
+					scrollMode={this.scrollMode}
 				/>
 			</div>
 		);
@@ -128,19 +134,20 @@ class MyVirtualList extends Component {
 }
 
 MyVirtualList.propTypes = {
-	args: PropTypes.array
+	scrollMode: PropTypes.string
 };
 
 class ButtonAndVirtualGridList extends Component {
 	constructor (props) {
 		super(props);
+		this.scrollMode = props.scrollMode;
 		this.state = {
 			isPopup: false
 		};
 	}
 
 	renderPopup = (rest) => {
-		return <MyVirtualList {...rest} closePopup={this.closePopup} args={this.props.args} />;
+		return <MyVirtualList {...rest} closePopup={this.closePopup} scrollMode={this.scrollMode}/>;
 	};
 
 	openPopup = () => {
@@ -152,6 +159,9 @@ class ButtonAndVirtualGridList extends Component {
 	};
 
 	render () {
+		let props = {...this.props};
+		delete props.scrollMode;
+
 		return (
 			<div>
 				<ContextualPopupButton
@@ -170,8 +180,8 @@ class ButtonAndVirtualGridList extends Component {
 }
 
 ButtonAndVirtualGridList.propTypes = {
-	args: PropTypes.array,
-	rtl: PropTypes.bool
+	rtl: PropTypes.bool,
+	scrollMode: PropTypes.string
 };
 
 const ButtonAndVirtualGridListSamples = I18nContextDecorator (
@@ -226,7 +236,7 @@ HorizontalVirtualGridList.parameters = {
 	propTables: [Config]
 };
 
-export const WithButtonSpotlightGoesToCorrectTarget = (args) => <ButtonAndVirtualGridListSamples args={args} />;
+export const WithButtonSpotlightGoesToCorrectTarget = (args) => <ButtonAndVirtualGridListSamples scrollMode={args['scrollMode']} />;
 
 WithButtonSpotlightGoesToCorrectTarget.storyName = 'with Button, Spotlight goes to correct target';
 WithButtonSpotlightGoesToCorrectTarget.parameters = {

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -84,11 +84,6 @@ const ContextualPopupButton = ContextualPopupDecorator(Button);
 let lastIndex = 0;
 
 class MyVirtualList extends Component {
-	constructor (props) {
-		super();
-		this.scrollMode = props.scrollMode;
-
-	}
 	componentDidMount () {
 		this.scrollTo({index: lastIndex, animate: false, focus: true});
 	}
@@ -113,9 +108,8 @@ class MyVirtualList extends Component {
 	};
 
 	render () {
-		let props = {...this.props};
+		let {scrollMode, ...props} = this.props;
 		delete props.closePopup;
-		delete props.scrollMode;
 
 		return (
 			<div {...props} style={{width: ri.scaleToRem(1830), height: ri.scaleToRem(1200)}}>
@@ -125,8 +119,8 @@ class MyVirtualList extends Component {
 					direction="vertical"
 					itemRenderer={this.renderItem}
 					itemSize={{minWidth: ri.scale(570), minHeight: ri.scale(156)}}
-					key={this.scrollMode}
-					scrollMode={this.scrollMode}
+					key={scrollMode}
+					scrollMode={scrollMode}
 				/>
 			</div>
 		);
@@ -159,8 +153,6 @@ class ButtonAndVirtualGridList extends Component {
 	};
 
 	render () {
-		let props = {...this.props};
-		delete props.scrollMode;
 
 		return (
 			<div>

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -108,7 +108,7 @@ class MyVirtualList extends Component {
 	};
 
 	render () {
-		let {scrollMode, ...props} = this.props;
+		const {scrollMode, ...rest} = this.props;
 		delete props.closePopup;
 
 		return (

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -228,14 +228,14 @@ HorizontalVirtualGridList.parameters = {
 
 export const WithButtonSpotlightGoesToCorrectTarget = (args) => <ButtonAndVirtualGridListSamples scrollMode={args['scrollMode']} />;
 
+select('scrollMode', WithButtonSpotlightGoesToCorrectTarget, prop.scrollModeOption, Config);
+
 WithButtonSpotlightGoesToCorrectTarget.storyName = 'with Button, Spotlight goes to correct target';
 WithButtonSpotlightGoesToCorrectTarget.parameters = {
 	controls: {
 		hideNoControlsWarning: true
 	}
 };
-
-select('scrollMode', WithButtonSpotlightGoesToCorrectTarget, prop.scrollModeOption, Config);
 
 export const HorizontalSquaredVirtualGridList = (args) => (
 	<VirtualGridList

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -153,7 +153,6 @@ class ButtonAndVirtualGridList extends Component {
 	};
 
 	render () {
-
 		return (
 			<div>
 				<ContextualPopupButton

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -109,10 +109,10 @@ class MyVirtualList extends Component {
 
 	render () {
 		const {scrollMode, ...rest} = this.props;
-		delete props.closePopup;
+		delete rest.closePopup;
 
 		return (
-			<div {...props} style={{width: ri.scaleToRem(1830), height: ri.scaleToRem(1200)}}>
+			<div {...rest} style={{width: ri.scaleToRem(1830), height: ri.scaleToRem(1200)}}>
 				<VirtualGridList
 					cbScrollTo={this.getScrollTo}
 					dataSize={itemList.length}

--- a/samples/sampler/stories/qa/VirtualGridList.js
+++ b/samples/sampler/stories/qa/VirtualGridList.js
@@ -147,7 +147,7 @@ class ButtonAndVirtualGridList extends Component {
 	}
 
 	renderPopup = (rest) => {
-		return <MyVirtualList {...rest} closePopup={this.closePopup} scrollMode={this.scrollMode}/>;
+		return <MyVirtualList {...rest} closePopup={this.closePopup} scrollMode={this.scrollMode} />;
 	};
 
 	openPopup = () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In qa-sampler > VirtualGridList > `with Button, Spotlight goes to correct target`, scroll with wheel did not work.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`scrollMode` value of VirtualGridList in the sample was `undefined` and this caused the issue.
I added control of `scrollMode`, which have `native` and `translate` value, so `scrollMode` value is passed into VirtualGridList and wheel works well.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-24170

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)