### PR TITLE
WRR-1863: Convert styles in internal and samples

### DIFF
--- a/Checkbox/Checkbox.module.scss
+++ b/Checkbox/Checkbox.module.scss
@@ -1,6 +1,5 @@
 // Checkbox.module.scss
 //
-
 @use "../styles/color-mixins";
 @use "../styles/colors";
 @use "../styles/mixins";

--- a/PageViews/Page.module.scss
+++ b/PageViews/Page.module.scss
@@ -1,5 +1,6 @@
 // Page.module.scss
 //
+
 .page {
     height: 100%;
 }

--- a/internal/DateComponentPicker/DateComponentPicker.js
+++ b/internal/DateComponentPicker/DateComponentPicker.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import Picker, {PickerItem} from '../Picker';
 
-import css from './DateComponentPicker.module.less';
+import css from './DateComponentPicker.module.scss';
 
 /**
  * {@link sandstone/internal/DataComponentPicker.DateComponentPickerBase} allows the selection of one

--- a/internal/DateComponentPicker/DateComponentPicker.module.scss
+++ b/internal/DateComponentPicker/DateComponentPicker.module.scss
@@ -1,0 +1,21 @@
+// DateComponentPicker.module.scss
+//
+@use "../../styles/mixins";
+@use "../../styles/variables";
+
+.dateComponentPicker {
+	display: inline-block;
+	text-align: center;
+	margin: variables.$sand-datecomponentpicker-margin;
+	vertical-align: inherit;
+
+	.label {
+		@include mixins.sand-body-text;
+
+		& {
+			text-align: center;
+			padding: 36px variables.$sand-spotlight-outset;
+			white-space: nowrap;
+		}
+	}
+}

--- a/internal/DateComponentPicker/DateComponentRangePicker.js
+++ b/internal/DateComponentPicker/DateComponentRangePicker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import RangePicker from '../../RangePicker';
 
-import css from './DateComponentPicker.module.less';
+import css from './DateComponentPicker.module.scss';
 
 /**
  * {@link sandstone/internal/DataComponentPicker.DateComponentRangePicker} allows the selection of

--- a/internal/DateTime/DateTime.js
+++ b/internal/DateTime/DateTime.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import Heading from '../../Heading';
 
-import componentCss from './DateTime.module.less';
+import componentCss from './DateTime.module.scss';
 
 /**
  * {@link sandstone/internal/DateTime.DateTime} provides the surrounding

--- a/internal/DateTime/DateTime.module.scss
+++ b/internal/DateTime/DateTime.module.scss
@@ -1,0 +1,25 @@
+// DateTime.module.scss
+//
+@use "../../styles/variables";
+
+.dateTime {
+	display: inline-block;
+
+	.heading {
+		font-weight: normal;
+	}
+
+	.pickers {
+		vertical-align: middle;
+		// direction: ltr;
+		margin: variables.$sand-component-spacing;
+
+		> *:first-child {
+			margin-inline-start: 0
+		}
+
+		> *:nth-last-child(2) {
+			margin-inline-end: 0
+		}
+	}
+}

--- a/samples/event-logger/src/components/InputBoard/Filter/Filter.js
+++ b/samples/event-logger/src/components/InputBoard/Filter/Filter.js
@@ -10,7 +10,7 @@ import {setEventCapturing as setEventCapturingAction} from '../../../reducer/eve
 import {isSyntheticEventOn as isSyntheticEventOnAction} from '../../../reducer/syntheticEventOnReducer';
 import {setTimerIndex as setTimerIndexAction} from '../../../reducer/timerIndexReducer';
 
-import css from './Filter.module.less';
+import css from './Filter.module.scss';
 
 const Filter = () => {
 	const dispatch = useContext(EventLoggerDispatchContext);

--- a/samples/event-logger/src/components/InputBoard/Filter/Filter.module.scss
+++ b/samples/event-logger/src/components/InputBoard/Filter/Filter.module.scss
@@ -1,0 +1,24 @@
+// Filter.module.scss
+//
+
+.eventGroup {
+	display: flex;
+
+	.pickerItem {
+		display: inline-flex;
+		margin-bottom: 30px;
+		align-items: center;
+	}
+
+	.switchItem {
+		font-size: 48px;
+		max-width: 840px;
+	}
+}
+
+// Allow items to wrap onto multiple lines on mobile devices
+@media (max-width: 1284px) {
+	.eventGroup {
+		flex-wrap: wrap;
+	}
+}

--- a/samples/event-logger/src/components/Log/Log.js
+++ b/samples/event-logger/src/components/Log/Log.js
@@ -1,7 +1,7 @@
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 
-import css from './Log.module.less';
+import css from './Log.module.scss';
 
 const Log = kind({
 	name: 'Log',

--- a/samples/event-logger/src/components/Log/Log.module.scss
+++ b/samples/event-logger/src/components/Log/Log.module.scss
@@ -1,0 +1,36 @@
+// Log.module.scss
+//
+
+.log {
+	line-height: 36px;
+
+	& > div {
+		display: inline-block;
+		padding:0 12px;
+		margin: 0 12px;
+		line-height: initial;
+		font-size: 36px;
+	}
+
+	div.name {
+		width: 210px;
+	}
+
+	div.elementKind {
+		width: 72px;
+	}
+
+	div.eventCapturing {
+		width: 150px;
+	}
+
+	div.eventInfo {
+		padding-left: 12px;
+	}
+}
+
+.content {
+	width: 100%;
+	margin-top: 12px;
+	overflow: hidden;
+}

--- a/samples/event-logger/src/components/Log/Logs.js
+++ b/samples/event-logger/src/components/Log/Logs.js
@@ -7,7 +7,7 @@ import {EventLoggerContext} from '../../context/EventLoggerContext';
 
 import Log from './Log';
 
-import css from './Log.module.less';
+import css from './Log.module.scss';
 
 const Logs = kind({
 	name: 'LogBase',

--- a/samples/event-logger/src/views/MainView.js
+++ b/samples/event-logger/src/views/MainView.js
@@ -3,7 +3,7 @@ import kind from '@enact/core/kind';
 import InputBoard from '../components/InputBoard';
 import Logs from '../components/Log';
 
-import css from './MainView.module.less';
+import css from './MainView.module.scss';
 
 const MainView = kind({
 	name: 'MainView',

--- a/samples/event-logger/src/views/MainView.module.scss
+++ b/samples/event-logger/src/views/MainView.module.scss
@@ -1,0 +1,28 @@
+// MainView.module.scss
+//
+
+$background-color: #e6e6e6;
+$hover-background-color: #abaeb3;
+$font-color: #4c5059;
+
+.mainView {
+	display: flex;
+	width: 100%;
+	height: 100%;
+	flex-direction: column;
+}
+
+.inputBoard {
+	background-color: $background-color;
+	height: 144px;
+	padding: 6px;
+	border-radius: 6px;
+	color: $font-color;
+	line-height: 36px;
+	font-size: 36px;
+
+	&:hover {
+		background-color: $hover-background-color;
+		color: $font-color;
+	}
+}

--- a/samples/perf-scroller-native/src/App.js
+++ b/samples/perf-scroller-native/src/App.js
@@ -2,7 +2,7 @@ import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 
-import css from './App.module.less';
+import css from './App.module.scss';
 
 const
 	items = [],

--- a/samples/perf-scroller-native/src/App.module.scss
+++ b/samples/perf-scroller-native/src/App.module.scss
@@ -1,0 +1,10 @@
+// App.module.scss
+//
+
+body {
+	overflow: hidden;
+}
+
+.item {
+	margin-bottom: 0;
+}

--- a/samples/perf-scroller-translate/src/App.js
+++ b/samples/perf-scroller-translate/src/App.js
@@ -2,7 +2,7 @@ import Item from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 
-import css from './App.module.less';
+import css from './App.module.scss';
 
 const
 	items = [],

--- a/samples/perf-scroller-translate/src/App.module.scss
+++ b/samples/perf-scroller-translate/src/App.module.scss
@@ -1,0 +1,10 @@
+// App.module.scss
+//
+
+body {
+	overflow: hidden;
+}
+
+.item {
+	margin-bottom: 0;
+}

--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -54,7 +54,7 @@ import VirtualGridList from '../views/VirtualGridList';
 import VirtualList from '../views/VirtualList';
 import WizardPanels from '../views/WizardPanels';
 
-import appCss from './App.module.less';
+import appCss from './App.module.scss';
 import Home from './Home';
 import View from './View';
 

--- a/samples/qa-a11y/src/App/App.module.scss
+++ b/samples/qa-a11y/src/App/App.module.scss
@@ -146,37 +146,58 @@ h2 {
 			content: "Role:\0020" attr(role);
 		}
 
-		--aria-label: "";
+		& {
+			--aria-label: "";
+		}
+
 		[aria-label]::after {
 			--aria-label: "label:\0020'" attr(aria-label) "'\0020/\0020";
 		}
 
-		--aria-valuetext: "";
+		& {
+			--aria-valuetext: "";
+		}
+
 		[aria-valuetext]::after {
 			--aria-valuetext: "valuetext:\0020'" attr(aria-valuetext) "'\0020/\0020";
 		}
 
-		--aria-checked: "";
+		& {
+			--aria-checked: "";
+		}
+
 		[aria-checked]::after {
 			--aria-checked: "checked:\0020'" attr(aria-checked) "'\0020/\0020";
 		}
 
-		--aria-live: "";
+		& {
+			--aria-live: "";
+		}
+
 		[aria-live]::after {
 			--aria-live: "live:\0020'" attr(aria-live) "'\0020/\0020";
 		}
 
-		--aria-labelledby: "";
+		& {
+			--aria-labelledby: "";
+		}
+
 		[aria-labelledby]::after {
 			--aria-labelledby: "labelledby:\0020'" attr(aria-labelledby) "'\0020/\0020";
 		}
 
-		--aria-owns: "";
+		& {
+			--aria-owns: "";
+		}
+
 		[aria-owns]::after {
 			--aria-owns: "owns:\0020'" attr(aria-owns) "'\0020/\0020";
 		}
 
-		--aria-disabled: "";
+		& {
+			--aria-disabled: "";
+		}
+
 		[aria-disabled="true"]::after {
 			--aria-disabled: "disabled:\0020'" attr(aria-disabled) "'\0020/\0020";
 		}

--- a/samples/qa-a11y/src/App/App.module.scss
+++ b/samples/qa-a11y/src/App/App.module.scss
@@ -1,0 +1,200 @@
+// App.module.scss
+//
+
+body {
+	position: fixed;
+	overflow: hidden;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+}
+
+h2 {
+	font-style: italic;
+	font-weight: bold;
+}
+
+.jumpToView {
+	height: 60px;
+	font-size: 36px;
+}
+
+.layout {
+	height: 100%;
+}
+
+.navItem {
+	height: 42px;
+	margin: 0;
+
+	& > div {
+		pointer-events: none;
+		font-size: 36px;
+	}
+
+	& > div:nth-child(2) {
+		color: #e6e6e6;
+	}
+}
+
+.marginTop {
+	margin-top: 90px;
+}
+
+.headerMarginTop {
+	margin-top: 180px;
+}
+
+.controls {
+	position: absolute;
+	display: flex;
+	top: 0;
+	right: 100%;
+
+	:global(.enact-locale-right-to-left) & {
+		right: initial;
+		left: 100%;
+	}
+}
+
+:global {
+	// To help visually tell what's going on
+	// `.debug.aria` Add in an Aria overlay to visualize what is assigned to the aria attributes
+	.debug.aria,
+	.debug.aria + div {
+		// If the position of the `div` element including the following aria attributes, is `static`.
+		// Then the before and after pseudo element will position incorrectly.
+		[aria-label],
+		[aria-valuetext],
+		[aria-checked],
+		[aria-live],
+		[aria-labelledby],
+		[aria-owns],
+		[aria-disabled="true"],
+		[role] {
+			& [role="region"] {
+				position: relative;
+			}
+		}
+
+		// The before and after pseudo element position and look
+		[aria-label]::after,
+		[aria-valuetext]::after,
+		[aria-checked]::after,
+		[aria-live]::after,
+		[aria-labelledby]::after,
+		[aria-owns]::after,
+		[aria-disabled="true"]::after,
+		[role]::before {
+			position: absolute;
+			padding: 0 1ex;
+			border-radius: 0.5em;
+			border-top-right-radius: 0;
+			border-top-left-radius: 0;
+			top: initial;
+			bottom: 0;
+			transform: translateY(100%);
+			z-index: 2;
+
+			color: white;
+			line-height: 1.3em;
+			font-size: small;
+			font-weight: 100;
+
+			pointer-events: none;
+		}
+
+		[role]::before {
+			background-color: darkred;
+			border: 1px solid red;
+			right: 50%;
+			left: initial;
+		}
+
+		[aria-label]::after,
+		[aria-valuetext]::after,
+		[aria-checked]::after,
+		[aria-live]::after,
+		[aria-labelledby]::after,
+		[aria-owns]::after,
+		[aria-disabled="true"]::after {
+			background-color: #ffaa0099;
+			border: 1px solid #ffaa00;
+			right: initial;
+			left: 50%;
+		}
+
+		[aria-live]::after,
+		[aria-labelledby]::after,
+		[aria-owns]::after,
+		[role][aria-live]::before,
+		[role][aria-labelledby]::before,
+		[role][aria-owns]::before {
+			border-radius: 0.5em;
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+			top: 0;
+			bottom: initial;
+			transform: translateY(-100%);
+
+			color: black;
+		}
+
+		// The before and after pseudo element content
+
+		[role]::before {
+			content: "Role:\0020" attr(role);
+		}
+
+		--aria-label: "";
+		[aria-label]::after {
+			--aria-label: "label:\0020'" attr(aria-label) "'\0020/\0020";
+		}
+
+		--aria-valuetext: "";
+		[aria-valuetext]::after {
+			--aria-valuetext: "valuetext:\0020'" attr(aria-valuetext) "'\0020/\0020";
+		}
+
+		--aria-checked: "";
+		[aria-checked]::after {
+			--aria-checked: "checked:\0020'" attr(aria-checked) "'\0020/\0020";
+		}
+
+		--aria-live: "";
+		[aria-live]::after {
+			--aria-live: "live:\0020'" attr(aria-live) "'\0020/\0020";
+		}
+
+		--aria-labelledby: "";
+		[aria-labelledby]::after {
+			--aria-labelledby: "labelledby:\0020'" attr(aria-labelledby) "'\0020/\0020";
+		}
+
+		--aria-owns: "";
+		[aria-owns]::after {
+			--aria-owns: "owns:\0020'" attr(aria-owns) "'\0020/\0020";
+		}
+
+		--aria-disabled: "";
+		[aria-disabled="true"]::after {
+			--aria-disabled: "disabled:\0020'" attr(aria-disabled) "'\0020/\0020";
+		}
+
+		[aria-label]::after,
+		[aria-valuetext]::after,
+		[aria-checked]::after,
+		[aria-live]::after,
+		[aria-labelledby]::after,
+		[aria-disabled="true"]::after {
+			content:
+				var(--aria-label)
+				var(--aria-valuetext)
+				var(--aria-checked)
+				var(--aria-live)
+				var(--aria-labelledby)
+				var(--aria-owns)
+				var(--aria-disabled)
+		}
+	}
+}

--- a/samples/qa-a11y/src/components/Section.js
+++ b/samples/qa-a11y/src/components/Section.js
@@ -5,7 +5,7 @@ import {Cell, Row} from '@enact/ui/Layout';
 
 import Heading from '@enact/sandstone/Heading';
 
-import css from './Section.module.less';
+import css from './Section.module.scss';
 
 //
 // A "section" to be used in Kitchen-Sink style QA stories

--- a/samples/qa-a11y/src/components/Section.module.scss
+++ b/samples/qa-a11y/src/components/Section.module.scss
@@ -1,0 +1,15 @@
+// Section.module.scss
+//
+
+.section {
+	label {
+		margin-inline-end: 1em;
+		font-weight: 300;
+		font-size: 80%;
+		text-align: end;
+	}
+
+	.componentDemo {
+		margin: 0.5em 1em;
+	}
+}

--- a/samples/qa-a11y/src/views/Alert.js
+++ b/samples/qa-a11y/src/views/Alert.js
@@ -4,7 +4,7 @@ import Button from '@enact/sandstone/Button';
 import Section from '../components/Section';
 import useArrayState from '../components/useArrayState';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const AlertView = () => {
 	const [open, handleOpen] = useArrayState(8);

--- a/samples/qa-a11y/src/views/Button.js
+++ b/samples/qa-a11y/src/views/Button.js
@@ -2,7 +2,7 @@ import Button from '@enact/sandstone/Button';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const ButtonView = () => (
 	<>

--- a/samples/qa-a11y/src/views/Checkbox.js
+++ b/samples/qa-a11y/src/views/Checkbox.js
@@ -2,7 +2,7 @@ import Checkbox from '@enact/sandstone/Checkbox';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const CheckboxView = () => (
 	<>

--- a/samples/qa-a11y/src/views/CheckboxItem.js
+++ b/samples/qa-a11y/src/views/CheckboxItem.js
@@ -2,7 +2,7 @@ import CheckboxItem from '@enact/sandstone/CheckboxItem';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const CheckboxItemView = () => (
 	<>

--- a/samples/qa-a11y/src/views/DatePicker.js
+++ b/samples/qa-a11y/src/views/DatePicker.js
@@ -8,7 +8,7 @@ import {useState} from 'react';
 import Section from '../components/Section';
 import useArrayState from '../components/useArrayState';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const DatePickerItem = (props) => {
 	const [open, handleOpen] = useArrayState(1);

--- a/samples/qa-a11y/src/views/Dropdown.js
+++ b/samples/qa-a11y/src/views/Dropdown.js
@@ -5,7 +5,7 @@ import {useState} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const list = [
 	{children: 'Option0', key: 'item0'},

--- a/samples/qa-a11y/src/views/FormCheckboxItem.js
+++ b/samples/qa-a11y/src/views/FormCheckboxItem.js
@@ -2,7 +2,7 @@ import FormCheckboxItem from '@enact/sandstone/FormCheckboxItem';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const FormCheckboxItemView = () => (
 	<>

--- a/samples/qa-a11y/src/views/Group.js
+++ b/samples/qa-a11y/src/views/Group.js
@@ -3,7 +3,7 @@ import Group from '@enact/ui/Group';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const GroupView = () => (
 	<>

--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -3,7 +3,7 @@ import {useState} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const SelectableImageItem = (props) => {
 	const [checked, setChecked] = useState(false);

--- a/samples/qa-a11y/src/views/Input.js
+++ b/samples/qa-a11y/src/views/Input.js
@@ -2,7 +2,7 @@ import Input from '@enact/sandstone/Input';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const InputView = () => (
 	<>

--- a/samples/qa-a11y/src/views/InputField.js
+++ b/samples/qa-a11y/src/views/InputField.js
@@ -2,7 +2,7 @@ import {InputField} from '@enact/sandstone/Input';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const InputFieldView = () => (
 	<>

--- a/samples/qa-a11y/src/views/Item.js
+++ b/samples/qa-a11y/src/views/Item.js
@@ -2,7 +2,7 @@ import Item from '@enact/sandstone/Item';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const ItemView = () => (
 	<>

--- a/samples/qa-a11y/src/views/Option.js
+++ b/samples/qa-a11y/src/views/Option.js
@@ -5,7 +5,7 @@ import {useCallback} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const Option = (props) => {
 	const {handleDebug, isDebugMode} = props;

--- a/samples/qa-a11y/src/views/Picker.js
+++ b/samples/qa-a11y/src/views/Picker.js
@@ -6,7 +6,7 @@ import {useState} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const SpotlightContainerSection = SpotlightContainerDecorator({enterTo: 'default-element', preserveId: true}, Section);
 

--- a/samples/qa-a11y/src/views/ProgressBar.js
+++ b/samples/qa-a11y/src/views/ProgressBar.js
@@ -6,7 +6,7 @@ import {useState} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const ProgressBarView = () => {
 	const [value, setValue] = useState(0);

--- a/samples/qa-a11y/src/views/ProgressButton.js
+++ b/samples/qa-a11y/src/views/ProgressButton.js
@@ -6,7 +6,7 @@ import {useState} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const ProgressButtonView = () => {
 	const [value, setValue] = useState(0);

--- a/samples/qa-a11y/src/views/RadioItem.js
+++ b/samples/qa-a11y/src/views/RadioItem.js
@@ -2,7 +2,7 @@ import RadioItem from '@enact/sandstone/RadioItem';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const RadioItemView = () => (
 	<>

--- a/samples/qa-a11y/src/views/RangePicker.js
+++ b/samples/qa-a11y/src/views/RangePicker.js
@@ -3,7 +3,7 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const SpotlightContainerSection = SpotlightContainerDecorator({enterTo: 'default-element', preserveId: true}, Section);
 

--- a/samples/qa-a11y/src/views/ReadAlert.js
+++ b/samples/qa-a11y/src/views/ReadAlert.js
@@ -6,7 +6,7 @@ import {useCallback, useEffect, useState} from 'react';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const ReadAlertView = () => {
 	const [audioGuidance, setAudioGuidance] = useState(false);

--- a/samples/qa-a11y/src/views/Region.js
+++ b/samples/qa-a11y/src/views/Region.js
@@ -4,9 +4,9 @@ import kind from '@enact/core/kind';
 import Button from '@enact/sandstone/Button';
 import Region from '@enact/sandstone/Region';
 
-import css from './Region.module.less';
+import css from './Region.module.scss';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const RegionView = kind({
 	name: 'RegionView',

--- a/samples/qa-a11y/src/views/Region.module.scss
+++ b/samples/qa-a11y/src/views/Region.module.scss
@@ -1,0 +1,6 @@
+// Region.module.scss
+//
+
+.region + .region {
+	margin: 180px 0;
+}

--- a/samples/qa-a11y/src/views/Switch.js
+++ b/samples/qa-a11y/src/views/Switch.js
@@ -2,7 +2,7 @@ import Switch from '@enact/sandstone/Switch';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const SwitchView = () => (
 	<>

--- a/samples/qa-a11y/src/views/SwitchItem.js
+++ b/samples/qa-a11y/src/views/SwitchItem.js
@@ -2,7 +2,7 @@ import SwitchItem from '@enact/sandstone/SwitchItem';
 
 import Section from '../components/Section';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const SwitchItemView = () => (
 	<>

--- a/samples/qa-a11y/src/views/TimePicker.js
+++ b/samples/qa-a11y/src/views/TimePicker.js
@@ -8,7 +8,7 @@ import {useState} from 'react';
 import Section from '../components/Section';
 import useArrayState from '../components/useArrayState';
 
-import appCss from '../App/App.module.less';
+import appCss from '../App/App.module.scss';
 
 const TimePickerItem = (props) => {
 	const [open, handleOpen] = useArrayState(1);

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -7,7 +7,7 @@ import Layout, {Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import {useState} from 'react';
 
-import css from './VirtualGridList.module.less';
+import css from './VirtualGridList.module.scss';
 
 const items = [];
 

--- a/samples/qa-a11y/src/views/VirtualGridList.module.scss
+++ b/samples/qa-a11y/src/views/VirtualGridList.module.scss
@@ -1,0 +1,11 @@
+// VirtualGridList.module.scss
+//
+@use '~@enact/sandstone/styles/mixins.scss';
+
+.verticalPadding {
+    @include mixins.padding-start-end(0, 36px);
+}
+
+.horizontalPadding {
+    padding-bottom: 36px;
+}

--- a/samples/qa-dropdown/src/App/App.module.scss
+++ b/samples/qa-dropdown/src/App/App.module.scss
@@ -1,0 +1,6 @@
+// App.module.scss
+//
+
+.app {
+	/* styles can be put here */
+}

