### PR TITLE
WRQ-17541: Fix Marquee to not override marqueeDirection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=feature/WRQ-17541 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/enact_v5 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ before_install:
 install:
     - npm config set prefer-offline false
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
+    - git clone --branch=feature/enact_v5 --depth 1 https://github.com/enactjs/cli ../cli
     - pushd ../cli
     - npm install
     - npm link
     - popd
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRQ-17541 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/Marquee/Marquee.js
+++ b/Marquee/Marquee.js
@@ -20,7 +20,7 @@ import {
 	MarqueeDecorator as UiMarqueeDecorator
 } from '@enact/ui/Marquee';
 
-const MarqueeDecorator = hoc(null, (config, Wrapped) => {
+const MarqueeDecorator = hoc((config, Wrapped) => {
 	return I18nContextDecorator(
 		{rtlProp: 'rtl', localeProp: 'locale'},
 		UiMarqueeDecorator(

--- a/Marquee/Marquee.js
+++ b/Marquee/Marquee.js
@@ -12,26 +12,18 @@
  * @exports MarqueeDecorator
  */
 
-import hoc from '@enact/core/hoc';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
-import {isRtlText} from '@enact/i18n/util';
 import {
 	MarqueeBase,
 	MarqueeController,
 	MarqueeDecorator as UiMarqueeDecorator
 } from '@enact/ui/Marquee';
+import compose from 'ramda/src/compose';
 
-const MarqueeDecorator = hoc({
-	marqueeDirection: (str) => isRtlText(str) ? 'rtl' : 'ltr'
-}, (config, Wrapped) => {
-	return I18nContextDecorator(
-		{rtlProp: 'rtl', localeProp: 'locale'},
-		UiMarqueeDecorator(
-			config,
-			Wrapped
-		)
-	);
-});
+const MarqueeDecorator = compose(
+    I18nContextDecorator({rtlProp: 'rtl', localeProp: 'locale'}),
+    UiMarqueeDecorator
+);
 
 const Marquee = MarqueeDecorator('div');
 

--- a/Marquee/Marquee.js
+++ b/Marquee/Marquee.js
@@ -12,18 +12,23 @@
  * @exports MarqueeDecorator
  */
 
+import hoc from '@enact/core/hoc';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {
 	MarqueeBase,
 	MarqueeController,
 	MarqueeDecorator as UiMarqueeDecorator
 } from '@enact/ui/Marquee';
-import compose from 'ramda/src/compose';
 
-const MarqueeDecorator = compose(
-    I18nContextDecorator({rtlProp: 'rtl', localeProp: 'locale'}),
-    UiMarqueeDecorator
-);
+const MarqueeDecorator = hoc(null, (config, Wrapped) => {
+	return I18nContextDecorator(
+		{rtlProp: 'rtl', localeProp: 'locale'},
+		UiMarqueeDecorator(
+			config,
+			Wrapped
+		)
+	);
+});
 
 const Marquee = MarqueeDecorator('div');
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix `Marquee` to not override `marqueeDirection`(that code moved to `@enact/ui/Marquee.MarqueeDecorator`)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove `marqueeDirection` override in `Marquee`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ-17541

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)