### PR TITLE
WRR-4591: Fix `VideoPlayer` to show only the mini feedback when pressing play/pause key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Scroller`, `sandstone/Slider`, and `sandstone/VirtualList` to have default prop when `undefined` prop is passed
 - `sandstone/Scroller` to show scroll indicator when `focusableScrollbar` prop is `true`
 - `sandstone/Steps` prop `size` to accept number type
+- `sandstone/VideoPlayer` to show only the mini feedback using play/pause key
 
 ## [2.9.0] - 2024-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/Scroller`, `sandstone/Slider`, and `sandstone/VirtualList` to have default prop when `undefined` prop is passed
 - `sandstone/Scroller` to show scroll indicator when `focusableScrollbar` prop is `true`
 - `sandstone/Steps` prop `size` to accept number type
-- `sandstone/VideoPlayer` to show only the mini feedback using play/pause key
+- `sandstone/VideoPlayer` to show only the mini feedback when pressing play/pause key
 
 ## [2.9.0] - 2024-07-17
 

--- a/VideoPlayer/VideoPlayer.js
+++ b/VideoPlayer/VideoPlayer.js
@@ -812,6 +812,7 @@ const VideoPlayerBase = class extends Component {
 		this.mediaControlsSpotlightId = props.spotlightId + '_mediaControls';
 		this.jumpButtonPressed = null;
 		this.playerRef = createRef();
+		this.playbackRate = 1;
 
 		// Re-render-necessary State
 		this.state = {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is an issue where the media slider appears when you press the play/pause button on the remote control.
But only mini feedback content should appear.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I set the initial value for playbackRate.

Previously, the playbackRate value was always set via the setPlaybackRate function when the play and pause functions were called.
Now, playbackRate is set only when in seeking mode when the play/pause functions were called. Therefore, the initial value of playbackRate is missing and set to undefined. Because of this, the visibility conditions of the media slider have changed.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4591

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
