### PR TITLE
WRQ-32429: Convert Sandstone components` style to SCSS (Steps - WizardPanels)

### DIFF
--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -23,7 +23,7 @@ import Skinnable from '../Skinnable';
 
 import {countReactChildren} from './util';
 
-import css from './MediaControls.module.less';
+import css from './MediaControls.module.scss';
 
 const DivComponent = ({mediaControlsRef, ...rest}) => (<div ref={mediaControlsRef} {...rest} />);
 

--- a/MediaPlayer/MediaControls.module.scss
+++ b/MediaPlayer/MediaControls.module.scss
@@ -1,4 +1,4 @@
-// MediaControls.module.less
+// MediaControls.module.scss
 //
 @use "../styles/mixins";
 @use "../styles/skin";

--- a/MediaPlayer/MediaControls.module.scss
+++ b/MediaPlayer/MediaControls.module.scss
@@ -1,0 +1,82 @@
+// MediaControls.module.less
+//
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.controlsFrame {
+	position: relative;
+	display: block;
+
+	&.hidden {
+		will-change: opacity;
+		opacity: 0;
+	}
+
+	.mediaControls {
+		text-align: center;
+		direction: ltr;
+		white-space: nowrap;
+
+		> *:first-child {
+			margin-inline-start: 0;
+		}
+	}
+
+	.actionGuide {
+		padding-top: variables.$sand-mediaplayer-controls-actionguide-padding-top;
+		transition: opacity variables.$sand-mediaplayer-controls-actionguide-time linear;
+
+		&.hidden {
+			opacity: 0;
+			visibility: hidden;
+		}
+	}
+
+	.moreComponents {
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 0;
+		opacity: 0;
+
+		&.hidden {
+			visibility: hidden;
+		}
+
+		.moreButtonsComponents {
+			> * {
+				margin: 0;
+				margin-inline-start: variables.$sand-mediaplayer-controls-morebuttons-margin-start;
+
+				&:first-child {
+					margin-inline-start: 0;
+				}
+			}
+		}
+
+		> :first-child {
+			margin-top: variables.$sand-mediaplayer-controls-moreComponents-margin-top;
+		}
+	}
+
+	.button {
+		height: variables.$sand-mediaplayer-button-height;
+		min-width: variables.$sand-mediaplayer-button-height;
+		margin: 0;
+		margin-inline-start: variables.$sand-mediaplayer-controls-button-margin-start;
+
+		.client {
+			padding: variables.$sand-mediaplayer-button-client-padding;
+		}
+	}
+
+	// Skin colors
+	@include skin.applySkins {
+		.button {
+			.bg {
+				border-radius: variables.$sand-mediaplayer-button-border-radius;
+			}
+		}
+	}
+}

--- a/MediaPlayer/MediaSlider.js
+++ b/MediaPlayer/MediaSlider.js
@@ -6,7 +6,7 @@ import Slider from '../Slider';
 import MediaKnob from './MediaKnob';
 import MediaSliderDecorator from './MediaSliderDecorator';
 
-import css from './MediaSlider.module.less';
+import css from './MediaSlider.module.scss';
 
 /**
  * The base component to render a customized {@link sandstone/Slider.Slider|Slider} for use in

--- a/MediaPlayer/MediaSlider.module.scss
+++ b/MediaPlayer/MediaSlider.module.scss
@@ -1,0 +1,139 @@
+// MediaSlider.module.scss
+//
+@use "sass:math";
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.sliderFrame {
+	$knob-transform-active: variables.$sand-translate-center scale(1);
+	$knob-transform-resting: variables.$sand-translate-center scale(variables.$sand-mediaplayer-slider-knob-resting-state-scale);
+	$slider-padding-v: math.div((variables.$sand-mediaplayer-slider-tap-area - variables.$sand-mediaplayer-slider-height), 2);
+	$slider-padding-h: variables.$sand-mediaplayer-slider-knob-size;
+	flex: 1 0 auto;
+
+	&.hidden {
+		will-change: opacity;
+		opacity: 0;
+	}
+
+	.mediaSlider {
+		margin: 0 $slider-padding-h;
+		padding: $slider-padding-v 0;
+		height: variables.$sand-mediaplayer-slider-height;
+
+		// Add a tap area that extends to the edges of the screen, to make the slider more accessible
+		&::before {
+			content: "";
+			position: absolute;
+			@include mixins.position(0 -#{variables.$sand-video-player-padding-side});
+		}
+
+		// Grow the knob when the Slider gets spotted
+		@include mixins.focus {
+			.knob::before {
+				opacity: 1;
+			}
+
+			&.active,
+			&.pressed {
+				.knob::before {
+					transform: $knob-transform-active;
+				}
+			}
+		}
+
+		@include mixins.spottable {
+			&.pressed {
+				.knob::before {
+					transform: $knob-transform-active;
+					opacity: 1;
+				}
+			}
+		}
+	}
+
+	// Knob
+	.knob {
+		$activate-transition-function: cubic-bezier(0.15, 0.85, 0.6, 1.65);
+		//@slide-transition-function:    cubic-bezier(0.15, 0.85, 0.53, 1.09);
+
+		//transition: transform @slide-transition-function 0.2s;
+
+		&::before {
+			width: variables.$sand-mediaplayer-slider-knob-size;
+			height: variables.$sand-mediaplayer-slider-knob-size;
+			border-width: 0;
+			border-radius: variables.$sand-mediaplayer-slider-knob-size;
+			transform: $knob-transform-resting;
+			opacity: 0;
+			will-change: transform, opacity;
+			transition: transform $activate-transition-function 0.2s, opacity ease 0.2s;
+		}
+	}
+
+	&.scrubbing {
+		.knob {
+			display: block;
+		}
+	}
+}
+
+@include skin.applySkins(true) {
+	.sliderFrame {
+		.slider {
+			.bar {
+				background-color: colors.$sand-mediaslider-bar-bg-color;
+			}
+
+			.fill {
+				background-color: colors.$sand-mediaslider-fill-bg-color;
+			}
+
+			.knob {
+				&::before {
+					background-color: colors.$sand-mediaplayer-slider-knob-color;
+				}
+			}
+
+			@include mixins.focus {
+				.bar {
+					background-color: colors.$sand-mediaslider-bar-bg-color;
+				}
+
+				.fill {
+					background-color: colors.$sand-mediaslider-fill-bg-color;
+				}
+
+				@include mixins.disabled {
+					.bar {
+						opacity: colors.$sand-mediaslider-disabled-bar-opacity;
+					}
+				}
+			}
+
+			:global(.spotlight-input-touch) &.pressed {
+				.bar {
+					background-color: colors.$sand-mediaslider-bar-bg-color;
+				}
+
+				.fill {
+					background-color: colors.$sand-mediaslider-fill-bg-color;
+				}
+
+				.knob {
+					&::before {
+						background-color: colors.$sand-mediaplayer-slider-knob-color;
+					}
+				}
+			}
+
+			@include mixins.disabled {
+				.bar {
+					opacity: colors.$sand-mediaslider-disabled-bar-opacity;
+				}
+			}
+		}
+	}
+}

--- a/MediaPlayer/Times.js
+++ b/MediaPlayer/Times.js
@@ -5,7 +5,7 @@ import {onlyUpdateForProps} from '../internal/util';
 
 import {secondsToPeriod, secondsToTime} from './util';
 
-import css from './Times.module.less';
+import css from './Times.module.scss';
 
 /**
  * Sandstone-styled formatted time component.

--- a/MediaPlayer/Times.module.scss
+++ b/MediaPlayer/Times.module.scss
@@ -5,7 +5,7 @@
 
 .times {
 	@include mixins.sand-text-base(variables.$sand-mediaplayer-times-text-size);
-	@include mixins.sand-font-number();
+	@include mixins.sand-font-number;
 
 	& {
 		white-space: nowrap;

--- a/MediaPlayer/Times.module.scss
+++ b/MediaPlayer/Times.module.scss
@@ -1,4 +1,4 @@
-// Times.module.less
+// Times.module.scss
 //
 @use "../styles/mixins";
 @use "../styles/variables";

--- a/MediaPlayer/Times.module.scss
+++ b/MediaPlayer/Times.module.scss
@@ -1,0 +1,26 @@
+// Times.module.less
+//
+@use "../styles/mixins";
+@use "../styles/variables";
+
+.times {
+	@include mixins.sand-text-base(variables.$sand-mediaplayer-times-text-size);
+	@include mixins.sand-font-number();
+
+	& {
+		white-space: nowrap;
+		min-width: variables.$sand-mediaplayer-times-min-width;
+	}
+
+	> * {
+		display: inline-block;
+	}
+
+	.separator {
+		padding: 0 1ex;
+	}
+
+	@include mixins.enact-locale-rtl("") {
+		direction: ltr;
+	}
+}

--- a/Scroller/Scroller.module.scss
+++ b/Scroller/Scroller.module.scss
@@ -1,0 +1,52 @@
+// Scroller.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/variables";
+
+.focusableBody {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 100%;
+	overflow: inherit;
+
+	&::before {
+		content: '';
+		position: absolute;
+		@include mixins.position(0);
+
+		& {
+			border-radius: variables.$sand-scroll-focusablebody-focus-border-radius;
+			opacity: 0;
+		}
+	}
+
+	@include mixins.focus {
+		&::before {
+			background-color: colors.$sand-scroll-focusablebody-focus-bg-color;
+			opacity: 1;
+		}
+	}
+}
+
+.verticalFadeout {
+	padding: variables.$sand-scroll-vertical-fade-out-padding;
+	mask-image: linear-gradient(transparent, #000 variables.$sand-scroll-fade-out-size, #000 calc(100% - #{variables.$sand-scroll-fade-out-size}), transparent 100%);
+
+	.focusableBody & {
+		padding: variables.$sand-scroll-focusablebody-padding;
+		@include mixins.enact-locale-rtl("") {
+			padding: variables.$sand-scroll-focusablebody-padding-rtl;
+		}
+
+		& {
+			mask-image: linear-gradient(transparent variables.$sand-scroll-fade-out-offset, #000 calc(#{variables.$sand-scroll-fade-out-offset} + #{variables.$sand-scroll-fade-out-size}), #000 calc(100% - #{variables.$sand-scroll-fade-out-size} - #{variables.$sand-scroll-fade-out-offset}), transparent calc(100% - #{variables.$sand-scroll-fade-out-offset}));
+		}
+	}
+}
+
+.horizontalFadeout {
+	padding: variables.$sand-scroll-horizontal-fade-out-padding;
+	mask-image: linear-gradient(to right, transparent, #000 variables.$sand-scroll-fade-out-size, #000 calc(100% - #{variables.$sand-scroll-fade-out-size}), transparent 100%);
+}

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -12,8 +12,8 @@ import {affordanceSize} from '../useScroll';
 
 import {useEventKey} from './useEvent';
 
-import css from './Scroller.module.less';
-import scrollbarTrackCss from '../useScroll/ScrollbarTrack.module.less';
+import css from './Scroller.module.scss';
+import scrollbarTrackCss from '../useScroll/ScrollbarTrack.module.scss';
 
 const
 	isCancel = is('cancel'),

--- a/Steps/Steps.js
+++ b/Steps/Steps.js
@@ -23,7 +23,7 @@ import compose from 'ramda/src/compose';
 import Icon from '../Icon';
 import Skinnable from '../Skinnable';
 
-import componentCss from './Steps.module.less';
+import componentCss from './Steps.module.scss';
 
 /**
  * Renders a sandstone-styled steps component only basic behavior.

--- a/Steps/Steps.module.scss
+++ b/Steps/Steps.module.scss
@@ -1,0 +1,62 @@
+// Steps.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.steps {
+	margin: variables.$sand-steps-margin;
+
+	.step {
+		margin: variables.$sand-steps-step-margin;
+
+		&.numbers {
+			@include mixins.sand-font-number();
+
+			& {
+				font-size: variables.$sand-steps-step-number-font-size;
+				font-weight: variables.$sand-steps-step-number-font-weight;
+			}
+		}
+
+		&.dots {
+			font-size: variables.$sand-steps-step-dot-font-size;
+			opacity: variables.$sand-steps-step-past-opacity;
+			margin: 0;
+			width: variables.$sand-steps-step-width;
+
+			&.current {
+				font-size: variables.$sand-steps-step-current-dot-font-size;
+			}
+
+			&.future {
+				opacity:  variables.$sand-steps-step-past-opacity;
+			}
+		}
+
+		&.past {
+			opacity:  variables.$sand-steps-step-past-opacity;
+		}
+
+		&.current {
+			opacity: variables.$sand-steps-step-current-opacity;
+		}
+
+		&.future {
+			opacity: variables.$sand-steps-step-future-opacity;
+		}
+	}
+}
+
+@include skin.applySkins(true) {
+	.step {
+		&.dots {
+			color: colors.$sand-steps-step-focused-dot-color;
+
+			&.current {
+				color: colors.$sand-steps-step-dot-color;
+			}
+		}
+	}
+};

--- a/Switch/Switch.js
+++ b/Switch/Switch.js
@@ -20,7 +20,7 @@ import Toggleable from '@enact/ui/Toggleable';
 import Icon from '../Icon';
 import Skinnable from '../Skinnable';
 
-import componentCss from './Switch.module.less';
+import componentCss from './Switch.module.scss';
 
 /**
  * Renders the base level DOM structure of the component.

--- a/Switch/Switch.module.scss
+++ b/Switch/Switch.module.scss
@@ -1,0 +1,170 @@
+// Switch.module.scss
+//
+@use "../styles/color-mixins";
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.switch {
+	display: inline-block;
+	position: relative;
+
+	.client {
+		border-radius: variables.$sand-switch-border-radius;
+		width: variables.$sand-switch-width;
+		height: variables.$sand-switch-height;
+		position: relative;
+		text-align: left;
+		cursor: default;
+	}
+
+	.icon {
+		visibility: visible;
+		left: 0;
+		width: variables.$sand-switch-icon-height;
+		height: inherit;
+		font-size: variables.$sand-switch-icon-font-size;
+		line-height: variables.$sand-switch-icon-line-height;
+		margin: 0;
+		vertical-align: top;
+	}
+
+	&.selected {
+		.icon {
+			left: (variables.$sand-switch-width - variables.$sand-switch-height);
+		}
+	}
+
+	&.animated {
+		.client {
+			transition: background-color 200ms;
+		}
+
+		.icon {
+			transition: left 200ms, color 200ms;
+		}
+	}
+
+	// The switch is acting a standalone capacity and is Spottable
+	@include mixins.spottable {
+		margin: variables.$sand-switch-spottable-margin;
+
+		.bg {
+			position: absolute;
+			@include mixins.position(variables.$sand-switch-spottable-position-top-bottom variables.$sand-switch-spottable-position-left-right);
+
+			& {
+				z-index: -1;
+			}
+		}
+	}
+
+	// Skin colors
+	@include skin.applySkins {
+		.client {
+			background-color: colors.$sand-switch-bg-color;
+		}
+
+		.icon {
+			background-color: transparent;
+			color: colors.$sand-switch-color;
+		}
+
+		&.selected {
+			.client {
+				background-color: colors.$sand-switch-selected-bg-color;
+			}
+
+			.icon {
+				color: colors.$sand-switch-selected-color;
+			}
+		}
+
+		@include mixins.disabled {
+			&.selected {
+				.client {
+					background-color: colors.$sand-switch-disabled-selected-bg-color;
+				}
+
+				.icon {
+					color: colors.$sand-switch-disabled-selected-color;
+				}
+			}
+		}
+
+		// Standalone Switch
+		@include mixins.spottable {
+			@include mixins.sand-taparea(variables.$sand-switch-height);
+
+			.bg {
+				border-radius: variables.$sand-switch-spottable-border-radius;
+				@include color-mixins.sand-spotlight-resting-bg-colors;
+			}
+		}
+
+		@include mixins.focus {
+			.bg {
+				@include color-mixins.sand-spotlight-focus-bg-colors;
+			}
+
+			.icon {
+				color: colors.$sand-switch-focus-color;
+			}
+
+			&.selected {
+				.icon {
+					color: colors.$sand-switch-selected-focus-color;
+				}
+			}
+		}
+
+		@include mixins.sand-disabled {
+			.client {
+				@include color-mixins.sand-disabled-colors;
+			}
+
+			@include mixins.focus {
+				.bg {
+					@include color-mixins.sand-disabled-focus-bg-colors;
+				}
+				.client {
+					@include color-mixins.sand-disabled-focus-content-colors;
+				}
+			}
+		}
+	}
+}
+
+// Keep the switch handle (the icon) a constant color regardless of focus state.
+@include skin.applySkins(true) {
+	@include mixins.focus(parent) {
+		.switch {
+			.icon {
+				color: colors.$sand-switch-focus-color;
+			}
+
+			&.selected {
+				.icon {
+					color: colors.$sand-switch-selected-focus-color;
+				}
+			}
+		}
+	}
+}
+
+@include skin.applySkins(true) {
+	@include mixins.disabled {
+		.switch {
+			&.selected {
+				.client {
+					background-color: colors.$sand-switch-disabled-selected-bg-color;
+				}
+
+				.icon {
+					color: colors.$sand-switch-disabled-selected-color;
+				}
+			}
+		}
+	}
+}

--- a/SwitchItem/SwitchItem.js
+++ b/SwitchItem/SwitchItem.js
@@ -22,7 +22,7 @@ import {ItemBase, ItemDecorator} from '../Item';
 import Skinnable from '../Skinnable';
 import {SwitchBase} from '../Switch';
 
-import componentCss from './SwitchItem.module.less';
+import componentCss from './SwitchItem.module.scss';
 
 const Item = ItemDecorator(ItemBase);
 

--- a/SwitchItem/SwitchItem.module.scss
+++ b/SwitchItem/SwitchItem.module.scss
@@ -1,0 +1,4 @@
+// SwitchItem.module.scss
+//
+
+.switchItem { /* Needed to prevent global class being added in the DOM */ }

--- a/TimePicker/TimePicker.module.scss
+++ b/TimePicker/TimePicker.module.scss
@@ -1,0 +1,49 @@
+// TimePicker.module.scss
+//
+@use "../styles/color-mixins";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.timePicker {
+	.timeSeparator {
+		vertical-align: inherit;
+		display: inline-block;
+		margin: variables.$sand-timepicker-colon-margin;
+	}
+
+	.pickers {
+		display: flex;
+		align-items: center;
+
+		@include mixins.enact-locale-rtl("") {
+			// RTL uses a special order:
+			// Reading from right to left, the sequence is "minute : hour meridiem"
+			.hourPicker {
+				order: 3;
+				margin-inline-start: nth(variables.$sand-datecomponentpicker-margin, 1);
+			}
+
+			.timeSeparator {
+				order: 2;
+			}
+
+			.minutePicker {
+				order: 1;
+				margin-inline-start: 0;
+			}
+
+			.meridiemPicker {
+				order: 4;
+			}
+		}
+	}
+
+	@include skin.applySkins {
+		.timeSeparator {
+			@include mixins.sand-disabled {
+				@include color-mixins.sand-disabled-colors;
+			}
+		}
+	}
+}

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -6,7 +6,7 @@ import $L from '../internal/$L';
 import {DateComponentPicker, DateComponentRangePicker} from '../internal/DateComponentPicker';
 import DateTime from '../internal/DateTime';
 
-import css from './TimePicker.module.less';
+import css from './TimePicker.module.scss';
 
 // values to use in hour picker for 24 and 12 hour locales
 const hours24 = [

--- a/VideoPlayer/Feedback.js
+++ b/VideoPlayer/Feedback.js
@@ -6,7 +6,7 @@ import {onlyUpdateForProps} from '../internal/util';
 import FeedbackIcon from './FeedbackIcon';
 import states from './FeedbackIcons.js';
 
-import css from './Feedback.module.less';
+import css from './Feedback.module.scss';
 
 /**
  * Feedback {@link sandstone/VideoPlayer}. This displays the media's playback rate and other

--- a/VideoPlayer/Feedback.module.scss
+++ b/VideoPlayer/Feedback.module.scss
@@ -1,0 +1,43 @@
+// Feedback.module.scss
+//
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.feedback {
+	display: inline-block;
+	margin-inline-end: variables.$sand-video-slider-tooltip-gutter-width;
+
+	&.hidden {
+		display: none;
+	}
+
+	> * {
+		display: inline-block;
+		margin: 0;
+		margin-inline-end: variables.$sand-video-slider-tooltip-gutter-width;
+
+		&:last-child {
+			margin-inline-end: 0;
+		}
+	}
+
+	.message {
+		@include mixins.sand-font(variables.$sand-video-feedback-message-font-weight);
+
+		& {
+			font-weight: variables.$sand-video-feedback-message-font-weight;
+		}
+	}
+
+	.icon {
+		font-size: variables.$sand-video-feedback-icon-font-size;
+		height: inherit;  // Use the height and line-height from the parent element to always middle align the icon, regardless of the container's size
+		line-height: inherit;
+		vertical-align: bottom;
+
+		@include skin.applySkins {
+			color: inherit;
+		}
+	}
+}

--- a/VideoPlayer/FeedbackIcon.js
+++ b/VideoPlayer/FeedbackIcon.js
@@ -6,7 +6,7 @@ import Skinnable from '../Skinnable';
 import Icon from '../Icon';
 import iconMap from './FeedbackIcons.js';
 
-import css from './Feedback.module.less';
+import css from './Feedback.module.scss';
 
 
 /**

--- a/VideoPlayer/FeedbackTooltip.js
+++ b/VideoPlayer/FeedbackTooltip.js
@@ -11,7 +11,7 @@ import FeedbackContent from './FeedbackContent';
 import states from './FeedbackIcons.js';
 import {secondsToTime} from '../MediaPlayer/';
 
-import css from './FeedbackTooltip.module.less';
+import css from './FeedbackTooltip.module.scss';
 
 /**
  * FeedbackTooltip {@link sandstone/VideoPlayer}. This displays the media's playback rate and

--- a/VideoPlayer/FeedbackTooltip.module.scss
+++ b/VideoPlayer/FeedbackTooltip.module.scss
@@ -1,0 +1,105 @@
+// FeedbackTooltip.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.feedbackTooltip {
+	position: absolute;
+	bottom: variables.$sand-video-slider-tooltip-position-bottom;
+
+	&.shift {
+		bottom: variables.$sand-video-slider-tooltip-shift-position-bottom;
+
+		.content {
+			position: absolute;
+			@include mixins.position(auto 0 0 0);
+		}
+	}
+
+	&.hidden {
+		display: none;
+	}
+
+	.thumbnail,
+	.content {
+		pointer-events: none;
+		will-change: transform;
+	}
+
+	.thumbnail {
+		border-width: variables.$sand-video-slider-tooltip-thumbnail-border-width;
+		border-style: solid;
+		border-radius: 0;
+		overflow: hidden;
+		transition: opacity 250ms;
+
+		.image {
+			margin: 0;
+			width: variables.$sand-video-slider-tooltip-thumbnail-width;
+			height: variables.$sand-video-slider-tooltip-thumbnail-height;
+		}
+	}
+
+	&.thumbnailDeactivated {
+		.thumbnail {
+			opacity: variables.$sand-video-slider-tooltip-deactivated-thumbnail-opacity;
+		}
+	}
+
+	.content {
+		@include mixins.sand-font(variables.$sand-video-slider-tooltip-font-size, variables.$sand-video-slider-tooltip-font-weight);
+		@include mixins.sand-font-number;
+
+		& {
+			font-size: variables.$sand-video-slider-tooltip-font-size;
+			font-weight: variables.$sand-video-slider-tooltip-font-weight;
+			line-height: variables.$sand-video-slider-tooltip-line-height;
+			white-space: nowrap;
+			text-align: center;
+			margin-bottom: variables.$sand-video-slider-tooltip-margin-bottom;
+		}
+	}
+
+	.alignmentContainer {
+		position: relative;
+		right: 50%;
+	}
+
+	.arrowContainer {
+		position: absolute;
+		left: 0;
+		right: 0;
+
+		&.hidden {
+			display: none;
+		}
+
+		.arrow {
+			margin: auto;
+			width: 0;
+			height: 0;
+			border-top: variables.$sand-video-slider-tooltip-arrow-border-top solid;
+			border-right: variables.$sand-video-slider-tooltip-arrow-border-left-right solid;
+			border-left: variables.$sand-video-slider-tooltip-arrow-border-left-right solid;
+		}
+	}
+
+	@include skin.applySkins {
+		.thumbnail {
+			border-color: colors.$sand-video-slider-tooltip-thumbnail-border-color;
+		}
+
+		.arrow {
+			border-top-color: colors.$sand-video-slider-tooltip-thumbnail-border-color;
+			border-right-color: transparent;
+			border-left-color: transparent;
+		}
+
+		.content {
+			color: colors.$sand-video-slider-tooltip-color;
+			text-shadow: colors.$sand-mediaplayer-slider-tooltip-text-shadow;
+		}
+	}
+}

--- a/VideoPlayer/MediaTitle.js
+++ b/VideoPlayer/MediaTitle.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import {onlyUpdateForProps} from '../internal/util';
 import Marquee from '../Marquee';
 
-import css from './MediaTitle.module.less';
+import css from './MediaTitle.module.scss';
 
 /**
  * MediaTitle {@link sandstone/VideoPlayer}.

--- a/VideoPlayer/MediaTitle.module.scss
+++ b/VideoPlayer/MediaTitle.module.scss
@@ -1,0 +1,84 @@
+// MediaTitle.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.titleFrame {
+	--infoComponentsOffset: 0;
+
+	$badges-present-transition: transform 500ms ease-in-out;
+
+	position: relative;
+	flex-grow: 1;
+	opacity: 1;
+	@include mixins.margin-start-end(0, variables.$sand-spotlight-outset);
+
+	&.hidden {
+		transition: opacity 1000ms ease-in-out;
+		opacity: 0;
+	}
+
+	// Title
+	.title {
+		position: absolute;
+		bottom: -10px;
+		width: 100%;
+		@include mixins.sand-text-base(variables.$sand-video-player-title-size);
+
+		& {
+			line-height: variables.$sand-heading-title-line-height;
+			transition: $badges-present-transition;
+
+		}
+
+		@include mixins.font-kerning;
+
+		&.infoVisible {
+			transform: translateY(calc(var(--infoComponentsOffset) * -1)) translateZ(0);
+		}
+
+		@include mixins.sand-enact-locale-tallglyph(
+			// The font-size .times is the same as .title in tallglyph locales so no
+			// vertical adjustment is required to align their baselines
+			bottom, 0);
+	}
+
+	// Badges and title components
+	.infoComponents {
+		vertical-align: super;
+		font-size: 54px;
+
+		&.hidden {
+			opacity: 0;
+		}
+
+		&.visible {
+			transition: opacity 500ms ease-in-out;
+		}
+
+		> * {
+			display: inline-block;
+			margin: 0 12px;
+		}
+
+		.badgeTextIcon {
+			font-family: variables.$sand-font-family-bold;
+			font-size: variables.$sand-video-player-badge-text-size;
+			text-align: center;
+			white-space: nowrap;
+			display: inline-block;
+		}
+
+		.fontLgIcons {
+			font-family: "LG Icons";
+		}
+	}
+
+	@include skin.applySkins {
+		.titleFrame {
+			color: colors.$sand-video-player-title-color;
+		}
+	}
+}

--- a/VideoPlayer/Overlay.js
+++ b/VideoPlayer/Overlay.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import {onlyUpdateForProps} from '../internal/util';
 
-import css from './VideoPlayer.module.less';
+import css from './VideoPlayer.module.scss';
 
 /**
  * Overlay {@link sandstone/VideoPlayer}. This covers the Video piece of the

--- a/VideoPlayer/Video.js
+++ b/VideoPlayer/Video.js
@@ -6,7 +6,7 @@ import Slottable from '@enact/ui/Slottable';
 import compose from 'ramda/src/compose';
 import {isValidElement, Component, Fragment} from 'react';
 
-import css from './VideoPlayer.module.less';
+import css from './VideoPlayer.module.scss';
 
 import PropTypes from 'prop-types';
 

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -51,7 +51,7 @@ import FeedbackContent from './FeedbackContent';
 import FeedbackTooltip from './FeedbackTooltip';
 import Video from './Video';
 
-import css from './VideoPlayer.module.less';
+import css from './VideoPlayer.module.scss';
 
 const isEnter = is('enter');
 const isLeft = is('left');

--- a/VideoPlayer/VideoPlayer.module.scss
+++ b/VideoPlayer/VideoPlayer.module.scss
@@ -1,0 +1,139 @@
+// VideoPlayer.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.videoPlayer {
+	// Set by counting the IconButtons inside the side components.
+	--liftDistance: 0px;
+
+	overflow: hidden;
+
+	.video {
+		height: 100%;
+		width: 100%;
+	}
+
+	.preloadVideo {
+		display: none;
+	}
+
+	.overlay {
+		position: absolute;
+		@include mixins.position(0);
+
+		&::after {
+			content: "";
+			position: absolute;
+			@include mixins.position(auto 0 0 0);
+
+			& {
+				height: 80%;
+				transform-origin: bottom;
+				// Fancier gradient for future reference. Keeping linear-gradient as specified from Enyo.
+				// background-image: radial-gradient(rgba(0, 0, 0, 0) 50%, #000000 100%);
+				// background-size: 170% 200%;
+				// background-position: bottom center;
+			}
+		}
+	}
+
+	.fullscreen {
+		.miniFeedback {
+			@include mixins.sand-font-number;
+
+			& {
+				position: absolute;
+				z-index: 50;  // Value assigned as part of the VideoPlayer API so layers may be inserted in-between
+				top: variables.$sand-video-feedback-mini-position-top;
+				left: variables.$sand-video-feedback-mini-position-left;
+				font-weight: variables.$sand-video-feedback-mini-font-weight;
+				font-style: variables.$sand-video-feedback-mini-font-style;
+				font-size: variables.$sand-video-feedback-mini-font-size;
+				padding: 0 variables.$sand-video-feedback-mini-padding-side;
+				line-height: variables.$sand-video-feedback-mini-line-height;
+				bottom: auto;
+				pointer-events: none;
+			}
+		}
+
+		.back {
+			position: absolute;
+			z-index: 100; // Value assigned as part of the VideoPlayer API so layers may be inserted in-between
+			top: variables.$sand-video-back-button-top;
+			@include mixins.position-start-end(variables.$sand-video-back-button-left, initial);
+		}
+
+		.bottom {
+			position: absolute;
+			z-index: 100;  // Value assigned as part of the VideoPlayer API so layers may be inserted in-between
+			bottom: variables.$sand-video-player-padding-bottom;
+			left: variables.$sand-video-player-padding-side;
+			right: variables.$sand-video-player-padding-side;
+
+			&.lift {
+				transform: translateY(calc(var(--liftDistance) * -1));
+				transition: transform 0.3s linear;
+			}
+
+			&.hidden {
+				pointer-events: none;
+
+				.sliderContainer {
+					position: absolute;
+					width: 100%;
+				}
+			}
+
+			.infoFrame {
+				display: flex;
+				margin: variables.$sand-video-player-info-margin;
+			}
+
+			.sliderContainer {
+				display: flex;
+				align-items: center;
+
+				> *:first-child {
+					text-align: right;
+				}
+
+				@include mixins.enact-locale-rtl("") {
+					direction: ltr;
+				}
+			}
+		}
+	}
+
+	.controlsHandleAbove {
+		pointer-events: none;
+		position: absolute;
+		@include mixins.position(0 0 auto 0);
+	}
+
+	// Skin colors
+	@include skin.applySkins {
+		.fullscreen {
+			.miniFeedback {
+				background-color: colors.$sand-video-feedback-mini-bg-color;
+				color: colors.$sand-video-feedback-mini-text-color;
+			}
+
+			.bottom {
+				background-color: colors.$sand-video-player-bottom-bg-color;
+
+				.infoFrame {
+					text-shadow: colors.$sand-video-player-title-text-shadow;
+				}
+			}
+		}
+
+		.overlay {
+			&.scrim::after {
+				background: colors.$sand-video-player-scrim-gradient-color;
+			}
+		}
+	}
+}

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -13,7 +13,7 @@ import {useEventKey, useEventFocus} from './useEvent';
 import usePreventScroll from './usePreventScroll';
 import {useSpotlightConfig, useSpotlightRestore} from './useSpotlight';
 
-import css from './useThemeVirtualList.module.less';
+import css from './useThemeVirtualList.module.scss';
 
 const SpotlightAccelerator = new Accelerator();
 const SpotlightPlaceholder = Spottable('div');

--- a/VirtualList/useThemeVirtualList.module.scss
+++ b/VirtualList/useThemeVirtualList.module.scss
@@ -1,0 +1,15 @@
+// useThemeVirtualList.module.scss
+//
+@use "../styles/colors";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.scaled {
+	transform: variables.$sand-imageitem-vertical-focus-image-transform;
+}
+
+@include skin.applySkins(true) {
+	.scaled {
+		box-shadow: colors.$sand-imageitem-focus-bg-shadow;
+	}
+}

--- a/WizardPanels/WizardPanels.js
+++ b/WizardPanels/WizardPanels.js
@@ -18,7 +18,7 @@ import {BasicArranger, CrossFadeArranger, CancelDecorator, FloatingLayerIdProvid
 import Skinnable from '../Skinnable';
 import Steps from '../Steps';
 
-import css from './WizardPanels.module.less';
+import css from './WizardPanels.module.scss';
 
 const DecoratedPanelBase = FloatingLayerIdProvider(PanelBase);
 const HeaderContainer = SpotlightContainerDecorator(Header);

--- a/WizardPanels/WizardPanels.module.scss
+++ b/WizardPanels/WizardPanels.module.scss
@@ -1,0 +1,21 @@
+// WizardPanels.module.scss
+//
+@use "../styles/skin";
+@use "../styles/variables";
+
+.wizardPanels {
+	&.noSteps {
+		.steps {
+			visibility: hidden;
+		}
+	}
+
+	.content {
+		margin: variables.$sand-wizardpanels-content-margin;
+	}
+
+	.footer {
+		text-align: center;
+		margin: variables.$sand-wizardpanels-footer-margin;
+	}
+}

--- a/internal/Panels/NavigationButton.js
+++ b/internal/Panels/NavigationButton.js
@@ -5,7 +5,7 @@ import {isValidElement} from 'react';
 
 import Button from '../../Button';
 
-import componentCss from './NavigationButton.module.less';
+import componentCss from './NavigationButton.module.scss';
 
 const NavigationButton = kind({
 	name: 'NavigationButton',

--- a/internal/Panels/NavigationButton.module.scss
+++ b/internal/Panels/NavigationButton.module.scss
@@ -1,0 +1,45 @@
+// NavigationButton.module.scss
+//
+@use "../../styles/colors";
+@use "../../styles/mixins";
+@use "../../styles/skin";
+@use "../../styles/variables";
+
+.button.hasIcon {
+	&.small {
+		padding: variables.$sand-button-icon-small-padding;
+
+		& .bg {
+			width: variables.$sand-button-small-height;
+		}
+	}
+
+	&.large {
+		padding: variables.$sand-button-icon-padding;
+
+		& .bg {
+			width: variables.$sand-button-height;
+		}
+	}
+
+	&.iconAfter {
+		.bg {
+			@include mixins.position-start-end(auto, 0);
+		}
+		.icon {
+			@include mixins.margin-start-end(variables.$sand-wizardpanels-button-icon-text-gap, 0);
+		}
+	}
+
+	&.iconBefore {
+		.icon {
+			@include mixins.margin-start-end(0, variables.$sand-wizardpanels-button-icon-text-gap);
+		}
+	}
+
+	@include skin.applySkins {
+		.client :not(.icon) {
+			color: colors.$sand-text-color;
+		}
+	}
+}

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -348,6 +348,17 @@ $sand-spinner-text-shadow-color: $sand-shadow-color;
 $sand-steps-step-dot-color: $sand-component-text-color;
 $sand-steps-step-focused-dot-color: rgb(111, 118, 128, 1);
 
+// Switch
+// ---------------------------------------
+$sand-switch-color: $sand-toggle-off-color;
+$sand-switch-bg-color: $sand-toggle-off-bg-color;
+$sand-switch-focus-color: $sand-switch-color;
+$sand-switch-selected-color: $sand-toggle-on-color;
+$sand-switch-selected-bg-color: $sand-toggle-on-bg-color;
+$sand-switch-selected-focus-color: $sand-switch-selected-color;
+$sand-switch-disabled-selected-color: $sand-switch-color;
+$sand-switch-disabled-selected-bg-color: $sand-switch-bg-color;
+
 // Tooltip
 // ---------------------------------------
 $sand-tooltip-bg-color:               $sand-focus-bg-color;

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -335,6 +335,10 @@ $sand-scrollbar-thumb-focus-bg-color: $sand-focus-bg-color;
 $sand-scrollbar-thumb-focus-direction-indicator-color: rgb($sand-component-focus-text-color-rgb, 40%);
 $sand-scrollbar-thumb-focus-box-shadow-color: $sand-shadow-color;
 
+// Scroller
+// ---------------------------------------
+$sand-scroll-focusablebody-focus-bg-color: rgb($sand-focus-bg-color-rgb, 10%);
+
 // Slider
 // ---------------------------------------
 $sand-slider-bar-bg-color: $sand-progressbar-bar-bg-color;

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -298,6 +298,11 @@ $sand-keyguide-colordot-blue-color: $sand-remote-button-blue-color;
 $sand-mediaoverlay-caption-color: $sand-text-color;
 $sand-mediaoverlay-subtitle-color: $sand-text-sub-color;
 
+// MediaPlayer
+// ---------------------------------------
+$sand-mediaplayer-slider-knob-color: $sand-progress-color;
+$sand-mediaplayer-slider-tooltip-text-shadow: $sand-overlay-text-shadow;
+
 // PopupTabLayout
 // ---------------------------------------
 $sand-popuptablayout-bg-color: $sand-popup-bg-color;
@@ -364,3 +369,14 @@ $sand-switch-disabled-selected-bg-color: $sand-switch-bg-color;
 $sand-tooltip-bg-color:               $sand-focus-bg-color;
 $sand-tooltip-text-color:             $sand-component-focus-text-color;
 $sand-tooltip-shadow:                 0 18px 12px $sand-shadow-color;
+
+// VideoPlayer
+// ---------------------------------------
+$sand-video-feedback-mini-bg-color: fade(#000000, 50%); // should be black
+$sand-video-feedback-mini-text-color: $sand-focus-text-color;
+$sand-video-slider-tooltip-color: $sand-text-color;
+$sand-video-slider-tooltip-thumbnail-border-color: $sand-text-color;
+$sand-video-player-bottom-bg-color: transparent;
+$sand-video-player-title-color: $sand-focus-text-color;
+$sand-video-player-title-text-shadow: 0 4px 4px rgb($sand-shadow-color-rgb, 75%);
+$sand-video-player-scrim-gradient-color: linear-gradient(180deg, transparent 0%, #000 100%);

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -303,6 +303,12 @@ $sand-mediaoverlay-subtitle-color: $sand-text-sub-color;
 $sand-mediaplayer-slider-knob-color: $sand-progress-color;
 $sand-mediaplayer-slider-tooltip-text-shadow: $sand-overlay-text-shadow;
 
+// MediaSlider
+// ---------------------------------------
+$sand-mediaslider-bar-bg-color: rgb(var(--sand-progress-color-rgb-base, (230, 230, 230)), 30%);
+$sand-mediaslider-disabled-bar-opacity: 0.3;
+$sand-mediaslider-fill-bg-color: $sand-progress-color;
+
 // PopupTabLayout
 // ---------------------------------------
 $sand-popuptablayout-bg-color: $sand-popup-bg-color;

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -321,6 +321,14 @@ $sand-progressbar-highlighted-fill-bg-color: $sand-progress-highlighted-color;
 $sand-tablayout-tab-horizontal-border-color: rgb($sand-text-color-rgb, 50%);
 $sand-tablayout-tab-horizontal-selected-border-color: $sand-selected-color;
 
+// Scrollbar
+// ---------------------------------------
+$sand-scrollbar-track-bg-color: rgb($sand-progress-bg-color-rgb, 50%);
+$sand-scrollbar-thumb-bg-color: rgb($sand-progress-color-rgb, 60%);
+$sand-scrollbar-thumb-focus-bg-color: $sand-focus-bg-color;
+$sand-scrollbar-thumb-focus-direction-indicator-color: rgb($sand-component-focus-text-color-rgb, 40%);
+$sand-scrollbar-thumb-focus-box-shadow-color: $sand-shadow-color;
+
 // Slider
 // ---------------------------------------
 $sand-slider-bar-bg-color: $sand-progressbar-bar-bg-color;

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -343,6 +343,11 @@ $sand-spinner-bg-color: $sand-component-bg-color;
 $sand-spinner-text-color: $sand-component-text-color;
 $sand-spinner-text-shadow-color: $sand-shadow-color;
 
+// Steps
+// ---------------------------------------
+$sand-steps-step-dot-color: $sand-component-text-color;
+$sand-steps-step-focused-dot-color: rgb(111, 118, 128, 1);
+
 // Tooltip
 // ---------------------------------------
 $sand-tooltip-bg-color:               $sand-focus-bg-color;

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -118,7 +118,9 @@
 	$target: normal
 ) {
 	@if content-exists() {
-		font-family: $family;
+		& {
+			font-family: $family;
+		}
 
 		@include enact-locale(non-latin, $target) {
 			font-family: $non-latin-family;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -902,6 +902,38 @@ $sand-tooltip-padding: (15px - calc((81px - 63px) / 2)) 48px; // Including the m
 $sand-tooltip-margin-offset: 18px; // GUI for the length of the arrow
 $sand-tooltip-marquee-width: 600px;
 
+// Video
+// ---------------------------------------
+$sand-video-back-button-left:                      150px;
+$sand-video-back-button-top:                       114px;
+$sand-video-slider-tooltip-arrow-border-left-right: 18px;
+$sand-video-slider-tooltip-arrow-border-top:       24px;
+$sand-video-slider-tooltip-position-bottom:        42px;
+$sand-video-slider-tooltip-shift-position-bottom:  $sand-video-slider-tooltip-position-bottom + $sand-video-slider-tooltip-arrow-border-top;
+$sand-video-slider-tooltip-margin-bottom:          6px;
+$sand-video-slider-tooltip-font-size:              48px;
+$sand-video-slider-tooltip-font-weight:            normal;
+$sand-video-slider-tooltip-line-height:            72px;
+$sand-video-slider-tooltip-gutter-width:           42px;
+$sand-video-slider-tooltip-thumbnail-border-width: 6px;
+$sand-video-slider-tooltip-thumbnail-width:  426px;
+$sand-video-slider-tooltip-thumbnail-height: 240px;
+$sand-video-slider-tooltip-deactivated-thumbnail-opacity: 0.5;
+$sand-video-feedback-icon-font-size:               1.25em;
+$sand-video-feedback-mini-font-weight:             normal;
+$sand-video-feedback-mini-font-style:              normal;
+$sand-video-feedback-mini-position-top:            60px;
+$sand-video-feedback-mini-position-left:           60px;
+$sand-video-feedback-mini-padding-side:            66px;
+$sand-video-feedback-mini-font-size:               66px;
+$sand-video-feedback-mini-line-height:             120px;
+$sand-video-feedback-message-font-weight:          600;
+$sand-video-player-badge-text-size:                48px;
+$sand-video-player-info-margin:                    0 66px 84px;
+$sand-video-player-padding-bottom:                 60px;
+$sand-video-player-padding-side:                   84px;
+$sand-video-player-title-size:                     78px;
+
 // WizardPanels
 // ---------------------------------------
 $sand-wizardpanels-content-margin: 0 0 150px 0;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -879,6 +879,22 @@ $sand-slider-tooltip-below-offset: math.div($sand-progressbar-bar-thickness, -2)
 $sand-slider-tooltip-before-offset: math.div($sand-progressbar-bar-thickness, 2);
 $sand-slider-tooltip-after-offset: math.div($sand-progressbar-bar-thickness, -2);
 
+// MediaPlayer
+// ---------------------------------------
+$sand-mediaplayer-button-client-padding: 0 18px;
+$sand-mediaplayer-button-border-radius: 96px;
+$sand-mediaplayer-button-height: 180px;
+$sand-mediaplayer-controls-actionguide-padding-top: 78px;
+$sand-mediaplayer-controls-actionguide-time: 0.2s;		// Length of the animation
+$sand-mediaplayer-controls-button-margin-start: 90px;
+$sand-mediaplayer-controls-morebuttons-margin-start: 228px;
+$sand-mediaplayer-controls-moreComponents-margin-top: 42px;
+$sand-mediaplayer-controls-moreComponents-time: 0.3s;		// Length of the animation
+$sand-mediaplayer-slider-height: 12px;
+$sand-mediaplayer-slider-knob-resting-state-scale: $sand-slider-knob-resting-state-scale;
+$sand-mediaplayer-slider-knob-size: 48px;
+$sand-mediaplayer-slider-tap-area: 162px;
+
 // Spinner
 // ---------------------------------------
 $sand-spinner-size: 96px;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -857,6 +857,16 @@ $sand-spinner-line-margin: 24px;
 $sand-spinner-small-line-margin: 12px;
 $sand-spinner-font-weight: bold;
 
+// Steps
+// ---------------------------------------
+$sand-steps-step-number-font-weight: 600;
+$sand-steps-margin: 0;
+$sand-steps-step-margin: 0 $sand-component-spacing;
+$sand-steps-step-width: 48px;
+$sand-steps-step-past-opacity: 1;
+$sand-steps-step-current-opacity: 1;
+$sand-steps-step-future-opacity: 0.2;
+
 // Tooltip
 // ---------------------------------------
 $sand-tooltip-font-weight: 600;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -388,6 +388,10 @@ $sand-button-icon-only-colordot-height: 9px;
 $sand-button-collapse-duration: 300ms;
 $sand-button-collapsable-icon-margin: 0 24px;
 
+// Date and Time Picker
+$sand-datecomponentpicker-margin: 24px;
+$sand-timepicker-colon-margin: 0 6px;
+
 // Header
 // ---------------------------------------
 $sand-header-slotabove-margin: 0 (-$sand-component-spacing) 30px (-$sand-component-spacing); // Negative margins accommodate the component-spacing
@@ -897,3 +901,9 @@ $sand-tooltip-label-height: 1.5em;
 $sand-tooltip-padding: (15px - calc((81px - 63px) / 2)) 48px; // Including the math for the difference in measured height of the node (81px) vs the GUI spec (63px) (we mismatch due to i18n line-height guidelines). The GUI Guide also says 15px padding, so we include that in the math for clarity.
 $sand-tooltip-margin-offset: 18px; // GUI for the length of the arrow
 $sand-tooltip-marquee-width: 600px;
+
+// WizardPanels
+// ---------------------------------------
+$sand-wizardpanels-content-margin: 0 0 150px 0;
+$sand-wizardpanels-footer-margin: 0 0 (102px - $sand-app-keepout) 0;
+$sand-wizardpanels-button-icon-text-gap: 54px;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -835,6 +835,36 @@ $sand-popuptablayout-panel-body-padding: $sand-panel-body-padding-top (108px - $
 // ---------------------------------------
 $sand-scrim-color: fade(black, 30%);
 
+// Scrollbar
+// ---------------------------------------
+$sand-scrollbar-padding: 30px;
+$sand-scrollbar-size: 36px;
+$sand-scrollbar-focusable-size: 60px;
+$sand-scrollbar-track-margin: 12px;
+$sand-scrollbar-track-focusable-margin: 24px;
+$sand-scrollbar-track-width: 12px;
+$sand-scrollbar-track-border-radius: 12px;
+$sand-scrollbar-thumb-border-radius: 12px;
+$sand-scrollbar-thumb-focus-width: 30px;
+$sand-scrollbar-thumb-focus-left: -9px;
+$sand-scrollbar-thumb-focus-border-radius: 12px;
+$sand-scrollbar-thumb-focus-box-shadow: 0 36px 36px;
+$sand-scrollbar-thumb-focus-direction-indicator-width: 18px;
+$sand-scrollbar-thumb-focus-direction-indicator-height: 12px;
+$sand-scrollbar-thumb-focus-direction-indicator-top: 6px;
+$sand-scrollbar-thumb-focus-direction-indicator-left: 6px;
+
+// Scroller
+// ---------------------------------------
+$sand-scroll-fade-out-size: 48px;
+$sand-scroll-fade-out-offset: 24px;
+$sand-scroll-vertical-fade-out-padding: $sand-scroll-fade-out-size 0;
+$sand-scroll-horizontal-fade-out-padding: 0 $sand-scroll-fade-out-size;
+$sand-scroll-hover-area-size: 120px;
+$sand-scroll-focusablebody-padding: 72px 48px 72px 90px;
+$sand-scroll-focusablebody-padding-rtl: 72px 90px 72px 48px;
+$sand-scroll-focusablebody-focus-border-radius: 12px;
+
 // Slider
 // ---------------------------------------
 $sand-slider-bar-height: $sand-progressbar-bar-thickness;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -867,6 +867,22 @@ $sand-steps-step-past-opacity: 1;
 $sand-steps-step-current-opacity: 1;
 $sand-steps-step-future-opacity: 0.2;
 
+// Switch
+// ---------------------------------------
+$sand-switch-border-radius: 960px;
+$sand-switch-height: 60px;
+$sand-switch-width: 114px;
+$sand-switch-icon-height: $sand-switch-height;
+$sand-switch-icon-line-height: $sand-switch-height;
+$sand-switch-height-large: $sand-icon-small-size-large;
+$sand-switch-width-large: 162px;
+$sand-switch-icon-height-large: $sand-icon-small-size-large;
+$sand-switch-icon-line-height-large: $sand-switch-icon-height-large;
+$sand-switch-spottable-margin: 18px ($sand-component-spacing + 30px);
+$sand-switch-spottable-border-radius: $sand-item-border-radius;
+$sand-switch-spottable-position-top-bottom: -18px; // These correlate with the numbers from 'margin" above
+$sand-switch-spottable-position-left-right: -30px; // These correlate with the numbers from 'margin" above
+
 // Tooltip
 // ---------------------------------------
 $sand-tooltip-font-weight: 600;

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -9,7 +9,7 @@ import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
 import {getLastInputType} from '../ThemeDecorator';
 
-import css from './HoverToScroll.module.less';
+import css from './HoverToScroll.module.scss';
 
 const {epsilon} = constants;
 const nop = () => {};

--- a/useScroll/HoverToScroll.module.scss
+++ b/useScroll/HoverToScroll.module.scss
@@ -1,0 +1,33 @@
+// HoverToScroll.module.scss
+//
+@use "../styles/mixins";
+@use "../styles/variables";
+
+.hoverToScroll {
+	position: absolute;
+	z-index: 10;
+	pointer-events: none;
+	:global(.spotlight-input-mouse) & {
+		pointer-events: auto;
+	}
+
+	&.vertical {
+		width: 100%;
+		height: variables.$sand-scroll-hover-area-size;
+		&.after {
+			bottom: 0;
+		}
+	}
+	&.horizontal {
+		width: variables.$sand-scroll-hover-area-size;
+		height: 100%;
+
+		&.before {
+			@include mixins.position-start-end(0, auto);
+		}
+
+		&.after {
+			@include mixins.position-start-end(auto, 0);
+		}
+	}
+}

--- a/useScroll/OverscrollEffect.module.scss
+++ b/useScroll/OverscrollEffect.module.scss
@@ -1,0 +1,19 @@
+// OverscrollEffect.module.scss
+//
+
+.scroll {
+	--scroll-overscroll-translate-horizontal: none;
+	--scroll-overscroll-transition-horizontal: transform 0 unset;
+	--scroll-overscroll-translate-vertical: none;
+	--scroll-overscroll-transition-vertical: transform 0 unset;
+}
+
+.horizontal {
+	transform: var(--scroll-overscroll-translate-horizontal);
+	transition: var(--scroll-overscroll-transition-horizontal);
+}
+
+.vertical {
+	transform: var(--scroll-overscroll-translate-vertical);
+	transition: var(--scroll-overscroll-transition-vertical);
+}

--- a/useScroll/Scrollbar.module.scss
+++ b/useScroll/Scrollbar.module.scss
@@ -1,0 +1,31 @@
+// Scrollbar.module.scss
+//
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.scrollbar {
+	background: none;
+	border-color: transparent;
+	opacity: 1;
+	pointer-events: none;
+	transition: opacity 100ms ease-out;
+	will-change: opacity;
+
+	&.horizontal {
+		@include mixins.enact-locale-rtl("") {
+			// Flip the entire bar horizontally in RTL mode, and force it to remain in LTR.
+			direction: ltr;
+			transform: scaleX(-1);
+		}
+	}
+
+	&.focusableScrollbar {
+		pointer-events: auto;
+	}
+
+	/* ScrollbarTrack */
+	.scrollbarTrackShown {
+		opacity: 1;
+	}
+}

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -8,7 +8,7 @@ import {forwardRef, useCallback, useEffect, useRef} from 'react';
 
 import $L from '../internal/$L';
 
-import css from './ScrollbarTrack.module.less';
+import css from './ScrollbarTrack.module.scss';
 
 const nop = () => {};
 const

--- a/useScroll/ScrollbarTrack.module.scss
+++ b/useScroll/ScrollbarTrack.module.scss
@@ -1,0 +1,118 @@
+// ScrollbarTrack.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/skin";
+@use "../styles/variables";
+
+.scrollbarTrack {
+	--scrollbar-track-margin: variables.$sand-scrollbar-track-margin;
+	--scrollbar-thumb-size-ratio: 1;
+	--scrollbar-thumb-progress-ratio: 0;
+	--scrollbar-thumb-size: calc(100% * var(--scrollbar-thumb-size-ratio));
+	--scrollbar-thumb-progress: calc(((1 - var(--scrollbar-thumb-size-ratio)) * var(--scrollbar-thumb-progress-ratio)) * 100%);
+
+	position: relative;
+	height: 100%;
+	width: 100%;
+	background-color: colors.$sand-scrollbar-track-bg-color;
+	border-radius: variables.$sand-scrollbar-track-border-radius;
+	opacity: 0;
+	transition: opacity 100ms ease-out;
+
+	&:hover {
+		opacity: 1;
+	}
+
+	&.focusableScrollbar {
+		// Always show the scrollbar
+		opacity: 1;
+		--scrollbar-track-margin: variables.$sand-scrollbar-track-focusable-margin;
+	}
+
+	.thumb {
+		background: colors.$sand-scrollbar-thumb-bg-color;
+		display: block;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		border-radius: variables.$sand-scrollbar-thumb-border-radius;
+
+		@include mixins.focus {
+			position: absolute;
+			background-color: colors.$sand-scrollbar-thumb-focus-bg-color;
+			box-shadow: variables.$sand-scrollbar-thumb-focus-box-shadow colors.$sand-scrollbar-thumb-focus-box-shadow-color;
+			border-radius: variables.$sand-scrollbar-thumb-focus-border-radius;
+
+			.directionIndicator {
+				position: absolute;
+				width: 0;
+				height: 0;
+				border-top: variables.$sand-scrollbar-thumb-focus-direction-indicator-height solid transparent;
+				border-bottom: variables.$sand-scrollbar-thumb-focus-direction-indicator-height solid colors.$sand-scrollbar-thumb-focus-direction-indicator-color;
+				border-right: variables.$sand-scrollbar-thumb-focus-direction-indicator-width/2 solid transparent;
+				border-left: variables.$sand-scrollbar-thumb-focus-direction-indicator-width/2 solid transparent;
+			}
+		}
+
+		:global(.spotlight-input-touch) & {
+			pointer-events: none;
+		}
+	}
+
+	&.vertical {
+		margin: 0 var(--scrollbar-track-margin);
+		width: variables.$sand-scrollbar-track-width;
+
+		.thumb {
+			height: var(--scrollbar-thumb-size);
+			top: var(--scrollbar-thumb-progress);
+			will-change: top;
+
+			&:focus {
+				width: variables.$sand-scrollbar-thumb-focus-width;
+				left: variables.$sand-scrollbar-thumb-focus-left;
+
+				.directionIndicator.backward {
+					top: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
+					left: variables.$sand-scrollbar-thumb-focus-direction-indicator-left;
+				}
+
+				.directionIndicator.forward {
+					transform: rotate(180deg);
+					bottom: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
+					left: variables.$sand-scrollbar-thumb-focus-direction-indicator-left;
+				}
+			}
+		}
+	}
+
+	&:not(.vertical) {
+		margin: var(--scrollbar-track-margin) 0;
+		height: variables.$sand-scrollbar-track-width;
+
+		.thumb {
+			width: var(--scrollbar-thumb-size);
+			left: var(--scrollbar-thumb-progress);
+			will-change: left;
+			top: 50%;
+			transform: translateY(-50%);
+
+			@include mixins.focus {
+				height: variables.$sand-scrollbar-thumb-focus-width;
+
+				.directionIndicator.backward {
+					transform: rotate(-90deg);
+					left: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
+					top: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-left/2);
+				}
+
+				.directionIndicator.forward {
+					transform: rotate(90deg);
+					right: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
+					top: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-left/2);
+				}
+			}
+		}
+	}
+}

--- a/useScroll/ScrollbarTrack.module.scss
+++ b/useScroll/ScrollbarTrack.module.scss
@@ -1,5 +1,6 @@
 // ScrollbarTrack.module.scss
 //
+@use "sass:math";
 @use "../styles/colors";
 @use "../styles/mixins";
 @use "../styles/skin";
@@ -50,8 +51,8 @@
 				height: 0;
 				border-top: variables.$sand-scrollbar-thumb-focus-direction-indicator-height solid transparent;
 				border-bottom: variables.$sand-scrollbar-thumb-focus-direction-indicator-height solid colors.$sand-scrollbar-thumb-focus-direction-indicator-color;
-				border-right: variables.$sand-scrollbar-thumb-focus-direction-indicator-width/2 solid transparent;
-				border-left: variables.$sand-scrollbar-thumb-focus-direction-indicator-width/2 solid transparent;
+				border-right: math.div(variables.$sand-scrollbar-thumb-focus-direction-indicator-width, 2) solid transparent;
+				border-left: math.div(variables.$sand-scrollbar-thumb-focus-direction-indicator-width, 2) solid transparent;
 			}
 		}
 
@@ -74,13 +75,13 @@
 				left: variables.$sand-scrollbar-thumb-focus-left;
 
 				.directionIndicator.backward {
-					top: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
+					top: calc(#{variables.$sand-scrollbar-thumb-focus-direction-indicator-top} - #{variables.$sand-scrollbar-thumb-focus-direction-indicator-height});
 					left: variables.$sand-scrollbar-thumb-focus-direction-indicator-left;
 				}
 
 				.directionIndicator.forward {
 					transform: rotate(180deg);
-					bottom: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
+					bottom: calc(#{variables.$sand-scrollbar-thumb-focus-direction-indicator-top} - #{variables.$sand-scrollbar-thumb-focus-direction-indicator-height});
 					left: variables.$sand-scrollbar-thumb-focus-direction-indicator-left;
 				}
 			}
@@ -103,14 +104,14 @@
 
 				.directionIndicator.backward {
 					transform: rotate(-90deg);
-					left: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
-					top: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-left/2);
+					left: calc(#{variables.$sand-scrollbar-thumb-focus-direction-indicator-top} - #{variables.$sand-scrollbar-thumb-focus-direction-indicator-height});
+					top: math.div(variables.$sand-scrollbar-thumb-focus-direction-indicator-left, 2);
 				}
 
 				.directionIndicator.forward {
 					transform: rotate(90deg);
-					right: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-top - variables.$sand-scrollbar-thumb-focus-direction-indicator-height);
-					top: calc(variables.$sand-scrollbar-thumb-focus-direction-indicator-left/2);
+					right: calc(#{variables.$sand-scrollbar-thumb-focus-direction-indicator-top} - #{variables.$sand-scrollbar-thumb-focus-direction-indicator-height});
+					top: math.div(variables.$sand-scrollbar-thumb-focus-direction-indicator-left, 2);
 				}
 			}
 		}

--- a/useScroll/ScrollbarTrack.module.scss
+++ b/useScroll/ScrollbarTrack.module.scss
@@ -7,7 +7,7 @@
 @use "../styles/variables";
 
 .scrollbarTrack {
-	--scrollbar-track-margin: variables.$sand-scrollbar-track-margin;
+	--scrollbar-track-margin: #{variables.$sand-scrollbar-track-margin};
 	--scrollbar-thumb-size-ratio: 1;
 	--scrollbar-thumb-progress-ratio: 0;
 	--scrollbar-thumb-size: calc(100% * var(--scrollbar-thumb-size-ratio));
@@ -28,7 +28,7 @@
 	&.focusableScrollbar {
 		// Always show the scrollbar
 		opacity: 1;
-		--scrollbar-track-margin: variables.$sand-scrollbar-track-focusable-margin;
+		--scrollbar-track-margin: #{variables.$sand-scrollbar-track-focusable-margin};
 	}
 
 	.thumb {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -31,8 +31,8 @@ import {
 import useOverscrollEffect from './useOverscrollEffect';
 import {useSpotlightRestore} from './useSpotlight';
 
-import overscrollCss from './OverscrollEffect.module.less';
-import css from './useScroll.module.less';
+import overscrollCss from './OverscrollEffect.module.scss';
+import css from './useScroll.module.scss';
 
 const
 	arrowKeyMultiplier = 0.2,

--- a/useScroll/useScroll.module.scss
+++ b/useScroll/useScroll.module.scss
@@ -1,0 +1,66 @@
+// useScroll.module.scss
+//
+@use "../styles/colors";
+@use "../styles/mixins";
+@use "../styles/variables";
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, variables.$sand-scrollbar-focusable-size - variables.$sand-scrollbar-size);
+}
+
+.scroll {
+	--scroll-scrollbar-size: variables.$sand-scrollbar-size;
+
+	box-sizing: border-box;
+	overflow: hidden;
+
+	&.focusableScrollbar {
+		--scroll-scrollbar-size: variables.$sand-scrollbar-focusable-size;
+	}
+
+	.verticalScrollbar {
+		position: absolute;
+		width: var(--scroll-scrollbar-size);
+		height: calc(100% - 2 * variables.$sand-scrollbar-padding);
+		right: 0;
+		top: 0;
+		padding: variables.$sand-scrollbar-padding 0;
+	}
+
+	@include mixins.enact-locale-rtl("") {
+		.verticalScrollbar {
+			left: 0;
+			right: initial;
+		}
+	}
+
+	.horizontalScrollbar {
+		position: absolute;
+		width: calc(100% - 2 * variables.$sand-scrollbar-padding);
+		height: var(--scroll-scrollbar-size);
+		left: 0;
+		bottom: 0;
+		padding: 0 variables.$sand-scrollbar-padding;
+	}
+
+	&.bidirectional {
+		.verticalScrollbar {
+			height: calc(100% - 2 * variables.$sand-scrollbar-padding - var(--scroll-scrollbar-size));
+		}
+
+		.horizontalScrollbar {
+			width: calc(100% - 2 * variables.$sand-scrollbar-padding -  var(--scroll-scrollbar-size));
+			left: 0;
+		}
+
+		@include mixins.enact-locale-rtl("") {
+			.horizontalScrollbar {
+				left: var(--scroll-scrollbar-size);
+			}
+		}
+	}
+
+	.scrollContent {
+		box-sizing: border-box;
+	}
+}

--- a/useScroll/useScroll.module.scss
+++ b/useScroll/useScroll.module.scss
@@ -9,13 +9,13 @@
 }
 
 .scroll {
-	--scroll-scrollbar-size: variables.$sand-scrollbar-size;
+	--scroll-scrollbar-size: #{variables.$sand-scrollbar-size};
 
 	box-sizing: border-box;
 	overflow: hidden;
 
 	&.focusableScrollbar {
-		--scroll-scrollbar-size: variables.$sand-scrollbar-focusable-size;
+		--scroll-scrollbar-size: #{variables.$sand-scrollbar-focusable-size};
 	}
 
 	.verticalScrollbar {

--- a/useScroll/useScroll.module.scss
+++ b/useScroll/useScroll.module.scss
@@ -21,7 +21,7 @@
 	.verticalScrollbar {
 		position: absolute;
 		width: var(--scroll-scrollbar-size);
-		height: calc(100% - 2 * variables.$sand-scrollbar-padding);
+		height: calc(100% - 2 * #{variables.$sand-scrollbar-padding});
 		right: 0;
 		top: 0;
 		padding: variables.$sand-scrollbar-padding 0;
@@ -36,7 +36,7 @@
 
 	.horizontalScrollbar {
 		position: absolute;
-		width: calc(100% - 2 * variables.$sand-scrollbar-padding);
+		width: calc(100% - 2 * #{variables.$sand-scrollbar-padding});
 		height: var(--scroll-scrollbar-size);
 		left: 0;
 		bottom: 0;
@@ -45,11 +45,11 @@
 
 	&.bidirectional {
 		.verticalScrollbar {
-			height: calc(100% - 2 * variables.$sand-scrollbar-padding - var(--scroll-scrollbar-size));
+			height: calc(100% - 2 * #{variables.$sand-scrollbar-padding} - var(--scroll-scrollbar-size));
 		}
 
 		.horizontalScrollbar {
-			width: calc(100% - 2 * variables.$sand-scrollbar-padding -  var(--scroll-scrollbar-size));
+			width: calc(100% - 2 * #{variables.$sand-scrollbar-padding} -  var(--scroll-scrollbar-size));
 			left: 0;
 		}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In order to migrate to SCSS, each Sandstone component styling must be converted one at a time. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Converted styling to SCSS for `Steps`, `Switch`, `SwitchItem`, `TimePicker`, `useScroll`, `VideoPlayer`, `VirtualList` and `WizardPanels` Sandstone components.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ-32429

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com