### PR TITLE
WRR-976: ContextualPopupDecorator: Modified to update position when screen orientation change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: node_js
 node_js:
     - lts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 dist: jammy
 language: node_js
 node_js:
-    - lts/*
-    - "20"
+    - "16"
 sudo: false
 before_install:
     - sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/ContextualPopupDecorator` to update popup position properly when the screen orientation change
+
 ## [2.7.18] - 2024-09-05
 
 ### Added

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -286,6 +286,12 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (props.setApiProvider) {
 				props.setApiProvider(this);
 			}
+
+			if (typeof ResizeObserver === 'function') {
+				this.resizeObserver = new ResizeObserver(() => {
+					this.positionContextualPopup();
+				});
+			};
 		}
 
 		componentDidMount () {
@@ -603,18 +609,14 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		getClientNode = (node) => {
 			this.clientNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 
-			if (!this.resizeObserver && typeof ResizeObserver === 'function') {
-				this.resizeObserver = new ResizeObserver(() => {
-					this.positionContextualPopup();
-				});
-			};
-
-			if (this.clientNode) {
-				// It is not easy to trigger changed position of activator,
-				// so we chose to observe the `div` element's size that has the real size below the root of floatLayer.
-				// This implementation is dependent on the current structure of FloatingLayer,
-				// so if the structure have changed, below code needs to be changed accordingly.
-				this.resizeObserver.observe(this.clientNode?.parentElement?.parentElement);
+			if (this.resizeObserver) {
+				if (this.clientNode) {
+					// It is not easy to trigger changed position of activator,
+					// so we chose to observe the `div` element's size that has the real size below the root of floatLayer.
+					// This implementation is dependent on the current structure of FloatingLayer,
+					// so if the structure have changed, below code needs to be changed accordingly.
+					this.resizeObserver.observe(this.clientNode?.parentElement?.parentElement);
+				}
 			}
 		};
 

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -1,3 +1,5 @@
+/* global ResizeObserver */
+
 /**
  * A higher-order component to add a Sandstone styled popup to a component.
  *
@@ -271,6 +273,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				activator: null
 			};
 
+			this.resizeObserver = null;
 			this.overflow = {};
 			this.adjustedDirection = this.props.direction;
 			this.id = this.generateId();
@@ -289,6 +292,12 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.props.open) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
+			}
+
+			if (typeof ResizeObserver === 'function') {
+				this.resizeObserver = new ResizeObserver(() => {
+					this.positionContextualPopup();
+				});
 			}
 		}
 
@@ -339,6 +348,11 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				off('keyup', this.handleKeyUp);
 			}
 			Spotlight.remove(this.state.containerId);
+
+			if (this.resizeObserver) {
+				this.resizeObserver.disconnect();
+				this.resizeObserver = null;
+			}
 		}
 
 		generateId = () => {
@@ -594,6 +608,18 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getClientNode = (node) => {
 			this.clientNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
+
+			if (this.resizeObserver) {
+				if (node) {
+					// It is not easy to trigger changed position of activator,
+					// so we chose to observe the `div` element's size that has the real size below the root of floatLayer.
+					// This implementation is dependent on the current structure of FloatingLayer,
+					// so if the structure have changed, below code needs to be changed accordingly.
+					this.resizeObserver.observe(node?.parentElement?.parentElement);
+				} else {
+					this.resizeObserver.disconnect();
+				}
+			}
 		};
 
 		handle = handle.bind(this);

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -293,12 +293,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
 			}
-
-			if (typeof ResizeObserver === 'function') {
-				this.resizeObserver = new ResizeObserver(() => {
-					this.positionContextualPopup();
-				});
-			}
 		}
 
 		getSnapshotBeforeUpdate (prevProps, prevState) {
@@ -609,16 +603,18 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		getClientNode = (node) => {
 			this.clientNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 
-			if (this.resizeObserver) {
-				if (node) {
-					// It is not easy to trigger changed position of activator,
-					// so we chose to observe the `div` element's size that has the real size below the root of floatLayer.
-					// This implementation is dependent on the current structure of FloatingLayer,
-					// so if the structure have changed, below code needs to be changed accordingly.
-					this.resizeObserver.observe(node?.parentElement?.parentElement);
-				} else {
-					this.resizeObserver.disconnect();
-				}
+			if (!this.resizeObserver && typeof ResizeObserver === 'function') {
+				this.resizeObserver = new ResizeObserver(() => {
+					this.positionContextualPopup();
+				});
+			};
+
+			if (this.clientNode) {
+				// It is not easy to trigger changed position of activator,
+				// so we chose to observe the `div` element's size that has the real size below the root of floatLayer.
+				// This implementation is dependent on the current structure of FloatingLayer,
+				// so if the structure have changed, below code needs to be changed accordingly.
+				this.resizeObserver.observe(this.clientNode?.parentElement?.parentElement);
 			}
 		};
 

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -286,18 +286,18 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (props.setApiProvider) {
 				props.setApiProvider(this);
 			}
-
-			if (typeof ResizeObserver === 'function') {
-				this.resizeObserver = new ResizeObserver(() => {
-					this.positionContextualPopup();
-				});
-			}
 		}
 
 		componentDidMount () {
 			if (this.props.open) {
 				on('keydown', this.handleKeyDown);
 				on('keyup', this.handleKeyUp);
+			}
+
+			if (typeof ResizeObserver === 'function') {
+				this.resizeObserver = new ResizeObserver(() => {
+					this.positionContextualPopup();
+				});
 			}
 		}
 
@@ -604,20 +604,22 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getContainerNode = (node) => {
 			this.containerNode = node;
-		};
-
-		getClientNode = (node) => {
-			this.clientNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 
 			if (this.resizeObserver) {
-				if (this.clientNode) {
+				if (node) {
 					// It is not easy to trigger changed position of activator,
 					// so we chose to observe the `div` element's size that has the real size below the root of floatLayer.
 					// This implementation is dependent on the current structure of FloatingLayer,
 					// so if the structure have changed, below code needs to be changed accordingly.
-					this.resizeObserver.observe(this.clientNode?.parentElement?.parentElement);
+					this.resizeObserver.observe(node?.parentElement?.parentElement);
+				} else {
+					this.resizeObserver.disconnect();
 				}
 			}
+		};
+
+		getClientNode = (node) => {
+			this.clientNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 		};
 
 		handle = handle.bind(this);

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -291,7 +291,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.resizeObserver = new ResizeObserver(() => {
 					this.positionContextualPopup();
 				});
-			};
+			}
 		}
 
 		componentDidMount () {

--- a/ContextualPopupDecorator/tests/ContextualPopupDecorator-specs.js
+++ b/ContextualPopupDecorator/tests/ContextualPopupDecorator-specs.js
@@ -505,4 +505,40 @@ describe('ContextualPopupDecorator Specs', () => {
 		expect(scrimDivFirst).toHaveClass(expectedFirst);
 		expect(scrimDivSecond).toHaveClass(expectedSecond);
 	});
+
+	test('should create and observe with `ResizeObserver` when the popup opened and disconnect when the popup closed', () => {
+		const originalObserver = global.ResizeObserver;
+
+		const MockObserverInstance = {
+			observe: jest.fn(),
+			disconnect: jest.fn()
+		};
+		global.ResizeObserver = jest.fn().mockImplementation(() => MockObserverInstance);
+
+		const Root = FloatingLayerDecorator('div');
+		const {rerender} = render(
+			<Root>
+				<ContextualButton data-testid="contextualButton" open popupComponent={() => <div><Button>Button</Button></div>}>
+					Hello
+				</ContextualButton>
+			</Root>
+		);
+
+		const contextualButton = screen.getByTestId('contextualButton');
+
+		expect(contextualButton).toBeInTheDocument();
+		expect(MockObserverInstance.observe).toHaveBeenCalled();
+
+		rerender(
+			<Root>
+				<ContextualButton data-testid="contextualButton" popupComponent={() => <div><Button>Button</Button></div>}>
+					Hello
+				</ContextualButton>
+			</Root>
+		);
+
+		expect(MockObserverInstance.disconnect).toHaveBeenCalled();
+
+		global.ResizeObserver = originalObserver;
+	});
 });


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When ContextualPopupDecorator or ContextualMenuDecorator is open, rotating the device in the inspector should change the popup's position. Currently the popup is fixed and does not update.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I needed to check whether the position had not been updated or the value had been entered incorrectly. When rotated, I saw that when I refreshed, the position was calculated normally again. Therefore, the position calculation was no problem.

The position is updated with the positionContextualPopup function, which is not called when the window size changes, including when the screen is rotated. Therefore, I modified it to use ResizeObserver to detect changes in FloatLayer. 
(document.body may or may not have a size depending on the app)



### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-976

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)