### PR TITLE
WRQ-28743: Storybook - Read custom colors/presets from luna settings service

### DIFF
--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -26,6 +26,7 @@
     "@enact/spotlight": "^4.9.0-beta.1",
     "@enact/storybook-utils": "^5.1.4",
     "@enact/ui": "^4.9.0-beta.1",
+    "@enact/webos": "^4.9.0-beta.1",
     "@storybook/addons": "^6.5.16",
     "@storybook/builder-webpack5": "^6.5.16",
     "@storybook/manager-webpack5": "^6.5.16",

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -91,7 +91,7 @@ const StorybookDecorator = (story, config = {}) => {
 						document.body?.appendChild(sheet);
 					}
 				}
-			})
+			});
 		}
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
 	// <--- end of custom theme code

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -4,7 +4,10 @@ import classnames from 'classnames';
 import kind from '@enact/core/kind';
 import {Panels, Panel, Header} from '@enact/sandstone/Panels';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
+import LS2Request from '@enact/webos/LS2Request';
+import {platform} from '@enact/webos/platform';
 import PropTypes from 'prop-types';
+import {useEffect} from 'react';
 
 import css from './ThemeEnvironment.module.less';
 
@@ -64,6 +67,34 @@ const StorybookDecorator = (story, config = {}) => {
 	if (Object.keys(classes).length > 0) {
 		classes.debug = true;
 	}
+
+	// ---> beginning of custom theme code
+	const request = new LS2Request();
+
+	useEffect(() => {
+		if (platform.tv) {
+			request.send({
+				service: 'luna://com.webos.service.settings/',
+				method: 'getSystemSettings',
+				parameters: {
+					category: 'customUi',
+					keys: ['theme']
+				},
+				subscribe: true,
+				onSuccess: (res) => {
+					// Create a new style sheet and append fetched colors on it
+					if (typeof document !== 'undefined') {
+						const sheet = document.createElement('style');
+						sheet.id = 'custom-skin';
+						sheet.innerHTML = JSON.parse(res.settings.theme).colors;
+						document.getElementById('custom-skin')?.remove();
+						document.body?.appendChild(sheet);
+					}
+				}
+			})
+		}
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+	// <--- end of custom theme code
 
 	return (
 		<Theme

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -68,12 +68,10 @@ const StorybookDecorator = (story, config = {}) => {
 		classes.debug = true;
 	}
 
-	// ---> beginning of custom theme code
-	const request = new LS2Request();
-
+	/* Custom theme support */
 	useEffect(() => {
 		if (platform.tv) {
-			request.send({
+			new LS2Request().send({
 				service: 'luna://com.webos.service.settings/',
 				method: 'getSystemSettings',
 				parameters: {
@@ -90,11 +88,11 @@ const StorybookDecorator = (story, config = {}) => {
 						document.getElementById('custom-skin')?.remove();
 						document.body?.appendChild(sheet);
 					}
-				}
+				},
+				onFailure: () => {} // prevent warning on unsupported platforms
 			});
 		}
-	}, []); // eslint-disable-line react-hooks/exhaustive-deps
-	// <--- end of custom theme code
+	}, []);
 
 	return (
 		<Theme

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -68,7 +68,7 @@ const StorybookDecorator = (story, config = {}) => {
 		classes.debug = true;
 	}
 
-	/* Custom theme support */
+	/* Custom theme support for the webOS device only */
 	useEffect(() => {
 		if (platform.tv) {
 			new LS2Request().send({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Storybook reads and applies colors fetched from service settings

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Storybook reads and applies colors fetched from service settings

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Added `@enact/webos` as sampler dependency

### Links
[//]: # (Related issues, references)
WRQ-28743

### Comments
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com