### PR TITLE
WRR-2431: Fix `Scroller` to show scroll indicator on scrollbar when `focusableScrollbar` prop is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/Scroller`, `sandstone/Slider`, and `sandstone/VirtualList` to have default prop when `undefined` prop is passed
+- `sandstone/Scroller` to show scroll indicator when `focusableScrollbar` prop is `true`
 - `sandstone/Steps` prop `size` to accept number type
 
 ## [2.9.0] - 2024-07-17

--- a/useScroll/ScrollbarTrack.module.less
+++ b/useScroll/ScrollbarTrack.module.less
@@ -49,8 +49,8 @@
 				height: 0;
 				border-top: @sand-scrollbar-thumb-focus-direction-indicator-height solid transparent;
 				border-bottom: @sand-scrollbar-thumb-focus-direction-indicator-height solid @sand-scrollbar-thumb-focus-direction-indicator-color;
-				border-right: @sand-scrollbar-thumb-focus-direction-indicator-width/2 solid transparent;
-				border-left: @sand-scrollbar-thumb-focus-direction-indicator-width/2 solid transparent;
+				border-right: (@sand-scrollbar-thumb-focus-direction-indicator-width / 2) solid transparent;
+				border-left: (@sand-scrollbar-thumb-focus-direction-indicator-width / 2) solid transparent;
 			}
 		});
 
@@ -103,13 +103,13 @@
 				.directionIndicator.backward {
 					transform: rotate(-90deg);
 					left: calc(@sand-scrollbar-thumb-focus-direction-indicator-top - @sand-scrollbar-thumb-focus-direction-indicator-height);
-					top: calc(@sand-scrollbar-thumb-focus-direction-indicator-left/2);
+					top: calc(@sand-scrollbar-thumb-focus-direction-indicator-left / 2);
 				}
 
 				.directionIndicator.forward {
 					transform: rotate(90deg);
 					right: calc(@sand-scrollbar-thumb-focus-direction-indicator-top - @sand-scrollbar-thumb-focus-direction-indicator-height);
-					top: calc(@sand-scrollbar-thumb-focus-direction-indicator-left/2);
+					top: calc(@sand-scrollbar-thumb-focus-direction-indicator-left / 2);
 				}
 			})
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The small indicator for Scrollbar when `focusableScrollbar` prop is true is not showing since 2.6.0.
​​![image](https://github.com/user-attachments/assets/45969a7c-e02e-4e07-9203-c5b0e396c4b8)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
While we were updating LESS v3 to v4, we missed to migrate the code that needs to be wrapped in parentheses to force math division. Because it doesn't have spaces between `/` it could have been missed from our "search".
So I fixed the code as well as adding sapces.

![image](https://github.com/user-attachments/assets/de978458-bc7c-4dba-852f-a190e460959b)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-2431

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)