--- a/samples/qa-fonts/src/App/App.module.scss
+++ b/samples/qa-fonts/src/App/App.module.scss
@@ -1,0 +1,6 @@
+// App.module.scss
+//
+
+.app {
+	/* styles can be put here */
+}

--- a/samples/qa-fonts/src/components/FontList/FontList.js
+++ b/samples/qa-fonts/src/components/FontList/FontList.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import Status from '../Status';
 
-import css from './FontList.module.less';
+import css from './FontList.module.scss';
 
 const FontList = kind({
 	name: 'FontList',

--- a/samples/qa-fonts/src/components/FontList/FontList.module.scss
+++ b/samples/qa-fonts/src/components/FontList/FontList.module.scss
@@ -1,0 +1,8 @@
+// FontList.module.scss
+//
+
+.list {
+	+ .list {
+		margin-top: 1em;
+	}
+}

--- a/samples/qa-fonts/src/components/Status/Status.js
+++ b/samples/qa-fonts/src/components/Status/Status.js
@@ -1,7 +1,7 @@
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 
-import css from './Status.module.less';
+import css from './Status.module.scss';
 
 const Status = kind({
 	name: 'Status',

--- a/samples/qa-fonts/src/components/Status/Status.module.scss
+++ b/samples/qa-fonts/src/components/Status/Status.module.scss
@@ -1,0 +1,14 @@
+// Status.module.scss
+//
+
+.status {
+	width: 7em;
+	display: inline-block;
+	text-align: right;
+	margin-right: 1em;
+	color: red;
+
+	&.loaded {
+		color: limegreen;
+	}
+}

--- a/samples/qa-i18n-async/src/App/App.module.scss
+++ b/samples/qa-i18n-async/src/App/App.module.scss
@@ -1,0 +1,6 @@
+// App.module.scss
+//
+
+.app {
+	// styles can be put here
+}

--- a/samples/qa-i18n/src/App/App.js
+++ b/samples/qa-i18n/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import './attachErrorHandler';
 
-import css from './App.less';
+import css from './App.module.scss';
 
 const App = kind({
 	name: 'App',

--- a/samples/qa-i18n/src/App/App.module.scss
+++ b/samples/qa-i18n/src/App/App.module.scss
@@ -1,0 +1,6 @@
+// App.module.scss
+//
+
+.app {
+	// styles can be put here
+}

--- a/samples/qa-tablayout/src/App/App.module.scss
+++ b/samples/qa-tablayout/src/App/App.module.scss
@@ -1,0 +1,6 @@
+// App.module.scss
+//
+
+.app {
+	// styles can be put here
+}

--- a/samples/qa-videoplayer/src/App/App.js
+++ b/samples/qa-videoplayer/src/App/App.js
@@ -3,7 +3,7 @@ import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import css from './App.module.scss';
 
 const App = kind({
 	name: 'App',

--- a/samples/qa-videoplayer/src/App/App.module.scss
+++ b/samples/qa-videoplayer/src/App/App.module.scss
@@ -1,0 +1,6 @@
+// App.module.scss
+//
+
+.app {
+	// styles can be put here
+}

--- a/samples/qa-virtualgridlist-datasize-changing/src/App.js
+++ b/samples/qa-virtualgridlist-datasize-changing/src/App.js
@@ -5,7 +5,7 @@ import Spottable from '@enact/spotlight/Spottable';
 import ri from '@enact/ui/resolution';
 import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 
-import css from './App.module.less';
+import css from './App.module.scss';
 
 const maxDataSize = 50;
 const items = [];

--- a/samples/qa-virtualgridlist-datasize-changing/src/App.module.scss
+++ b/samples/qa-virtualgridlist-datasize-changing/src/App.module.scss
@@ -1,0 +1,29 @@
+// App.module.scss
+//
+@use '~@enact/sandstone/styles/colors.scss';
+@use '~@enact/sandstone/styles/mixins.scss';
+
+.app {
+	background-color: black;
+	overflow: hidden;
+	width: 100%;
+	height: 100%;
+
+	& > * {
+		display: inline-block;
+		height: 100%;
+	}
+}
+
+.list {
+	width: 90%;
+}
+
+.side {
+	width: 5%;
+	background-color: colors.$sand-component-bg-color;
+
+	@include mixins.focus {
+		background-color: colors.$sand-focus-bg-color;
+	}
+}

--- a/samples/qa-virtualgridlist/src/components/ImageList/ImageList.js
+++ b/samples/qa-virtualgridlist/src/components/ImageList/ImageList.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import ImageListItem from '../ImageListItem';
 import {RecordContext} from '../../context/RecordContext';
 
-import css from './ImageList.module.less';
+import css from './ImageList.module.scss';
 
 const ImageList = (props) => {
 	const {dataOrder, minHeight, minWidth, spacing} = useContext(RecordContext);

--- a/samples/qa-virtualgridlist/src/components/ImageList/ImageList.module.scss
+++ b/samples/qa-virtualgridlist/src/components/ImageList/ImageList.module.scss
@@ -1,0 +1,11 @@
+// ImageList.module.scss
+//
+@use '~@enact/sandstone/styles/mixins.scss';
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}
+
+.horizontalPadding {
+	padding-bottom: 36px;
+}

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
@@ -4,7 +4,7 @@ import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback} from 'react';
 
-import css from './SampleVirtualGridList.module.less';
+import css from './SampleVirtualGridList.module.scss';
 
 const svgGenerator = (width, height, bgColor, textColor, customText) => (
 	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.module.scss
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.module.scss
@@ -1,0 +1,7 @@
+// SampleVirtualGridList.module.scss
+//
+@use '~@enact/sandstone/styles/mixins.scss';
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}

--- a/samples/qa-virtuallist/src/views/MainPanel.js
+++ b/samples/qa-virtuallist/src/views/MainPanel.js
@@ -13,7 +13,7 @@ import LocaleSwitch from '../components/LocaleSwitch';
 import ScrollModeSwitch from '../components/ScrollModeSwitch';
 import {setData as setDataAction, ListContext, ListDispatchContext} from '../context/ListContext';
 
-import css from './MainPanel.module.less';
+import css from './MainPanel.module.scss';
 
 const childProps = {text: ' child props'};
 

--- a/samples/qa-virtuallist/src/views/MainPanel.module.scss
+++ b/samples/qa-virtuallist/src/views/MainPanel.module.scss
@@ -1,0 +1,7 @@
+// MainPanel.module.scss
+//
+@use '~@enact/sandstone/styles/mixins.scss';
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}

--- a/samples/qa-voice-control/src/App/App.js
+++ b/samples/qa-voice-control/src/App/App.js
@@ -6,7 +6,7 @@ import Layout, {Cell} from '@enact/ui/Layout';
 import Panels, {Panel} from '@enact/sandstone/Panels';
 import {Fragment, useState} from 'react';
 
-import css from './App.module.less';
+import css from './App.module.scss';
 import Home from './Home';
 
 import DataWebosVoiceChecked from '../views/attribute/DataWebosVoiceChecked';

--- a/samples/qa-voice-control/src/App/App.module.scss
+++ b/samples/qa-voice-control/src/App/App.module.scss
@@ -1,0 +1,38 @@
+// App.module.scss
+//
+
+body {
+	position: fixed;
+	overflow: hidden;
+	width: 100%;
+	height: 100%;
+	margin: 0;
+}
+
+h2 {
+	font-style: italic;
+	font-weight: bold;
+}
+
+.layout {
+	height: 100%;
+}
+
+.navItem {
+	height: 60px;
+	margin: 0;
+
+	& > div {
+		font-size: 36px;
+	}
+
+	& > div:nth-child(2) {
+		color: #e6e6e6;
+	}
+}
+
+.heading {
+	font-style: italic;
+	margin: 17px 36px;
+	padding-bottom: 0;
+}

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -9,7 +9,7 @@ import {platform} from '@enact/webos/platform';
 import PropTypes from 'prop-types';
 import {useEffect} from 'react';
 
-import css from './ThemeEnvironment.module.less';
+import css from './ThemeEnvironment.module.scss';
 
 const reloadPage = () => {
 	const {protocol, host, pathname} = window.parent.location;

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.scss
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.scss
@@ -1,4 +1,4 @@
-// ThemeEnvrionment.module.less
+// ThemeEnvironment.module.scss
 //
 @use "~@enact/sandstone/styles/variables.scss";
 @use "~@enact/sandstone/styles/mixins.scss";

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.scss
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.scss
@@ -1,0 +1,84 @@
+// ThemeEnvrionment.module.less
+//
+@use "@enact/sandstone/styles/variables.scss";
+@use "@enact/sandstone/styles/mixins.scss";
+
+// from @enact/ui/styles/core.scss. Can't import global mixins.
+@mixin enact-selectable {
+	cursor: auto;
+	-webkit-user-select: text;
+	user-select: text;
+}
+
+[data-reactroot] {
+	overflow: auto !important;
+	transition: none !important;
+}
+
+.themeEnvironmentPanels {
+	&::before {
+		content: "";
+		background: var(--sand-env-background);
+		position: absolute;
+		@include mixins.position(0);
+
+		& {
+			filter: blur(6px);
+			opacity: 0.5;
+		}
+	}
+
+	.description {
+		margin: 0 variables.$sand-spotlight-outset 1em;
+
+		p:first-child {
+			margin-top: 0;
+		}
+	}
+}
+
+// Fix for the +/- buttons
+html {
+	height: 100%;
+	margin: 0;
+}
+
+// Fix for margin added around zoom-area
+body {
+	margin: 0;
+}
+
+// Fix or scrollable tabs area
+// Notes: Storybook provides its own scroller, so we don't need to see the OS version of it.
+// :global(.simplebar-content) {
+// 	overflow: hidden;
+// }
+
+// Storybook injects the info overlay within the ThemeEnvironment panel itself, so we need to
+// assign the z-index of `section` to be at the same level as the X button to allow the info overlay
+// to overlap it (hiding the X while the info overlay is open).
+//
+// This was removed (but may be needed in the future) due to this causing layering ordering issues
+// in the Panels.Header story. the info module injects code into the panel, which breaks the
+// top-level expectations of Slottable for the Header to drop into the "header" slot (since the info
+// overlay div is inserted at the top as a wrapper), which causes the Header render into the body
+// (<section> tag), resulting in layering order problems.
+// .panel > section {
+// 	z-index: 1;
+// }
+
+// Here, we target the storybook rendering canvas div. It's inserted as a child of our Panel, but it
+// applies position:relative, which doesn't help us when we have stories that should fill the entire
+// panel body. This targets that inaccessible node using Panel's structure and storybook's structure
+// to update that goofy rule to a rational one.
+// The :not() bit targets only non-enact elements, so if a story doesn't use withInfo, and a `div`
+// isn't added, the components aren't being told to be a different size/position.
+.panel > section > div:not([class]):not([style]):first-child,
+// additional selector on first div right after themeEnvironmentPanels to add min-height to display Panels content when Panels are used as a component inside storybook.
+.themeEnvironmentPanels > div:first-child,
+// additional selector when noPanel option is used
+.themeEnvironmentPanels > main > div {
+	width: 100%;
+	height: 100%;
+	position: relative !important;
+}

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.scss
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.scss
@@ -1,7 +1,7 @@
 // ThemeEnvrionment.module.less
 //
-@use "@enact/sandstone/styles/variables.scss";
-@use "@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/variables.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
 
 // from @enact/ui/styles/core.scss. Can't import global mixins.
 @mixin enact-selectable {

--- a/samples/sampler/stories/default/About.js
+++ b/samples/sampler/stories/default/About.js
@@ -7,7 +7,7 @@ import {boolean} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 
-import css from './About.module.less';
+import css from './About.module.scss';
 
 const edgeDotKeepout = 12;
 BodyText.displayName = 'BodyText';

--- a/samples/sampler/stories/default/About.module.scss
+++ b/samples/sampler/stories/default/About.module.scss
@@ -1,0 +1,127 @@
+// About.module.scss
+//
+@use "sass:math";
+@use "@enact/sandstone/styles/variables.scss";
+
+$bg-color: #e6e6e6;
+$accent-color: #30ad6b;
+$icon-size: 24px;
+$pointer-edge-offset: 18px;
+
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+b {
+	border-radius: 12px;
+	background-color: $accent-color;
+	padding: 6px 24px;
+	white-space: nowrap;
+	color: white;
+}
+
+.hintDialog {
+	position: fixed;
+	opacity: 0;
+	animation: fadeIn ease-in 1;
+	animation-fill-mode: forwards;
+	animation-duration: 1s;
+	direction: ltr;
+	filter: drop-shadow(6px 12px 48px fade-out(black, 0.7));
+
+	.pointer {
+		background-color: $bg-color;
+		height: calc(var(--pointer-length) - #{math.div($icon-size, 2)});
+		position: absolute;
+		text-align: center;
+		transform-origin: top center;
+		width: 6px;
+
+		.pointerIcon {
+			bottom: 0;
+			color: $bg-color;
+			font-size: ($icon-size * 2);
+			width: $icon-size;
+			height: $icon-size;
+			line-height: $icon-size;
+			margin: 0;
+			position: absolute;
+			transform: translate(-50%, 50%);
+		}
+	}
+
+	&:nth-of-type(1) {
+		animation-delay: 0.1s;
+	}
+
+	&:nth-of-type(2) {
+		animation-delay: 0.6s;
+	}
+
+	&:nth-of-type(3) {
+		animation-delay: 1.2s;
+	}
+
+	&:nth-of-type(4) {
+		animation-delay: 1.8s;
+	}
+
+	&.above {
+		margin-top: var(--pointer-length);
+		margin-right: -$pointer-edge-offset;
+
+		.pointer {
+			left: $pointer-edge-offset;
+			transform: rotate(180deg);
+		}
+	}
+
+	&.right {
+		margin-top: -$pointer-edge-offset;
+		margin-right: var(--pointer-length);
+
+		.pointer {
+			top: $pointer-edge-offset;
+			transform: rotate(270deg);
+		}
+	}
+
+	&.below {
+		margin-left: -$pointer-edge-offset;
+		margin-bottom: var(--pointer-length);
+
+		.pointer {
+			top: 100%;
+			left: $pointer-edge-offset;
+		}
+	}
+
+	&.left {
+		margin-top: -$pointer-edge-offset;
+		margin-left: var(--pointer-length);
+
+		.pointer {
+			top: $pointer-edge-offset;
+			transform: rotate(90deg);
+		}
+	}
+
+	.text {
+		display: inline-block;
+		padding: 42px;
+		border-radius: 12px;
+		background-color: $bg-color;
+		color: black;
+		font-size: 42px;
+
+		.icon {
+			margin: 0 0 0 0.25ex;
+		}
+	}
+}

--- a/samples/sampler/stories/default/About.module.scss
+++ b/samples/sampler/stories/default/About.module.scss
@@ -1,7 +1,7 @@
 // About.module.scss
 //
 @use "sass:math";
-@use "@enact/sandstone/styles/variables.scss";
+@use "~@enact/sandstone/styles/variables.scss";
 
 $bg-color: #e6e6e6;
 $accent-color: #30ad6b;

--- a/samples/sampler/stories/default/FixedPopupPanels.js
+++ b/samples/sampler/stories/default/FixedPopupPanels.js
@@ -6,7 +6,7 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
 
-import css from './FixedPopupPanels.module.less';
+import css from './FixedPopupPanels.module.scss';
 
 const Config = mergeComponentMetadata('FixedPopupPanels', FixedPopupPanels);
 Config.defaultProps.position = 'right';

--- a/samples/sampler/stories/default/FixedPopupPanels.module.scss
+++ b/samples/sampler/stories/default/FixedPopupPanels.module.scss
@@ -1,5 +1,6 @@
 // FixedPopupPanels.module.scss
 //
+
 .footer {
     margin-top: auto;
     padding-bottom: 30px;

--- a/samples/sampler/stories/default/FixedPopupPanels.module.scss
+++ b/samples/sampler/stories/default/FixedPopupPanels.module.scss
@@ -1,0 +1,7 @@
+// FixedPopupPanels.module.scss
+//
+.footer {
+    margin-top: auto;
+    padding-bottom: 30px;
+    text-align: center;
+}

--- a/samples/sampler/stories/default/ProgressBar.js
+++ b/samples/sampler/stories/default/ProgressBar.js
@@ -2,7 +2,7 @@ import ProgressBar, {ProgressBarTooltip} from '@enact/sandstone/ProgressBar';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
 
-import css from './ProgressBar.module.less';
+import css from './ProgressBar.module.scss';
 
 const ProgressBarConfig = mergeComponentMetadata('ProgressBar', ProgressBar);
 const ProgressBarTooltipConfig = mergeComponentMetadata('ProgressBarTooltip', ProgressBarTooltip);

--- a/samples/sampler/stories/default/ProgressBar.module.scss
+++ b/samples/sampler/stories/default/ProgressBar.module.scss
@@ -1,5 +1,6 @@
 // ProgressBar.module.scss
 //
+
 .margin {
 	margin: 0 144px;
 }

--- a/samples/sampler/stories/default/ProgressBar.module.scss
+++ b/samples/sampler/stories/default/ProgressBar.module.scss
@@ -1,0 +1,5 @@
+// ProgressBar.module.scss
+//
+.margin {
+	margin: 0 144px;
+}

--- a/samples/sampler/stories/default/QuickGuidePanels.js
+++ b/samples/sampler/stories/default/QuickGuidePanels.js
@@ -6,7 +6,7 @@ import QuickGuidePanels from '@enact/sandstone/QuickGuidePanels';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {number, select} from '@enact/storybook-utils/addons/controls';
 
-import css from './QuickGuidePanels.module.less';
+import css from './QuickGuidePanels.module.scss';
 
 QuickGuidePanels.displayName = 'QuickGuidePanels';
 

--- a/samples/sampler/stories/default/QuickGuidePanels.module.scss
+++ b/samples/sampler/stories/default/QuickGuidePanels.module.scss
@@ -1,0 +1,38 @@
+// QuickGuidePanels.module.scss
+//
+@use "@enact/sandstone/styles/skin.scss";
+
+.button {
+	&.small {
+		margin-bottom: 162px;
+		margin-left: 64px;
+	}
+}
+
+.guide {
+	position: relative;
+	z-index: 10;
+	margin: 60px;
+}
+
+.panel {
+	margin: 240px;
+}
+
+.popup {
+	@include skin.applySkins {
+		background-color: transparent;
+	}
+
+	.body {
+		padding: 0;
+	}
+}
+
+.svg {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}

--- a/samples/sampler/stories/default/QuickGuidePanels.module.scss
+++ b/samples/sampler/stories/default/QuickGuidePanels.module.scss
@@ -1,6 +1,6 @@
 // QuickGuidePanels.module.scss
 //
-@use "@enact/sandstone/styles/skin.scss";
+@use "~@enact/sandstone/styles/skin.scss";
 
 .button {
 	&.small {

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -7,7 +7,7 @@ import {boolean, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import {ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
 
-import css from './Scroller.module.less';
+import css from './Scroller.module.scss';
 
 const prop = {
 	direction: ['both', 'horizontal', 'vertical'],

--- a/samples/sampler/stories/default/Scroller.module.scss
+++ b/samples/sampler/stories/default/Scroller.module.scss
@@ -1,0 +1,19 @@
+// Scroller.module.scss
+//
+@use "@enact/sandstone/styles/mixins.scss";
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}
+
+.horizontalPadding {
+	padding-bottom: 36px;
+}
+
+.verticalPadding.bodyText {
+	@include mixins.padding-start-end(0, 60px);
+}
+
+.horizontalPadding.bodyText {
+	padding-bottom: 60px;
+}

--- a/samples/sampler/stories/default/Scroller.module.scss
+++ b/samples/sampler/stories/default/Scroller.module.scss
@@ -1,6 +1,6 @@
 // Scroller.module.scss
 //
-@use "@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
 
 .verticalPadding {
 	@include mixins.padding-start-end(0, 36px);

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -8,8 +8,7 @@ import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
 import {svgGenerator} from '../helper/svg';
 
-// import css from './VirtualGridList.module.scss';
-import css from './VirtualGridList.module.less';
+import css from './VirtualGridList.module.scss';
 
 const prop = {
 		direction: {horizontal: 'horizontal', vertical: 'vertical'},

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -8,6 +8,7 @@ import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
 import {svgGenerator} from '../helper/svg';
 
+// import css from './VirtualGridList.module.scss';
 import css from './VirtualGridList.module.less';
 
 const prop = {

--- a/samples/sampler/stories/default/VirtualGridList.module.scss
+++ b/samples/sampler/stories/default/VirtualGridList.module.scss
@@ -1,6 +1,6 @@
 // VirtualGridList.module.scss
 //
-@use "@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
 
 .verticalPadding {
 	@include mixins.padding-start-end(0, 36px);

--- a/samples/sampler/stories/default/VirtualGridList.module.scss
+++ b/samples/sampler/stories/default/VirtualGridList.module.scss
@@ -1,0 +1,11 @@
+// VirtualGridList.module.scss
+//
+@use "@enact/sandstone/styles/mixins.scss";
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}
+
+.horizontalPadding {
+	padding-bottom: 36px;
+}

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -6,6 +6,7 @@ import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
+// import css from './VirtualList.module.scss';
 import css from './VirtualList.module.less';
 
 const prop = {

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -6,8 +6,7 @@ import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 
-// import css from './VirtualList.module.scss';
-import css from './VirtualList.module.less';
+import css from './VirtualList.module.scss';
 
 const prop = {
 		scrollbarOption: ['auto', 'hidden', 'visible'],

--- a/samples/sampler/stories/default/VirtualList.module.scss
+++ b/samples/sampler/stories/default/VirtualList.module.scss
@@ -1,0 +1,11 @@
+// VirtualList.module.scss
+//
+@use "@enact/sandstone/styles/mixins.scss";
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}
+
+.horizontalPadding {
+	padding-bottom: 36px;
+}

--- a/samples/sampler/stories/default/VirtualList.module.scss
+++ b/samples/sampler/stories/default/VirtualList.module.scss
@@ -1,6 +1,6 @@
 // VirtualList.module.scss
 //
-@use "@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
 
 .verticalPadding {
 	@include mixins.padding-start-end(0, 36px);

--- a/samples/sampler/stories/qa/Button.js
+++ b/samples/sampler/stories/qa/Button.js
@@ -11,9 +11,9 @@ import iconNames from '../helper/icons';
 
 import Section from './components/KitchenSinkSection';
 
-import css from './Button.module.less';
+import css from './Button.module.scss';
 
-// Button's prop `minWidth` defaults to true and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean control and return `void 0` when `true`.
+// Button's prop `minWidth` defaults to true, and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean control and return `void 0` when `true`.
 Button.displayName = 'Button';
 const Config = mergeComponentMetadata('Button', UIButtonBase, UIButton, ButtonBase, Button);
 

--- a/samples/sampler/stories/qa/Button.module.scss
+++ b/samples/sampler/stories/qa/Button.module.scss
@@ -1,0 +1,21 @@
+// Button.module.scss
+//
+
+@mixin highlight {
+	background: rgba(0, 100, 200, 0.2);
+	border: 1px solid rgba(0, 100, 200, 0.4);
+}
+
+.tapArea {
+	&:first-child {
+		@include highlight;
+	}
+
+	&:before {
+		@include highlight;
+	}
+}
+
+.bgColor {
+	background-color: rgb(255, 0, 0);
+}

--- a/samples/sampler/stories/qa/Heading.js
+++ b/samples/sampler/stories/qa/Heading.js
@@ -6,7 +6,7 @@ import {select, text} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import IString from 'ilib/lib/IString';
 
-import css from './Heading.module.less';
+import css from './Heading.module.scss';
 
 Heading.displayName = 'Heading';
 

--- a/samples/sampler/stories/qa/Heading.module.scss
+++ b/samples/sampler/stories/qa/Heading.module.scss
@@ -1,0 +1,6 @@
+// Heading.module.scss
+//
+
+.italic {
+	font-style: italic;
+}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -18,7 +18,7 @@ import gameHomeIcon from '../../images/icon_app_game.png';
 import homeOfficeIcon from '../../images/icon_app_homeoffice.png';
 import mediaDiscoveryIcon from '../../images/icon_app_mediadiscovery.png';
 
-import css from './IconItem.module.less';
+import css from './IconItem.module.scss';
 
 add('cancel', 27);
 const isCancel = is('cancel');

--- a/samples/sampler/stories/qa/IconItem.module.scss
+++ b/samples/sampler/stories/qa/IconItem.module.scss
@@ -1,0 +1,156 @@
+// IconItem.module.scss
+//
+@use "@enact/sandstone/styles/mixins.scss";
+
+.scrollbarTrack {
+	background-color: white;
+
+	.thumb {
+		background-color: orangered;
+	}
+}
+
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hidden {
+		.iconItem {
+			display: none;
+		}
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
+.wrapper { // public class for editable wrapper
+	padding-left: 36px;
+	padding-right: 36px;
+
+	.removeButtonContainer {
+		height: 156px;
+
+		&:hover ~ .editableIconItem {
+			transform: none;
+		}
+
+		&:focus-within ~ .editableIconItem {
+			transform: none;
+		}
+
+		.removeButton {
+			display: none;
+		}
+	}
+
+	.itemWrapper {
+		text-align: center;
+
+		&:is([disabled]):not(.hidden).focused {
+			.removeButton {
+				display: none;
+			}
+		}
+
+		.editableIconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+
+		&:not(.selected,.focused) .editableIconItem {
+			&:focus {
+				transform: none;
+
+				:global(.enact-a11y-focus-ring) & {
+					.content {
+						outline: none;
+					}
+				}
+			}
+
+			&.labelOnFocus:focus {
+				.labelContainer {
+					display: none;
+				}
+			}
+		}
+
+		&.selected .editableIconItem.labelOnFocus {
+			.label, .labelContainer {
+				display: block;
+			}
+		}
+
+		.iconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+	}
+
+	.focused { // public class for focused item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			:global(.enact-a11y-focus-ring) & {
+				transform: none;
+			}
+
+			transform: scale(1.2);
+		}
+	}
+
+	.selected { // public class for selected item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+
+			:global(.enact-a11y-focus-ring) & {
+				.content {
+					@include mixins.sand-focus-ring;
+				}
+
+				transform: none;
+			}
+		}
+
+		@mixin arrow {
+			font-family: "Sandstone Icons";
+			font-size: 108px;
+			position: absolute;
+			top: 15%;
+			background: none;
+			opacity: 1;
+		}
+
+		&:not(.hidden):not(.noBefore)::before {
+			content: '\EFFF3';
+			@include arrow;
+			@include mixins.position-start-end(-30px, initial);
+		}
+
+		&:not(.hidden):not(.noAfter)::after {
+			content: '\EFFF4';
+			@include arrow;
+			@include mixins.position-start-end(initial, -30px);
+		}
+
+		@include mixins.enact-locale-rtl("") {
+			&:not(.hidden):not(.noBefore)::before,
+			&:not(.hidden):not(.noAfter)::after {
+				transform: scaleX(-1);
+			}
+		}
+	}
+}

--- a/samples/sampler/stories/qa/IconItem.module.scss
+++ b/samples/sampler/stories/qa/IconItem.module.scss
@@ -1,6 +1,6 @@
 // IconItem.module.scss
 //
-@use "@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
 
 .scrollbarTrack {
 	background-color: white;

--- a/samples/sampler/stories/qa/IconItem.module.scss
+++ b/samples/sampler/stories/qa/IconItem.module.scss
@@ -104,7 +104,9 @@
 				transform: none;
 			}
 
-			transform: scale(1.2);
+			& {
+				transform: scale(1.2);
+			}
 		}
 	}
 
@@ -121,7 +123,9 @@
 					@include mixins.sand-focus-ring;
 				}
 
-				transform: none;
+				& {
+					transform: none;
+				}
 			}
 		}
 

--- a/samples/sampler/stories/qa/Item.js
+++ b/samples/sampler/stories/qa/Item.js
@@ -12,7 +12,7 @@ import icons from '../helper/icons';
 
 import Section from './components/KitchenSinkSection';
 
-import css from './Item.module.less';
+import css from './Item.module.scss';
 
 const iconNames = ['', ...icons];
 

--- a/samples/sampler/stories/qa/Item.module.scss
+++ b/samples/sampler/stories/qa/Item.module.scss
@@ -1,7 +1,7 @@
 // Item.module.scss
 //
-@use "@enact/spotlight/styles/mixins.scss";
-@use "@enact/sandstone/styles/skin.scss";
+@use "~@enact/spotlight/styles/mixins.scss";
+@use "~@enact/sandstone/styles/skin.scss";
 
 .item {
 	@include skin.applySkins {

--- a/samples/sampler/stories/qa/Item.module.scss
+++ b/samples/sampler/stories/qa/Item.module.scss
@@ -1,0 +1,51 @@
+// Item.module.scss
+//
+@use "@enact/spotlight/styles/mixins.scss";
+@use "@enact/sandstone/styles/skin.scss";
+
+.item {
+	@include skin.applySkins {
+		border-left: 48px solid orangered;
+
+		@include mixins.focus {
+			& {
+				border-left: 48px solid green;
+			}
+		}
+
+		.bg {
+			border-radius: 0;
+		}
+
+		.itemContent,
+		.slotAfter,
+		.slotBefore {
+			color: orange;
+		}
+
+		.content {
+			font-weight: 100;
+		}
+
+		.label {
+			color: white;
+		}
+
+		@include mixins.focus {
+			.itemContent,
+			.slotAfter,
+			.slotBefore {
+				color: green;
+			}
+
+			.label {
+				font-style: italic;
+			}
+		}
+	}
+}
+
+.itemContainer {
+	width: 912px;
+	height: 810px;
+}

--- a/samples/sampler/stories/qa/Marquee.js
+++ b/samples/sampler/stories/qa/Marquee.js
@@ -11,7 +11,7 @@ import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import {Component} from 'react';
 
-import css from './Marquee.module.less';
+import css from './Marquee.module.scss';
 
 Marquee.displayName = 'Marquee';
 

--- a/samples/sampler/stories/qa/Marquee.module.scss
+++ b/samples/sampler/stories/qa/Marquee.module.scss
@@ -1,8 +1,8 @@
 // Marquee.module.scss
 //
-@use "@enact/sandstone/styles/colors.scss";
-@use "@enact/sandstone/styles/mixins.scss";
-@use "@enact/sandstone/styles/skin.scss";
+@use "~@enact/sandstone/styles/colors.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/skin.scss";
 
 .spotlight {
 	@include skin.applySkins {

--- a/samples/sampler/stories/qa/Marquee.module.scss
+++ b/samples/sampler/stories/qa/Marquee.module.scss
@@ -1,0 +1,37 @@
+// Marquee.module.scss
+//
+@use "@enact/sandstone/styles/colors.scss";
+@use "@enact/sandstone/styles/mixins.scss";
+@use "@enact/sandstone/styles/skin.scss";
+
+.spotlight {
+	@include skin.applySkins {
+		background-color: transparent;
+		color: colors.$sand-text-color;
+		@include mixins.focus {
+			background-color: colors.$sand-spotlight-bg-color;
+			color: colors.$sand-spotlight-text-color;
+		}
+	}
+}
+
+.scaledItem {
+	width: 600px;
+	height: 600px;
+	padding: 48px;
+	box-sizing: border-box;
+	background-color: #4c5059;
+
+	.textArea {
+		width: 450px;
+		border-color: transparent #d3b85f;
+		border-width: 12px;
+		border-style: solid;
+		margin: auto;
+	}
+
+	&:focus {
+		transform: scale(1.2);
+		transition: transform 0.3s ease-in-out;
+	}
+}

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -25,7 +25,7 @@ import homeOfficeIcon from '../../images/icon_app_homeoffice.png';
 import mediaDiscoveryIcon from '../../images/icon_app_mediadiscovery.png';
 import {svgGenerator} from '../helper/svg';
 
-import css from './Panels.module.less';
+import css from './Panels.module.scss';
 
 const Config = mergeComponentMetadata('Panels', Panels);
 

--- a/samples/sampler/stories/qa/Panels.module.scss
+++ b/samples/sampler/stories/qa/Panels.module.scss
@@ -1,0 +1,130 @@
+// Panels.module.scss
+//
+@use "@enact/sandstone/styles/mixins.scss";
+
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hidden {
+		.iconItem {
+			display: none;
+		}
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
+.wrapper { // public class for editable wrapper
+	padding-left: 36px;
+	padding-right: 36px;
+
+	.removeButtonContainer {
+		height: 156px;
+
+		&:hover ~ .editableIconItem {
+			transform: none;
+		}
+
+		&:focus-within ~ .editableIconItem {
+			transform: none;
+		}
+
+		.removeButton {
+			display: none;
+		}
+	}
+
+	.itemWrapper {
+		text-align: center;
+
+		&:is([disabled]):not(.hidden).focused {
+			.removeButton {
+				display: none;
+			}
+		}
+
+		.editableIconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+
+		&:not(.selected,.focused) .editableIconItem {
+			&:focus {
+				transform: none;
+			}
+
+			&.labelOnFocus:focus {
+				.labelContainer {
+					display: none;
+				}
+			}
+		}
+
+		&.selected .editableIconItem.labelOnFocus {
+			.label, .labelContainer {
+				display: block;
+			}
+		}
+
+		.iconItem {
+			width: 312px;
+			height: 240px;
+			margin: 60px;
+		}
+	}
+
+	.focused { // public class for focused item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+		}
+	}
+
+	.selected { // public class for selected item
+		.removeButton {
+			display: inline-block;
+		}
+
+		.editableIconItem {
+			transform: scale(1.2);
+		}
+
+		@mixin arrow {
+			font-family: "Sandstone Icons";
+			font-size: 108px;
+			position: absolute;
+			top: 15%;
+			background: none;
+			opacity: 1;
+		}
+
+		&:not(.hidden):not(.noBefore)::before {
+			content: '\EFFF3';
+			@include arrow;
+			@include mixins.position-start-end(-30px, initial);
+		}
+
+		&:not(.hidden):not(.noAfter)::after {
+			content: '\EFFF4';
+			@include arrow;
+			@include mixins.position-start-end(initial, -30px);
+		}
+
+		@include mixins.enact-locale-rtl("") {
+			&:not(.hidden):not(.noBefore)::before,
+			&:not(.hidden):not(.noAfter)::after {
+				transform: scaleX(-1);
+			}
+		}
+	}
+}

--- a/samples/sampler/stories/qa/Panels.module.scss
+++ b/samples/sampler/stories/qa/Panels.module.scss
@@ -1,6 +1,6 @@
 // Panels.module.scss
 //
-@use "@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
 
 .scrollerWrapper {
 	--selected-item-offset: 0;

--- a/samples/sampler/stories/qa/Picker.js
+++ b/samples/sampler/stories/qa/Picker.js
@@ -13,7 +13,7 @@ import Section from './components/KitchenSinkSection';
 import PickerAddRemove from './components/PickerAddRemove';
 import PickerRTL from './components/PickerRTL';
 
-import css from './Picker.module.less';
+import css from './Picker.module.scss';
 
 Picker.displayName = 'Picker';
 

--- a/samples/sampler/stories/qa/Picker.module.scss
+++ b/samples/sampler/stories/qa/Picker.module.scss
@@ -1,0 +1,11 @@
+// Picker.module.scss
+//
+
+.title {
+	width: 300px;
+
+	&.inlineTitle {
+		margin-left: 0;
+		width: 240px;
+	}
+}

--- a/samples/sampler/stories/qa/RangePicker.js
+++ b/samples/sampler/stories/qa/RangePicker.js
@@ -3,7 +3,7 @@ import {mergeComponentMetadata, nullify} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select, text} from '@enact/storybook-utils/addons/controls';
 
-import css from './Picker.module.less';
+import css from './Picker.module.scss';
 
 const Config = mergeComponentMetadata('RangePicker', RangePickerBase, RangePicker);
 

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -23,7 +23,7 @@ import {Component, useCallback, useEffect, useLayoutEffect, useRef, useState} fr
 
 import {svgGenerator} from '../helper/svg';
 
-import css from './Scroller.module.less';
+import css from './Scroller.module.scss';
 
 add('cancel', 27);
 const isCancel = is('cancel');

--- a/samples/sampler/stories/qa/Scroller.module.scss
+++ b/samples/sampler/stories/qa/Scroller.module.scss
@@ -1,0 +1,89 @@
+// Scroller.module.scss
+//
+
+.scrollbarTrack {
+	background-color: white;
+
+	.thumb {
+		background-color: orangered;
+	}
+}
+
+.scrollerWrapper {
+	--selected-item-offset: 0;
+	display: flex;
+	flex-direction: row;
+	min-width: fit-content;
+	padding-top: 60px;
+
+	.hidden {
+		.imageItem {
+			display: none;
+		}
+	}
+}
+
+.centered {
+	justify-content: center;
+}
+
+.wrapper { // public class for editable wrapper
+	padding-left: 36px;
+	padding-right: 36px;
+
+	.removeButtonContainer {
+		height: 156px;
+
+		.removeButton {
+			display: none;
+		}
+	}
+
+	.itemWrapper {
+		text-align: center;
+
+		.imageItem {
+			width: 768px;
+			height: 588px;
+		}
+	}
+
+	.focused { // public class for focused item
+		.removeButton {
+			display: inline-block;
+		}	
+	}
+
+	.selected { // public class for selected item
+		.removeButton {
+			display: inline-block;
+		}
+
+		@mixin arrow {
+			font-family: "Sandstone Icons";
+			font-size: 108px;
+			position: absolute;
+			top: 15%;
+			background: none;
+			opacity: 1;
+		}
+
+		&:not(.hidden)::before {
+			content: '\EFFF3';
+			@include arrow;
+
+			& {
+				left: -30px;
+			}
+		}
+
+		&:not(.hidden)::after {
+			content: '\EFFF4';
+			@include arrow;
+
+			& {
+				right: -30px;
+			}
+		}
+	}
+}

--- a/samples/sampler/stories/qa/Spotlight.js
+++ b/samples/sampler/stories/qa/Spotlight.js
@@ -25,7 +25,7 @@ import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {Component, cloneElement} from 'react';
 
-import css from './Spotlight.module.less';
+import css from './Spotlight.module.scss';
 
 import docs from '../../images/icon-enact-docs.png';
 import {svgGenerator} from '../helper/svg';

--- a/samples/sampler/stories/qa/Spotlight.module.scss
+++ b/samples/sampler/stories/qa/Spotlight.module.scss
@@ -1,8 +1,8 @@
 // Spotlight.module.scss
 //
-@use "@enact/sandstone/styles/colors.scss";
-@use "@enact/sandstone/styles/mixins.scss";
-@use "@enact/sandstone/styles/skin.scss";
+@use "~@enact/sandstone/styles/colors.scss";
+@use "~@enact/sandstone/styles/mixins.scss";
+@use "~@enact/sandstone/styles/skin.scss";
 
 .spottableitem {
 	@include skin.applySkins {

--- a/samples/sampler/stories/qa/Spotlight.module.scss
+++ b/samples/sampler/stories/qa/Spotlight.module.scss
@@ -1,0 +1,40 @@
+// Spotlight.module.scss
+//
+@use "@enact/sandstone/styles/colors.scss";
+@use "@enact/sandstone/styles/mixins.scss";
+@use "@enact/sandstone/styles/skin.scss";
+
+.spottableitem {
+	@include skin.applySkins {
+		background-color: transparent;
+		color: colors.$sand-text-color;
+		@include mixins.focus {
+			background-color: colors.$sand-spotlight-bg-color;
+			color: colors.$sand-spotlight-text-color;
+		}
+	}
+}
+
+.spottableDiv1 {
+	@include skin.applySkins {
+		@include mixins.sand-focus-highlight;
+	}
+
+	@include mixins.focus {
+		transform: scale(1.1);
+	}
+
+	& .image {
+		margin: 0;
+	}
+}
+
+.spottableDiv2 {
+	@include skin.applySkins {
+		@include mixins.sand-focus-highlight(image);
+	}
+
+	@include mixins.focus {
+		transform: scale(1.1);
+	}
+}

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -15,7 +15,7 @@ import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import {Component, useCallback, useState} from 'react';
 
-import css from './VirtualList.module.less';
+import css from './VirtualList.module.scss';
 
 const Config = mergeComponentMetadata('VirtualList', UiVirtualListBasic, VirtualList);
 

--- a/samples/sampler/stories/qa/VirtualList.module.scss
+++ b/samples/sampler/stories/qa/VirtualList.module.scss
@@ -1,6 +1,6 @@
 // VirtualList.module.scss
 //
-@use '@enact/sandstone/styles/mixins.scss';
+@use '~@enact/sandstone/styles/mixins.scss';
 
 .verticalPadding {
 	@include mixins.padding-start-end(0, 36px);

--- a/samples/sampler/stories/qa/VirtualList.module.scss
+++ b/samples/sampler/stories/qa/VirtualList.module.scss
@@ -1,0 +1,11 @@
+// VirtualList.module.scss
+//
+@use '@enact/sandstone/styles/mixins.scss';
+
+.verticalPadding {
+	@include mixins.padding-start-end(0, 36px);
+}
+
+.horizontalPadding {
+	padding-bottom: 36px;
+}

--- a/samples/sampler/stories/qa/components/KitchenSinkSection/KitchenSinkSection.js
+++ b/samples/sampler/stories/qa/components/KitchenSinkSection/KitchenSinkSection.js
@@ -5,7 +5,7 @@ import {Cell, Row} from '@enact/ui/Layout';
 
 import Heading from '@enact/sandstone/Heading';
 
-import css from './KitchenSinkSection.module.less';
+import css from './KitchenSinkSection.module.scss';
 
 //
 // A "section" to be used in Kitchen-Sink style QA stories

--- a/samples/sampler/stories/qa/components/KitchenSinkSection/KitchenSinkSection.module.scss
+++ b/samples/sampler/stories/qa/components/KitchenSinkSection/KitchenSinkSection.module.scss
@@ -1,0 +1,14 @@
+// KitchenSinkSection.module.scss
+//
+
+.section {
+	label {
+		text-align: end;
+		margin-inline-end: 1em;
+		font-weight: 300;
+		font-size: 80%;
+	}
+	.componentDemo {
+		margin: 0.5em 1em;
+	}
+}

--- a/samples/sampler/stories/qa/components/KitchenSinkSection/KitchenSinkSection.module.scss
+++ b/samples/sampler/stories/qa/components/KitchenSinkSection/KitchenSinkSection.module.scss
@@ -8,6 +8,7 @@
 		font-weight: 300;
 		font-size: 80%;
 	}
+
 	.componentDemo {
 		margin: 0.5em 1em;
 	}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In order to migrate to SCSS, each Sandstone component and sample styling must be converted one at a time. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Converted styling for internal Sandstone components and samples.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-1863

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com