### PR TITLE
WRR-4628: Added `jumpBackwardAriaLabel` and `jumpForwardAriaLabel` props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Added
+
+- `sandstone/MediaControls` props `jumpBackwardAriaLabel` and `jumpForwardAriaLabel` to override aria-label of jumpButtons
+
 ### Fixed
 
 - `sandstone/VideoPlayer` to show only the mini feedback when pressing play/pause key

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -124,6 +124,14 @@ const MediaControlsBase = kind({
 		bottomComponents: PropTypes.node,
 
 		/**
+		 * The `aria-label` for the jumpBackward button.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		jumpBackwardAriaLabel: PropTypes.string,
+
+		/**
 		 * Jump backward {@link sandstone/Icon.Icon|icon} name. Accepts any
 		 * {@link sandstone/Icon.Icon|icon} component type.
 		 *
@@ -140,6 +148,14 @@ const MediaControlsBase = kind({
 		 * @public
 		 */
 		jumpButtonsDisabled: PropTypes.bool,
+
+		/**
+		 * The `aria-label` for the jumpForward button.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		jumpForwardAriaLabel: PropTypes.string,
 
 		/**
 		 * Jump forward {@link sandstone/Icon.Icon|icon} name. Accepts any
@@ -348,8 +364,10 @@ const MediaControlsBase = kind({
 		actionGuideShowing,
 		children,
 		id,
+		jumpBackwardAriaLabel,
 		jumpBackwardIcon,
 		jumpButtonsDisabled,
+		jumpForwardAriaLabel,
 		jumpForwardIcon,
 		bottomComponents,
 		mediaControlsRef,
@@ -379,9 +397,9 @@ const MediaControlsBase = kind({
 		return (
 			<OuterContainer {...rest} id={id} mediaControlsRef={mediaControlsRef} spotlightId={spotlightId}>
 				<Container className={css.mediaControls} spotlightDisabled={spotlightDisabled} onKeyDown={onKeyDownFromMediaButtons}>
-					{noJumpButtons ? null : <MediaButton aria-label={$L('Previous')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpBackwardIcon} onClick={onJumpBackwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
+					{noJumpButtons ? null : <MediaButton aria-label={jumpBackwardAriaLabel || $L('Previous')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpBackwardIcon} onClick={onJumpBackwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 					<MediaButton aria-label={paused ? $L('Play') : $L('Pause')} className={spotlightDefaultClass} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || playPauseButtonDisabled} icon={paused ? playIcon : pauseIcon} onClick={onPlayButtonClick} size="large" spotlightDisabled={spotlightDisabled} />
-					{noJumpButtons ? null : <MediaButton aria-label={$L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
+					{noJumpButtons ? null : <MediaButton aria-label={jumpForwardAriaLabel || $L('Next')} backgroundOpacity="transparent" css={css} disabled={mediaDisabled || jumpButtonsDisabled} icon={jumpForwardIcon} onClick={onJumpForwardButtonClick} size="large" spotlightDisabled={spotlightDisabled} />}
 				</Container>
 				{actionGuideShowing ?
 					<ActionGuide id={`${id}_actionGuide`} aria-label={actionGuideAriaLabel != null ? actionGuideAriaLabel : null} buttonAriaLabel={actionGuideButtonAriaLabel} css={css} className={actionGuideClassName} icon="arrowsmalldown" onClick={onActionGuideClick} disabled={actionGuideDisabled}>{actionGuideLabel}</ActionGuide> :

--- a/samples/sampler/stories/default/VideoPlayer.js
+++ b/samples/sampler/stories/default/VideoPlayer.js
@@ -173,8 +173,10 @@ export const _VideoPlayer = (args) => {
 				</infoComponents>
 				<MediaControls
 					actionGuideButtonAriaLabel={args['actionGuideButtonAriaLabel']}
+					jumpBackwardAriaLabel={args['jumpBackwardAriaLabel']}
 					jumpBackwardIcon={args['jumpBackwardIcon']}
 					jumpButtonsDisabled={args['jumpButtonsDisabled']}
+					jumpForwardAriaLabel={args['jumpForwardAriaLabel']}
 					jumpForwardIcon={args['jumpForwardIcon']}
 					noJumpButtons={args['noJumpButtons']}
 					rateChangeDisabled={args['rateChangeDisabled']}
@@ -238,8 +240,10 @@ text(
 	MediaControlsConfig,
 	''
 );
+text('jumpBackwardAriaLabel', _VideoPlayer, MediaControlsConfig, '');
 select('jumpBackwardIcon', _VideoPlayer, icons, MediaControlsConfig, 'jumpbackward');
 boolean('jumpButtonsDisabled', _VideoPlayer, MediaControlsConfig);
+text('jumpForwardAriaLabel', _VideoPlayer, MediaControlsConfig, '');
 select('jumpForwardIcon', _VideoPlayer, icons, MediaControlsConfig, 'jumpforward');
 boolean('noJumpButtons', _VideoPlayer, MediaControlsConfig);
 boolean('rateChangeDisabled', _VideoPlayer, MediaControlsConfig);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We ​​need to allow overriding the aria-label of JumpButtons in `MediaControls`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `jumpBackwardAriaLabel` and `jumpForwardAriaLabel` props

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4628

### Comments
