### PR TITLE
WRR-5417: Modified so that PageViews do not receive focus when autoFocus is set to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
+- `sandstone/Scroller` to focus the topmost element after scroll by voice control
+- `sandstone/Scroller` to read out properly when `sandstone/Panels` has `sandstone/Scroller` with `focusableScrollbar`
 - `sandstone/VideoPlayer` to show only the mini feedback when pressing play/pause key
 
 ## [2.9.2] - 2024-09-26
@@ -20,8 +22,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Panels.Header` to show title and subtitle properly in `sandstone/WizardPanels`
 - `sandstone/Scroller` to show scroll indicator when `focusableScrollbar` prop is `true`
-- `sandstone/Scroller` to focus the topmost element after scroll by voice control
-- `sandstone/Scroller` to read out properly when `sandstone/Panels` has `sandstone/Scroller` with `focusableScrollbar`
 
 ## [2.9.1] - 2024-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Added
 
 - `sandstone/MediaControls` props `jumpBackwardAriaLabel` and `jumpForwardAriaLabel` to override aria-label of jumpButtons
+- `sandstone/PageViews` prop `autoFocus` to set whether focus element automatically or not
 
 ### Fixed
 

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -54,16 +54,6 @@ const PageViewsBase = kind({
 		arranger: shape,
 
 		/**
-		 * Sets the strategy used to automatically focus an element within the PageViews upon render.
-		 * When set to 'none', focus is not set only on the first render.
-		 *
-		 * @type {('default-element'|'last-focused'|'none'|String)}
-		 * @default 'default-element'
-		 * @public
-		 */
-		autoFocus: PropTypes.string,
-
-		/**
 		 * {@link sandstone/PageViews.Page|Page} to be rendered.
 		 *
 		 * @type {Node}
@@ -328,6 +318,17 @@ const PageViewsBase = kind({
 		);
 	}
 });
+
+/**
+ * Sets the strategy used to automatically focus an element within the PageViews upon render.
+ * When set to 'none', focus is not set only on the first render.
+ *
+ * @name autoFocus
+ * @type {('default-element'|'last-focused'|'none'|String)}
+ * @memberof sandstone/PageViews.prototype
+ * @default 'last-focused'
+ * @public
+ */
 
 const PageViewsDecorator = compose(
 	Changeable({prop: 'index'}),

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -325,7 +325,7 @@ const PageViewsBase = kind({
  *
  * @name autoFocus
  * @type {('default-element'|'last-focused'|'none'|String)}
- * @memberof sandstone/PageViews.prototype
+ * @memberof sandstone/PageViews
  * @default 'last-focused'
  * @public
  */

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -325,7 +325,7 @@ const PageViewsBase = kind({
  *
  * @name autoFocus
  * @type {('default-element'|'last-focused'|'none'|String)}
- * @memberof sandstone/PageViews
+ * @memberof sandstone/PageViews.PageViews.prototype
  * @default 'last-focused'
  * @public
  */

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -54,6 +54,16 @@ const PageViewsBase = kind({
 		arranger: shape,
 
 		/**
+		 * Sets the strategy used to automatically focus an element within the PageViews upon render.
+		 * When set to 'none', focus is not set only on the first render.
+		 *
+		 * @type {('default-element'|'last-focused'|'none'|String)}
+		 * @default 'default-element'
+		 * @public
+		 */
+		autoFocus: PropTypes.string,
+
+		/**
 		 * {@link sandstone/PageViews.Page|Page} to be rendered.
 		 *
 		 * @type {Node}

--- a/PageViews/PageViewsRouter.js
+++ b/PageViews/PageViewsRouter.js
@@ -73,7 +73,7 @@ function PageViewsRouter (Wrapped) {
 		 * When set to 'none', focus is not set only on the first render.
 		 *
 		 * @type {('default-element'|'last-focused'|'none'|String)}
-		 * @default 'default-element'
+		 * @default 'last-focused'
 		 * @private
 		 */
 		autoFocus: PropTypes.string,

--- a/PageViews/PageViewsRouter.js
+++ b/PageViews/PageViewsRouter.js
@@ -26,6 +26,7 @@ function useReverseTransition (index, rtl) {
  */
 function PageViewsRouter (Wrapped) {
 	const PageViewsProvider = ({
+		autoFocus,
 		children,
 		componentRef,
 		'data-spotlight-id': spotlightId,
@@ -37,8 +38,8 @@ function PageViewsRouter (Wrapped) {
 	}) => {
 		const totalIndex = Children.count(children);
 		const {ref: a11yRef, onWillTransition: a11yOnWillTransition} = useToggleRole();
-		const autoFocus = useAutoFocus({autoFocus: 'default-element'});
-		const ref = useChainRefs(autoFocus, a11yRef, componentRef);
+		const autoFocusRef = useAutoFocus({autoFocus});
+		const ref = useChainRefs(autoFocusRef, a11yRef, componentRef);
 		const {reverseTransition} = useReverseTransition(index, rtl);
 		const {
 			onWillTransition: focusOnWillTransition,
@@ -67,6 +68,16 @@ function PageViewsRouter (Wrapped) {
 	};
 
 	PageViewsProvider.propTypes =  /** @lends sandstone/PageViews.PageViewsRouter.prototype */  {
+		/**
+		 * Sets the strategy used to automatically focus an element within the PageViews upon render.
+		 * When set to 'none', focus is not set only on the first render.
+		 *
+		 * @type {('default-element'|'last-focused'|'none'|String)}
+		 * @default 'default-element'
+		 * @private
+		 */
+		autoFocus: PropTypes.string,
+
 		/**
 		 * Obtains a reference to the root node.
 		 *


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Even if autoFocus is set to none to PageViews and noAutoFocus is set to true to ThemeDecorator, there is an issue where focus is set to the navigation button of PageViews.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added autoFocus as a prop so that it can be set to a received value rather than a fixed value.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-5417

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
