### PR TITLE
WRQ-27279: Added x of y feature to VirtualList and VirtualGridList qa-a11y samples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: node_js
 node_js:
     - lts/*

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -93,7 +93,7 @@ const VirtualGridListView = () => {
 					onToggle={handleToggleRole}
 					selected={role}
 				>
-					X of Y feature
+					Read X of Y
 				</CheckboxItem>
 			</Cell>
 			<VirtualGridList

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -32,6 +32,23 @@ const renderItem = ({index, ...rest}) => {
 	);
 };
 
+// eslint-disable-next-line enact/prop-types
+const renderItemWithRole = ({index, ...rest}) => {
+	const {caption, label, src} = items[index];
+	return (
+		<ImageItem
+			aria-posinset={index + 1}
+			aria-setsize={items.length}
+			label={label}
+			role="listitem"
+			src={src}
+			{...rest}
+		>
+			{caption}
+		</ImageItem>
+	);
+};
+
 for (let i = 0; i < 100; i++) {
 	const
 		count = ('00' + i).slice(-3),
@@ -50,10 +67,12 @@ for (let i = 0; i < 100; i++) {
 const VirtualGridListView = () => {
 	const [native, setNative] = useState(true);
 	const [horizontal, setHorizontal] = useState(false);
+	const [role, setRole] = useState(false);
 	const scrollMode = native ? 'native' : 'translate';
 
 	const handleToggleScrollMode = () => setNative(!native);
 	const handleToggleOrientation = () => setHorizontal(!horizontal);
+	const handleToggleRole = () => setRole(!role);
 
 	return (
 		<Layout orientation="vertical">
@@ -70,12 +89,18 @@ const VirtualGridListView = () => {
 				>
 					Native
 				</CheckboxItem>
+				<CheckboxItem
+					onToggle={handleToggleRole}
+					selected={role}
+				>
+					X of Y feature
+				</CheckboxItem>
 			</Cell>
 			<VirtualGridList
 				className={horizontal ? css.horizontalPadding : css.verticalPadding}
 				dataSize={items.length}
 				direction={horizontal ? 'horizontal' : 'vertical'}
-				itemRenderer={renderItem}
+				itemRenderer={role ? renderItemWithRole : renderItem}
 				itemSize={{
 					minWidth: ri.scale(678), // 606px(size of expanded ImageItem) + 36px(for shadow) * 2
 					minHeight: ri.scale(678) // 606px(size of expanded ImageItem) + 36px(for shadow) * 2

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -15,15 +15,29 @@ const renderItem = ({index, ...rest}) => (
 	</Item>
 );
 
+// eslint-disable-next-line enact/prop-types
+const renderItemWithRole = ({index, ...rest}) => (
+	<Item
+		aria-posinset={index + 1}
+		aria-setsize={items.length}
+		role="listitem"
+		{...rest}
+	>
+		{items[index]}
+	</Item>
+);
+
 for (let i = 0; i < 100; i++) {
 	items.push('Item ' + ('00' + i).slice(-3));
 }
 
 const VirtualListView = () => {
 	const [native, setNative] = useState(true);
+	const [role, setRole] = useState(false);
 	const scrollMode = native ? 'native' : 'translate';
 
 	const handleToggleScrollMode = () => setNative(!native);
+	const handleToggleRole = () => setRole(!role);
 
 	return (
 		<Layout orientation="vertical">
@@ -34,10 +48,16 @@ const VirtualListView = () => {
 				>
 					Native
 				</CheckboxItem>
+				<CheckboxItem
+					onClick={handleToggleRole}
+					selected={role}
+				>
+					X of Y feature
+				</CheckboxItem>
 			</Cell>
 			<VirtualList
 				dataSize={items.length}
-				itemRenderer={renderItem}
+				itemRenderer={role ? renderItemWithRole : renderItem}
 				itemSize={ri.scale(156)}
 				scrollMode={scrollMode}
 			/>

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -52,7 +52,7 @@ const VirtualListView = () => {
 					onClick={handleToggleRole}
 					selected={role}
 				>
-					X of Y feature
+					Read X of Y
 				</CheckboxItem>
 			</Cell>
 			<VirtualList


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/enact/pull/3260, we added support for reading the order of items in VirtualList and VirtualGridList.
So I added qa-a11y samples for this added feature in VirtualList and VirtualGridList. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add x of y feature in VirtualList and VritualGridList qa-a11y sample

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-27279

### Comments
