### PR TITLE
WRQ-27436: Added public classes to expand size of title and content in Alert

### DIFF
--- a/Alert/Alert.js
+++ b/Alert/Alert.js
@@ -23,7 +23,7 @@ import Popup from '../Popup';
 
 import AlertImage from './AlertImage';
 
-import css from './Alert.module.less';
+import componentCss from './Alert.module.less';
 
 /**
  * A modal Alert component.
@@ -63,6 +63,22 @@ const AlertBase = kind({
 		 * @public
 		 */
 		children: PropTypes.node,
+
+		/**
+		 * Customizes the component by mapping the supplied collection of CSS class names to the
+		 * corresponding internal elements and states of this component.
+		 *
+		 * The following classes are supported:
+		 *
+		 * * `alert` - The root class name
+		 * * `content` - The content component class
+		 * * `fullscreen` - Applied to a `type='fullscreen'` alert
+		 * * `title` - The title component class
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		css: PropTypes.object,
 
 		/**
 		 * The `id` of Alert referred to when generating ids for `'title'` and `'buttons'`.
@@ -140,12 +156,13 @@ const AlertBase = kind({
 	},
 
 	styles: {
-		css,
-		className: 'alert'
+		css: componentCss,
+		className: 'alert',
+		publicClassName: ['alert', 'content', 'fullscreen', 'title']
 	},
 
 	computed: {
-		buttons: ({buttons}) => {
+		buttons: ({buttons, css}) => {
 			return mapAndFilterChildren(buttons, (button, index) => (
 				<Cell className={css.buttonCell} key={`button${index}`} shrink>
 					{button}
@@ -179,7 +196,7 @@ const AlertBase = kind({
 		}
 	},
 
-	render: ({buttons, contentComponent, children, id, image, overflow, title, type, ...rest}) => {
+	render: ({buttons, contentComponent, children, css, id, image, overflow, title, type, ...rest}) => {
 		const fullscreen = (type === 'fullscreen');
 		const position = (type === 'overlay' ? 'bottom' : type);
 		const showTitle = (fullscreen && title);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Added
+
+- `sandstone/Alert` public class names `alert`, `content`, `fullscreen`, and `title`
+
 ## [2.9.0] - 2024-07-17
 
 ### Added

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -18,7 +18,7 @@ const fullscreenTests = [
 	<Alert open title="Title" />,
 	<Alert open>Alert!</Alert>,
 	<Alert open>{LoremString}</Alert>,
-	<Alert open title="Loooooooooooooooooooooong Title with custom width" css={css}>{LoremString}</Alert>
+	<Alert open title="Loooooooooooooooooooooong title with custom width" css={css}>{LoremString}</Alert>
 ];
 
 // Only type: 'overlay' supports children

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -18,7 +18,6 @@ const fullscreenTests = [
 	<Alert open title="Title" />,
 	<Alert open>Alert!</Alert>,
 	<Alert open>{LoremString}</Alert>,
-	<Alert open>{LoremString}</Alert>,
 	<Alert open title="Loooooooooooooooooooooong Title with custom width" css={css}>{LoremString}</Alert>
 ];
 

--- a/tests/screenshot/apps/components/Alert.js
+++ b/tests/screenshot/apps/components/Alert.js
@@ -11,12 +11,15 @@ import img from '../../images/300x300.png';
 
 import {withConfig, withProps, LoremString} from './utils';
 
+import css from './Alert.module.less';
 
 // Only type: 'fullscreen' supports title prop
 const fullscreenTests = [
 	<Alert open title="Title" />,
 	<Alert open>Alert!</Alert>,
-	<Alert open>{LoremString}</Alert>
+	<Alert open>{LoremString}</Alert>,
+	<Alert open>{LoremString}</Alert>,
+	<Alert open title="Loooooooooooooooooooooong Title with custom width" css={css}>{LoremString}</Alert>
 ];
 
 // Only type: 'overlay' supports children

--- a/tests/screenshot/apps/components/Alert.module.less
+++ b/tests/screenshot/apps/components/Alert.module.less
@@ -1,0 +1,8 @@
+.alert {
+	&.fullscreen {
+		.title,
+		.content {
+			max-width: 100%;
+		}
+	}
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We decided to provide a public class to expand size of title and content in Alert so that full text can be shown wider on the screen.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added public classes to Alert.

- alert
- fullscreen
- title
- content

Title and content width can be expanded using these public classes.

This PR is for sandstone 2.9 and copied from https://github.com/enactjs/sandstone/pull/1652

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-27436

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)