### PR TITLE
WRQ-27016: Fix PageViews styling as GUI guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `sandstone/PageViews` styling to match the latest GUI
+
 ### Fixed
 
 - `sandstone/Input` back button to be disabled when `disabled` prop is `true`

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -202,7 +202,7 @@ const PageViewsBase = kind({
 			};
 			return (
 				<Cell className={css.navButton} shrink>
-					{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} style={navigationButtonStyle} size="small" /> : null}
+					{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} size="small" style={navigationButtonStyle} /> : null}
 				</Cell>
 			);
 		},
@@ -213,7 +213,7 @@ const PageViewsBase = kind({
 			};
 			return (
 				<Cell className={css.navButton} shrink>
-					{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} style={navigationButtonStyle} size="small" /> : null}
+					{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} size="small" style={navigationButtonStyle} /> : null}
 				</Cell>
 			);
 		},

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -202,7 +202,7 @@ const PageViewsBase = kind({
 			};
 			return (
 				<Cell className={css.navButton} shrink>
-					{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} style={navigationButtonStyle} /> : null}
+					{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} style={navigationButtonStyle} size="small" /> : null}
 				</Cell>
 			);
 		},
@@ -213,7 +213,7 @@ const PageViewsBase = kind({
 			};
 			return (
 				<Cell className={css.navButton} shrink>
-					{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} style={navigationButtonStyle} /> : null}
+					{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} style={navigationButtonStyle} size="small" /> : null}
 				</Cell>
 			);
 		},
@@ -253,11 +253,11 @@ const PageViewsBase = kind({
 						</Row> :
 						<Row className={css.steps}>
 							<Cell className={css.navButton} shrink>
-								{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowsmallleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} size="small" /> : null}
+								{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} size="small" /> : null}
 							</Cell>
 							<Cell className={css.pageNumber} shrink>{index + 1}</Cell><Cell className={css.separator} shrink>/</Cell><Cell className={css.pageNumber} shrink>{totalIndex}</Cell>
 							<Cell className={css.navButton} shrink>
-								{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowsmallright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} size="small" /> : null}
+								{isNextButtonVisible ? <Button aria-label={$L('Next')} icon="arrowlargeright" iconFlip="auto" id="NextNavButton" onClick={onNextClick} size="small" /> : null}
 							</Cell>
 						</Row>}
 				</>

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -6,16 +6,16 @@
 	display: inline-flex;
 	flex-direction: column;
 
-    .navButton {
+	.navButton {
 		text-align: center;
 		display: flex;
 		align-items: center;
-		width: 216px;
+		width: @sand-pageviews-navigation-button-area-width;
 		justify-content: center;
 	}
 
 	&.number .navButton {
-		width: 108px;
+		width: @sand-pageviews-number-navigation-button-area-width;
 	}
 
 	.steps {
@@ -23,30 +23,30 @@
 		justify-content: center;
 		text-align: center;
 		&.hidden {
-			min-height: 132px;
+			min-height: @sand-pageviews-steps-area-min-height;
 			visibility: hidden;
 		}
 	}
 
 	&.number .steps {
-		min-height: 252px;
+		min-height: @sand-pageviews-number-steps-area-min-height;
 		.pageNumber {
-			width: 126px;
+			width: @sand-pageviews-number-steps-number-width;
 		}
 		.separator {
-			width: 60px;
+			width: @sand-pageviews-number-steps-separator-width;
 		}
 	}
 
 	&.dot .steps {
-		min-height: 132px;
+		min-height: @sand-pageviews-dot-steps-area-min-height;
 	}
 
 	&.fullContents .steps {
 		position: absolute;
 		align-self: center;
-		bottom: 0px;
-		min-height: 132px;
+		bottom: @sand-pageviews-full-steps-position-bottom;
+		min-height: @sand-pageviews-full-steps-area-min-height;
 	}
 
 	.contentsArea {

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -14,6 +14,10 @@
 		justify-content: center;
 	}
 
+	&.number .navButton {
+		width: 108px;
+	}
+
 	.steps {
 		align-items: center;
 		justify-content: center;

--- a/PageViews/tests/PageViews-specs.js
+++ b/PageViews/tests/PageViews-specs.js
@@ -63,7 +63,7 @@ describe('PageViews Specs', () => {
 		'should show previous button and hide next button on the last page when pageIndicatorType is `number`',
 		() => {
 			render(
-				<PageViews index={1}>
+				<PageViews pageIndicatorType="number" index={1}>
 					<Page>I gots contents</Page>
 					<Page>I gots contents</Page>
 				</PageViews>

--- a/PageViews/tests/PageViews-specs.js
+++ b/PageViews/tests/PageViews-specs.js
@@ -24,7 +24,43 @@ describe('PageViews Specs', () => {
 	);
 
 	test(
+		'should show next button and hide previous button on the first page when pageIndicatorType is `number`',
+		() => {
+			render(
+				<PageViews pageIndicatorType="number" index={0}>
+					<Page>I gots contents</Page>
+					<Page>I gots contents</Page>
+				</PageViews>
+			);
+
+			const nextButton = screen.getByLabelText('Next');
+			const prevButton = screen.queryByLabelText('Previous');
+
+			expect(nextButton).toBeInTheDocument();
+			expect(prevButton).toBeNull();
+		}
+	);
+
+	test(
 		'should show previous button and hide next button on the last page',
+		() => {
+			render(
+				<PageViews index={1}>
+					<Page>I gots contents</Page>
+					<Page>I gots contents</Page>
+				</PageViews>
+			);
+
+			const prevButton = screen.getByLabelText('Previous');
+			const nextButton = screen.queryByLabelText('Next');
+
+			expect(prevButton).toBeInTheDocument();
+			expect(nextButton).toBeNull();
+		}
+	);
+
+	test(
+		'should show previous button and hide next button on the last page when pageIndicatorType is `number`',
 		() => {
 			render(
 				<PageViews index={1}>

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -759,6 +759,18 @@
 @sand-mediaplayer-slider-knob-size: 48px;
 @sand-mediaplayer-slider-tap-area: 162px;
 
+// PageViews
+// ---------------------------------------
+@sand-pageviews-navigation-button-area-width: 216px;
+@sand-pageviews-steps-area-min-height: 132px;
+@sand-pageviews-dot-steps-area-min-height: @sand-pageviews-steps-area-min-height;
+@sand-pageviews-full-steps-area-min-height: @sand-pageviews-steps-area-min-height;
+@sand-pageviews-full-steps-position-bottom: 0;
+@sand-pageviews-number-navigation-button-area-width: 108px;
+@sand-pageviews-number-steps-area-min-height: 252px;
+@sand-pageviews-number-steps-number-width: 126px;
+@sand-pageviews-number-steps-separator-width: 60px;
+
 // Panels
 // ---------------------------------------
 @sand-panel-padding: 0;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
According to the recent GUI guide, prev and next navigation buttons seem to be `small` type buttons and icons are `arrowlargeleft` and `arrowlargeright`. 


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I updated prev and next navigation buttons to `small` type when `pageIndicatorType` is `dot`.
I updated prev and next navigation buttons icons to be `arrowlargelft` and `arrowlargeright`.
### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I modified PageViews.module.less to update navigation button width when `pageIndicatorType` is `number`.
According to the GUI guide, it appears that `width: 216px` should only apply to `dot` type.

### Links
[//]: # (Related issues, references)
WRQ-27016

### Comments
