### PR TITLE
WRQ-32437: Fixed deletion of favorite colors for ColorPicker

### DIFF
--- a/ColorPickerPOC/ColorPickerPOC.js
+++ b/ColorPickerPOC/ColorPickerPOC.js
@@ -17,6 +17,7 @@ import ColorPickerSpectrum from './ColorPickerSpectrum';
 import {generateOppositeColor} from './utils';
 
 import componentsCss from './ColorPickerPOC.module.less';
+import Spotlight, {getDirection} from "../../enact/packages/spotlight";
 
 const SpottableButton = Spottable(ButtonBase);
 
@@ -90,6 +91,35 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 		}, 100);
 	}, []);
 
+	const handleKeyDown = useCallback((ev) => {
+		if(ev.keyCode === 13) {
+			const target = ev.target.id ? ev.target : ev.target.offsetParent;
+
+			shakeEffectRef.current = setTimeout(() => {
+				target.classList.add(componentsCss.shakeFavoriteColor);
+			}, 300);
+
+			timerRef.current = setTimeout(() => {
+				setEditEnabled(true);
+				setClickEnabled(false);
+				target.classList.remove(componentsCss.shakeFavoriteColor);
+			}, 1000);
+		}
+	}, [editEnabled]);
+
+	const handleKeyUp = useCallback((ev) => {
+		if(ev.keyCode === 13) {
+			const target = ev.target.id ? ev.target : ev.target.offsetParent;
+			target.classList.remove(componentsCss.shakeFavoriteColor);
+
+			clearTimeout(shakeEffectRef.current);
+			clearTimeout(timerRef.current);
+			setTimeout(() => {
+				setClickEnabled(true);
+			}, 100);
+		}
+	}, []);
+
 	return (
 		<div>
 			<Row className={componentsCss.favoriteColorsRow}>
@@ -102,6 +132,8 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 								key={`${color}_${index + 4}`}
 								minWidth={false}
 								onClick={onSelectFavoriteColor}
+								onKeyDown={handleKeyDown}
+								onKeyUp={handleKeyUp}
 								onPointerDown={onPressHandler}
 								onPointerUp={onReleaseHandler}
 								size="small"
@@ -125,6 +157,8 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 								key={`${color}_${index}`}
 								minWidth={false}
 								onClick={onSelectFavoriteColor}
+								onKeyDown={handleKeyDown}
+								onKeyUp={handleKeyUp}
 								onPointerDown={onPressHandler}
 								onPointerUp={onReleaseHandler}
 								size="small"

--- a/ColorPickerPOC/ColorPickerPOC.js
+++ b/ColorPickerPOC/ColorPickerPOC.js
@@ -173,10 +173,10 @@ const ColorPickerPOCBase = ({color = '#eb4034', colors = [], css, onChangeColor,
 	const [favoriteColors, setFavoriteColors] = useState(colors);
 	const [selectedColor, setSelectedColor] = useState(color);
 
-	// useEffect(() => {
-	// 	setSelectedColor(color);
-	// 	setFavoriteColors(colors);
-	// }, [color, colors]);
+	useEffect(() => {
+		setSelectedColor(color);
+		setFavoriteColors(colors);
+	}, [color, colors]);
 
 	useEffect(() => {
 		if (selectedColor || favoriteColors) {

--- a/ColorPickerPOC/ColorPickerPOC.js
+++ b/ColorPickerPOC/ColorPickerPOC.js
@@ -102,8 +102,6 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 								key={`${color}_${index + 4}`}
 								minWidth={false}
 								onClick={onSelectFavoriteColor}
-								onMouseDown={onPressHandler}
-								onMouseUp={onReleaseHandler}
 								onPointerDown={onPressHandler}
 								onPointerUp={onReleaseHandler}
 								size="small"
@@ -127,8 +125,6 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 								key={`${color}_${index}`}
 								minWidth={false}
 								onClick={onSelectFavoriteColor}
-								onMouseDown={onPressHandler}
-								onMouseUp={onReleaseHandler}
 								onPointerDown={onPressHandler}
 								onPointerUp={onReleaseHandler}
 								size="small"
@@ -176,6 +172,11 @@ FavoriteColors.propTypes = {
 const ColorPickerPOCBase = ({color = '#eb4034', colors = [], css, onChangeColor, open, ...rest}) => {
 	const [favoriteColors, setFavoriteColors] = useState(colors);
 	const [selectedColor, setSelectedColor] = useState(color);
+
+	// useEffect(() => {
+	// 	setSelectedColor(color);
+	// 	setFavoriteColors(colors);
+	// }, [color, colors]);
 
 	useEffect(() => {
 		if (selectedColor || favoriteColors) {

--- a/ColorPickerPOC/ColorPickerPOC.js
+++ b/ColorPickerPOC/ColorPickerPOC.js
@@ -17,7 +17,6 @@ import ColorPickerSpectrum from './ColorPickerSpectrum';
 import {generateOppositeColor} from './utils';
 
 import componentsCss from './ColorPickerPOC.module.less';
-import Spotlight, {getDirection} from "../../enact/packages/spotlight";
 
 const SpottableButton = Spottable(ButtonBase);
 
@@ -67,32 +66,7 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 
 	const onPressHandler = useCallback((ev) => {
 		if (editEnabled) return;
-		const target = ev.target.id ? ev.target : ev.target.offsetParent;
-
-		shakeEffectRef.current = setTimeout(() => {
-			target.classList.add(componentsCss.shakeFavoriteColor);
-		}, 300);
-
-		timerRef.current = setTimeout(() => {
-			setEditEnabled(true);
-			setClickEnabled(false);
-			target.classList.remove(componentsCss.shakeFavoriteColor);
-		}, 1000);
-	}, [editEnabled]);
-
-	const onReleaseHandler = useCallback((ev) => {
-		const target = ev.target.id ? ev.target : ev.target.offsetParent;
-		target.classList.remove(componentsCss.shakeFavoriteColor);
-
-		clearTimeout(shakeEffectRef.current);
-		clearTimeout(timerRef.current);
-		setTimeout(() => {
-			setClickEnabled(true);
-		}, 100);
-	}, []);
-
-	const handleKeyDown = useCallback((ev) => {
-		if(ev.keyCode === 13) {
+		if (ev.type === 'pointerdown' || (ev.type === 'keydown' && ev.keyCode === 13)) {
 			const target = ev.target.id ? ev.target : ev.target.offsetParent;
 
 			shakeEffectRef.current = setTimeout(() => {
@@ -107,17 +81,15 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 		}
 	}, [editEnabled]);
 
-	const handleKeyUp = useCallback((ev) => {
-		if(ev.keyCode === 13) {
-			const target = ev.target.id ? ev.target : ev.target.offsetParent;
-			target.classList.remove(componentsCss.shakeFavoriteColor);
+	const onReleaseHandler = useCallback((ev) => {
+		const target = ev.target.id ? ev.target : ev.target.offsetParent;
+		target.classList.remove(componentsCss.shakeFavoriteColor);
 
-			clearTimeout(shakeEffectRef.current);
-			clearTimeout(timerRef.current);
-			setTimeout(() => {
-				setClickEnabled(true);
-			}, 100);
-		}
+		clearTimeout(shakeEffectRef.current);
+		clearTimeout(timerRef.current);
+		setTimeout(() => {
+			setClickEnabled(true);
+		}, 100);
 	}, []);
 
 	return (
@@ -132,8 +104,8 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 								key={`${color}_${index + 4}`}
 								minWidth={false}
 								onClick={onSelectFavoriteColor}
-								onKeyDown={handleKeyDown}
-								onKeyUp={handleKeyUp}
+								onKeyDown={onPressHandler}
+								onKeyUp={onReleaseHandler}
 								onPointerDown={onPressHandler}
 								onPointerUp={onReleaseHandler}
 								size="small"
@@ -157,8 +129,8 @@ const FavoriteColors = ({favoriteColors = [], favoriteColorsHandler, selectedCol
 								key={`${color}_${index}`}
 								minWidth={false}
 								onClick={onSelectFavoriteColor}
-								onKeyDown={handleKeyDown}
-								onKeyUp={handleKeyUp}
+								onKeyDown={onPressHandler}
+								onKeyUp={onReleaseHandler}
 								onPointerDown={onPressHandler}
 								onPointerUp={onReleaseHandler}
 								size="small"

--- a/ColorPickerPOC/ColorPickerPOC.js
+++ b/ColorPickerPOC/ColorPickerPOC.js
@@ -174,11 +174,6 @@ const ColorPickerPOCBase = ({color = '#eb4034', colors = [], css, onChangeColor,
 	const [selectedColor, setSelectedColor] = useState(color);
 
 	useEffect(() => {
-		setSelectedColor(color);
-		setFavoriteColors(colors);
-	}, [color, colors]);
-
-	useEffect(() => {
 		if (selectedColor || favoriteColors) {
 			onChangeColor({selectedColor, favoriteColors});
 		}

--- a/ColorPickerPOC/ColorPickerPOC.js
+++ b/ColorPickerPOC/ColorPickerPOC.js
@@ -174,6 +174,11 @@ const ColorPickerPOCBase = ({color = '#eb4034', colors = [], css, onChangeColor,
 	const [selectedColor, setSelectedColor] = useState(color);
 
 	useEffect(() => {
+		setFavoriteColors(colors);
+		setSelectedColor(color);
+	}, [color, colors]);
+
+	useEffect(() => {
 		if (selectedColor || favoriteColors) {
 			onChangeColor({selectedColor, favoriteColors});
 		}

--- a/ColorPickerPOC/ColorPickerSpectrum.js
+++ b/ColorPickerPOC/ColorPickerSpectrum.js
@@ -10,10 +10,12 @@ import css from './ColorPickerSpectrum.module.less';
 const SpectrumColorPicker = (props) => {
 	const {selectedColor, selectedColorHandler} = props;
 	const canvasRef = useRef(null);
+	const [canvasHeight, setCanvasHeight] = useState(ri.scale(660));
+	const [canvasWidth, setCanvasWidth] = useState(ri.scale(800));
+	const [indicatorBgColor, setIndicatorBgColor] = useState('transparent');
 	const [indicatorX, setIndicatorX] = useState(0);
 	const [indicatorY, setIndicatorY] = useState(0);
 	const [isDragging, setIsDragging] = useState(false);
-	const [indicatorBgColor, setIndicatorBgColor] = useState('transparent');
 	const [isIndicatorActive, setIsIndicatorActive] = useState(false);
 
 	useEffect(() => {
@@ -57,7 +59,15 @@ const SpectrumColorPicker = (props) => {
 			}
 		};
 		positionIndicator();
-	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+		const handleResize = () => {
+			setCanvasHeight(canvas.parentElement.clientHeight);
+			setCanvasWidth(canvas.parentElement.clientWidth);
+		};
+
+		window.addEventListener('resize', handleResize);
+		handleResize();
+	}, [canvasHeight, canvasWidth]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const handleCanvasPointerDown = useCallback((e) => {
 		const canvas = canvasRef.current;
@@ -107,14 +117,14 @@ const SpectrumColorPicker = (props) => {
 	return (
 		<div className={css.colorPicker}>
 			<canvas
-				ref={canvasRef}
-				height={ri.scale(600)}
+				className={css.gradientCanvas}
+				height={canvasHeight}
 				onPointerDown={handleCanvasPointerDown}
 				onPointerLeave={handleCanvasPointerLeave}
 				onPointerMove={handleCanvasPointerMove}
 				onPointerUp={handleCanvasPointerUp}
-				style={{touchAction: 'none'}}
-				width={ri.scale(800)}
+				ref={canvasRef}
+				width={canvasWidth}
 			/>
 			<SpectrumIndicator
 				bgColor={indicatorBgColor}

--- a/ColorPickerPOC/ColorPickerSpectrum.module.less
+++ b/ColorPickerPOC/ColorPickerSpectrum.module.less
@@ -6,6 +6,12 @@
 
 .colorPicker {
 	position: relative;
+
+	.gradientCanvas {
+		height: 100%;
+		touch-action: none;
+		width: 100%;
+	}
 }
 
 .circleIndicator {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
onPointerDown currently activates long press, which is ok for touch screens, but not for click.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed mouse event handlers for favorite color buttons

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Added an useEffect to update component state when the props for current color of favorite colors change.

### Links
[//]: # (Related issues, references)
WRQ-32437

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))
