### PR TITLE
WRR-4590: Fix to focus the topmost element after scroll by voice control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Panels.Header` to show title and subtitle properly in `sandstone/WizardPanels`
 - `sandstone/Scroller` to show scroll indicator when `focusableScrollbar` prop is `true`
+- `sandstone/Scroller` to focus the topmost element after scroll by voice control
 
 ## [2.9.1] - 2024-09-09
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -448,11 +448,11 @@ const useEventVoice = (props, instances) => {
 				first = mutableRef.current.voiceControlDirection === 'vertical' ? 'top' : 'left',
 				last = mutableRef.current.voiceControlDirection === 'vertical' ? 'bottom' : 'right';
 
-			if (spotItemBounds[last] < viewportBounds[first] || spotItemBounds[first] > viewportBounds[last]) {
+			if (spotItemBounds[last] <= viewportBounds[first] || spotItemBounds[first] >= viewportBounds[last]) {
 				for (let i = 0; i < nodes.length; i++) {
 					const nodeBounds = nodes[i].getBoundingClientRect();
 
-					if (nodeBounds[first] > viewportBounds[first] && nodeBounds[last] < viewportBounds[last]) {
+					if (nodeBounds[first] >= viewportBounds[first] && nodeBounds[last] <= viewportBounds[last]) {
 						Spotlight.focus(nodes[i]);
 						break;
 					}

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -441,14 +441,15 @@ const useEventVoice = (props, instances) => {
 			scrollContainerNode = scrollContainerRef.current;
 
 		if (utilDOM.containsDangerously(scrollContainerNode, spotItem)) {
-			const
-				viewportBounds = scrollContainerNode.getBoundingClientRect(),
-				spotItemBounds = spotItem.getBoundingClientRect(),
-				nodes = Spotlight.getSpottableDescendants(scrollContainerNode.dataset.spotlightId),
-				first = mutableRef.current.voiceControlDirection === 'vertical' ? 'top' : 'left',
-				last = mutableRef.current.voiceControlDirection === 'vertical' ? 'bottom' : 'right';
+			const viewportBounds = scrollContainerNode.getBoundingClientRect();
+			const spotItemBounds = spotItem.getBoundingClientRect();
+			const isVertical = mutableRef.current.voiceControlDirection === 'vertical';
+			const first = isVertical ? 'top' : 'left';
+			const last = isVertical ? 'bottom' : 'right';
 
+			/* if the focused element is out of the viewport, find another spottable element in the viewport */
 			if (spotItemBounds[last] <= viewportBounds[first] || spotItemBounds[first] >= viewportBounds[last]) {
+				const nodes = Spotlight.getSpottableDescendants(scrollContainerNode.dataset.spotlightId);
 				for (let i = 0; i < nodes.length; i++) {
 					const nodeBounds = nodes[i].getBoundingClientRect();
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a focusable node inside a scroller is sticked to the top, it cannot be focused after scroll by voice control.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The cause is a logic to check if the candidate focus target is inside of a scroller viewport. When a focusable node is touching the boundary of a viewport, the existing logic does not consider the node as visible since it missed simply '='.

I updated to recognize the case that boundaries are the same.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

I also refine some code with another commit.

### Links
[//]: # (Related issues, references)
WRR-4590

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)