### PR TITLE
WRR-3137: Fixed `Panels.Header` to show title and subtitle properly in `WizardPanels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Panels.Header` to show subtitle and title after slotSize is fixed in WizardPanels
+- `sandstone/Panels.Header` to show title and subtitle properly in WizardPanels
 
 ## [2.9.1] - 2024-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Panels.Header` to show title and subtitle properly in WizardPanels
+- `sandstone/Panels.Header` to show title and subtitle properly in `sandstone/WizardPanels`
 
 ## [2.9.1] - 2024-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Panels.Header` to show subtitle and title after slotSize is fixed in WizardPanels
+
 ## [2.9.1] - 2024-09-09
 
 ### Added

--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -438,6 +438,7 @@ const HeaderBase = kind({
 		slotBeforeRef,
 		slotSize,
 		titleCell,
+		type,
 		...rest
 	}) => {
 		delete rest.arranger;
@@ -447,7 +448,6 @@ const HeaderBase = kind({
 		delete rest.subtitleId;
 		delete rest.title;
 		delete rest.titleId;
-		delete rest.type;
 
 		// Set up the back button
 		const backButton = (backButtonAvailable && !noBackButton ? (
@@ -483,7 +483,7 @@ const HeaderBase = kind({
 		// Hide slots for the first render to avoid unexpected positioning when 'centered' is given.
 		// After the first render, HeaderMeasurementDecorator measures widths of slots and set right 'slotSize'.
 		const hideSlots = {
-			opacity: centered && (!slotBeforeRef.current || !slotAfterRef.current) ? '0' : null
+			opacity: centered && slotSize === '0rem' ? '0' : null
 		};
 
 		// The side Cells are always present, even if empty, to support the measurement ref.
@@ -496,7 +496,7 @@ const HeaderBase = kind({
 							{backButton}{slotBefore}
 						</span>
 					</Cell>
-					{titleCell}
+					{(type === 'wizard' && (slotBefore?.props?.visible || slotAfter?.props?.visible) && slotSize === '0rem') ? null : titleCell}
 					<Cell className={css.slotAfter} shrink={!syncCellSize} size={syncCellSize} style={hideSlots}>
 						<span ref={slotAfterRef} className={css.slotSizer}>
 							{slotAfter}{closeButton}

--- a/samples/sampler/stories/qa/WizardPanels.js
+++ b/samples/sampler/stories/qa/WizardPanels.js
@@ -360,3 +360,33 @@ _WizardPanelsWithAlert.parameters = {
 		noPanel: true
 	}
 };
+
+const WizardPanelsWithLongSubtitle = () => {
+	return (
+		<WizardPanels
+			total={2}
+			noAnimation
+		>
+			<Panel
+				title="title 0"
+				subtitle="This is very long text. It is very very long. This is very long text. It is very very long. This is very long text. It is very very long. This is very long text. It is very very long."
+			>
+				<Button>Button1</Button>
+				<Button>Button2</Button>
+			</Panel>
+			<Panel title="title 1">
+				<Button>Button3</Button>
+				<Button>Button4</Button>
+			</Panel>
+		</WizardPanels>
+	);
+};
+
+export const _WizardPanelsWithLongSubtitle = () => <WizardPanelsWithLongSubtitle />;
+
+_WizardPanelsWithLongSubtitle.storyName = 'with long subtitle';
+_WizardPanelsWithLongSubtitle.parameters = {
+	props: {
+		noPanel: true
+	}
+};


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When using WizardPanels, if the subtitles are long, they appear long for a moment and then shorten.

This is because the sizes of slotAfter and slotBefore are fixed after the subtitle is drawn. For centering of the title, the slot is measured after the element is drawn.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I adjusted the timing of when the slot is fixed and when the subtitle and title are drawn.
Specifically, I modified the subtitle and title to be drawn together when the slot is drawn.

Therefore, the phenomenon of the subtitle appearing long for a moment and then appearing short disappears.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-3137

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
