### PR TITLE
WRR-4972: Fixed PageViews dot indicator to be centered

### DIFF
--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -249,8 +249,9 @@ const PageViewsBase = kind({
 			return (
 				<>
 					{pageIndicatorType !== 'number' ?
-						<Row className={classNames(css.steps, {[css.hidden]: !isStepVisible})}>
+						<Row className={classNames(css.stepsRow, {[css.hidden]: !isStepVisible})}>
 							<Steps
+								css={css}
 								current={index + 1}
 								currentIcon="circle"
 								futureIcon="circle"
@@ -260,7 +261,7 @@ const PageViewsBase = kind({
 								size={30}
 							/>
 						</Row> :
-						<Row className={css.steps}>
+						<Row className={css.stepsRow}>
 							<Cell className={css.navButton} shrink>
 								{isPrevButtonVisible ? <Button aria-label={$L('Previous')} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} size="small" /> : null}
 							</Cell>

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -33,7 +33,7 @@
 		justify-content: center;
 		text-align: center;
 		&.hidden {
-			min-height: @sand-pageviews-steps-area-min-height;
+			min-height: @sand-pageviews-steps-area-hidden-min-height;
 			visibility: hidden;
 		}
 	}

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -28,7 +28,7 @@
 		width: @sand-pageviews-number-navigation-button-area-width;
 	}
 
-	.steps {
+	.stepsRow {
 		align-items: center;
 		justify-content: center;
 		text-align: center;
@@ -38,7 +38,7 @@
 		}
 	}
 
-	&.number .steps {
+	&.number .stepsRow {
 		min-height: @sand-pageviews-number-steps-area-min-height;
 		.pageNumber {
 			width: @sand-pageviews-number-steps-number-width;
@@ -49,10 +49,16 @@
 	}
 
 	&.dot .steps {
+		display: flex;
 		min-height: @sand-pageviews-dot-steps-area-min-height;
+		align-items: center;
+		.step {
+			line-height: @sand-pageviews-dot-steps-area-min-height;
+			height: @sand-pageviews-dot-steps-area-min-height
+		}
 	}
 
-	&.fullContents .steps {
+	&.fullContents .stepsRow {
 		position: absolute;
 		align-self: center;
 		bottom: @sand-pageviews-full-steps-position-bottom;

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -33,7 +33,7 @@
 		justify-content: center;
 		text-align: center;
 		&.hidden {
-			min-height: @sand-pageviews-steps-area-hidden-min-height;
+			min-height: @sand-pageviews-steps-area-min-height;
 			visibility: hidden;
 		}
 	}
@@ -53,8 +53,9 @@
 		min-height: @sand-pageviews-dot-steps-area-min-height;
 		align-items: center;
 		.step {
-			line-height: @sand-pageviews-dot-steps-area-min-height;
-			height: @sand-pageviews-dot-steps-area-min-height
+			&.future, &.past {
+				height: @sand-pageviews-dot-steps-step-offset;
+			}
 		}
 	}
 
@@ -63,6 +64,14 @@
 		align-self: center;
 		bottom: @sand-pageviews-full-steps-position-bottom;
 		min-height: @sand-pageviews-full-steps-area-min-height;
+	}
+
+	&.fullContents .steps {
+		.step {
+			&.future, &.past {
+				height: @sand-pageviews-fullContents-steps-step-offset;
+			}
+		}
 	}
 
 	.contentsArea {

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -762,6 +762,7 @@
 // PageViews
 // ---------------------------------------
 @sand-pageviews-navigation-button-area-width: 216px;
+@sand-pageviews-steps-area-hidden-min-height: 132px; // @sand-pageviews-steps-area-min-height + margin(18px)
 @sand-pageviews-steps-area-min-height: 114px;
 @sand-pageviews-dot-steps-area-min-height: @sand-pageviews-steps-area-min-height;
 @sand-pageviews-full-steps-area-min-height: @sand-pageviews-steps-area-min-height;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -762,7 +762,7 @@
 // PageViews
 // ---------------------------------------
 @sand-pageviews-navigation-button-area-width: 216px;
-@sand-pageviews-steps-area-min-height: 132px;
+@sand-pageviews-steps-area-min-height: 114px;
 @sand-pageviews-dot-steps-area-min-height: @sand-pageviews-steps-area-min-height;
 @sand-pageviews-full-steps-area-min-height: @sand-pageviews-steps-area-min-height;
 @sand-pageviews-full-steps-position-bottom: 0;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -762,8 +762,8 @@
 // PageViews
 // ---------------------------------------
 @sand-pageviews-navigation-button-area-width: 216px;
-@sand-pageviews-steps-area-hidden-min-height: 132px; // @sand-pageviews-steps-area-min-height + margin(18px)
-@sand-pageviews-steps-area-min-height: 114px;
+@sand-pageviews-dot-steps-step-offset: 27px;
+@sand-pageviews-fullContents-steps-step-offset: 24px;
 @sand-pageviews-dot-steps-area-min-height: @sand-pageviews-steps-area-min-height;
 @sand-pageviews-full-steps-area-min-height: @sand-pageviews-steps-area-min-height;
 @sand-pageviews-full-steps-position-bottom: 0;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Dot indicator of PageViews needs to be centered

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed height of past and future step icon in pageIndicator to make circle icon which forms page indicator to be centered

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4972

### Comments
