### PR TITLE
WRR-2172: Update VirtualList qa-sampler for cases where the contents of a VirtualList change between fixed size and variable size contents

### DIFF
--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -557,7 +557,7 @@ const renderVirtualListItem = (variableItemSizesMode) => ({index, ...rest}) => {
 	);
 };
 
-export const UpdateItemsBetweenFixedAndVariableSizes = () => {
+export const WithChangingFixedAndVariableItemSizes = () => {
 	const [variableItemSizesMode, setVariableItemSizesMode] = useState(false);
 	const handleDataSize = useCallback(() => {
 		setVariableItemSizesMode(!variableItemSizesMode);
@@ -585,7 +585,7 @@ export const UpdateItemsBetweenFixedAndVariableSizes = () => {
 	);
 };
 
-UpdateItemsBetweenFixedAndVariableSizes.storyName = 'Update Items Between Fixed And Variable Sizes';
-UpdateItemsBetweenFixedAndVariableSizes.parameters = {
+WithChangingFixedAndVariableItemSizes.storyName = 'With Changing Fixed And Variable Item Sizes';
+WithChangingFixedAndVariableItemSizes.parameters = {
 	propTables: [Config]
 };

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -585,7 +585,7 @@ export const WithChangingFixedAndVariableItemSizes = () => {
 	);
 };
 
-WithChangingFixedAndVariableItemSizes.storyName = 'with Changing Fixed And Variable Item Sizes';
+WithChangingFixedAndVariableItemSizes.storyName = 'with changing fixed and variable item sizes';
 WithChangingFixedAndVariableItemSizes.parameters = {
 	propTables: [Config]
 };

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -542,3 +542,50 @@ WithContainerItemsHaveSpottableControls.storyName = 'with container items have s
 WithContainerItemsHaveSpottableControls.parameters = {
 	propTables: [Config]
 };
+
+const fixedItemSizes = new Array(16).fill(ri.scale(390));
+const variableItemSizes = fixedItemSizes.map((size, index) => {
+	return index % 2  ? size * 2  : size;
+});
+
+// eslint-disable-next-line enact/prop-types, enact/display-name
+const renderVirtualListItem = (variableItemSizesMode) => ({index, ...rest}) => {
+	return (
+		<Item {...rest} style={{width: variableItemSizesMode && index % 2 ? ri.scaleToRem(720) : ri.scaleToRem(360), margin: ri.scaleToRem(15)}}>
+			{`item ${index}`}
+		</Item>
+	);
+};
+
+export const UpdateItemsBetweenFixedAndVariableSizes = () => {
+	const [variableItemSizesMode, setVariableItemSizesMode] = useState(false);
+	const handleDataSize = useCallback(() => {
+		setVariableItemSizesMode(!variableItemSizesMode);
+	}, [variableItemSizesMode]);
+
+	return (
+		<Column>
+			<Cell shrink>
+				<Button size="small" onClick={handleDataSize}>Update Items</Button>
+			</Cell>
+			<br />
+			<br />
+			<Cell>
+				<VirtualList
+					dataSize={16}
+					direction="horizontal"
+					itemRenderer={renderVirtualListItem(variableItemSizesMode)}
+					itemSize={{
+						size: variableItemSizesMode ? variableItemSizes : fixedItemSizes,
+						minSize: Math.min(...variableItemSizes)
+					}}
+				/>
+			</Cell>
+		</Column>
+	);
+};
+
+UpdateItemsBetweenFixedAndVariableSizes.storyName = 'Update Items Between Fixed And Variable Sizes';
+UpdateItemsBetweenFixedAndVariableSizes.parameters = {
+	propTables: [Config]
+};

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -585,7 +585,7 @@ export const WithChangingFixedAndVariableItemSizes = () => {
 	);
 };
 
-WithChangingFixedAndVariableItemSizes.storyName = 'With Changing Fixed And Variable Item Sizes';
+WithChangingFixedAndVariableItemSizes.storyName = 'with Changing Fixed And Variable Item Sizes';
 WithChangingFixedAndVariableItemSizes.parameters = {
 	propTables: [Config]
 };


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the content of the virtual list changed, there was a issue that the scroller could not move to the end of the scroller.
This issue fixed in https://github.com/enactjs/enact/pull/3279 implementation. In this PR, we will add this issue case in qa-sampler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In virtualList qa-sampler, I added case where the contents of a VirtualList change between fixed size and variable size

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-2172

### Comments
