### PR TITLE
WRR-4660: Fixed `PageViews` to not clip the shadow of navigation buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/VideoPlayer` to show only the mini feedback when pressing play/pause key
 
 ## [2.9.2] - 2024-09-26

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -19,10 +19,9 @@
 	.navButtonContainer {
 		position: absolute;
 		width: 100%;
-		height: @sand-button-height * 2;
-		top: ~"calc(50% - " (@sand-button-height * 2) / 2 ~")";
+		height: @sand-button-height;
+		top: ~"calc(50% - "@sand-button-height / 2 ~")";
 		z-index: 10;
-		overflow: hidden;
 	}
 
 	&.number .navButton {

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -17,11 +17,12 @@
 	}
 
 	.navButtonContainer {
-		overflow: hidden;
-		z-index: 10;
-		top: ~"calc(50% - " (@sand-button-height + 12) / 2 ~")";
 		position: absolute;
 		width: 100%;
+		height: @sand-button-height * 2;
+		top: ~"calc(50% - " (@sand-button-height * 2) / 2 ~")";
+		z-index: 10;
+		overflow: hidden;
 	}
 
 	&.number .navButton {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The issue is that the navButtonContainer area of the PageViews was too tight, so the shadow of navigation buttons was clip when `fullContents` prop is `true`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set the height of the `navButtonContainer` to twice the height of the button.
And the formula related to `top`is a calculation that will position the navButtonContainer in the center.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4660

### Comments
