### PR TITLE
WRR-4572: Fix `Scroller` to read out its content properly when it is located in `Panel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Panels.Header` to show title and subtitle properly in `sandstone/WizardPanels`
 - `sandstone/Scroller`, `sandstone/Slider`, and `sandstone/VirtualList` to have default prop when `undefined` prop is passed
 - `sandstone/Scroller` to show scroll indicator when `focusableScrollbar` prop is `true`
+- `sandstone/Scroller` to read out properly when `sandstone/Panels` has `sandstone/Scroller` with `focusableScrollbar`
 - `sandstone/Steps` prop `size` to accept number type
 
 ## [2.9.0] - 2024-07-17

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -436,3 +436,43 @@ WithEditableScroller.parameters = {
 		noPanels: true
 	}
 };
+
+export const WithFocusableScrollbar = () => {
+	const [panelIndex, setPanelIndex] = useState(0);
+
+	const forward = useCallback(() => {
+		setPanelIndex(panelIndex + 1);
+	}, [panelIndex]);
+
+	const backward = useCallback(() => {
+		setPanelIndex(panelIndex - 1);
+	}, [panelIndex]);
+
+	return (
+		<Panels
+			index={panelIndex}
+			noCloseButton
+			onBack={backward}
+		>
+			<Panel aria-label="This is a Panel 0">
+				<Header title="Panel 0" />
+				<Scroller>
+					<Button onClick={forward}>Next</Button>
+				</Scroller>
+			</Panel>
+			<Panel aria-label="This is a Panel 1">
+				<Header title="Panel 1" />
+				<Scroller focusableScrollbar>
+					<Button onClick={backward}>Previous</Button>
+				</Scroller>
+			</Panel>
+		</Panels>
+	);
+};
+
+WithFocusableScrollbar.storyName = 'with focusable scrollbar';
+WithFocusableScrollbar.parameters = {
+	props: {
+		noPanels: true
+	}
+};

--- a/useScroll/ScrollbarPlaceholder.js
+++ b/useScroll/ScrollbarPlaceholder.js
@@ -37,7 +37,7 @@ const ScrollbarPlaceholder = () => {
 		}, 0); // Wait for unmounting placeholder node.
 	}, []);
 
-	return (showPlaceholder ? (<SpotlightPlaceholder onSpotlightDisappear={resetFocus} data-spotlight-ignore-restore />) : null);
+	return (showPlaceholder ? (<SpotlightPlaceholder aria-hidden onSpotlightDisappear={resetFocus} data-spotlight-ignore-restore />) : null);
 };
 
 ScrollbarPlaceholder.displayName = 'ScrollbarPlaceholder';


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a `Scroller` with a `focusableScrollbar` contains a button and is located in a `Panel`, the read-out feature behaved differently than we expected.
Screen reader read "Button A" before "This is a panel" was fully read, so the user would only hear the aria label of the `button`.
```
<Panel aria-label = 'This is a panel'>
    <Header title = 'Title' />
        <Scroller focusableScrollbar>
            <Button onClick={() => this.setState({index: 0})}>Button A</Button>
        </Scroller>
</Panel>
```

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* This issue occurred because when `focusableScrollbar` was enabled, Spotlight first focused the SpotlightPlaceholder and then focused the scroller's content. This caused the screen reader to read the panel's aria-label and the button's aria-label separately.
* So I added `aria-hidden` attribute to `ScrollbarPlaceholder` to removed it from the Accessibility tree.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4572

### Comments
