### PR TITLE
WRR-6050: Fixed `IconItem` to restart marquee after done editing in `Scroller` with `editable` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/IconItem` to restart marquee after done editing in `sandstone/Scroller` with `editable` prop
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` with `editable` prop to move an item via 5-way keys properly in pointer mode
 

--- a/IconItem/IconItem.js
+++ b/IconItem/IconItem.js
@@ -27,7 +27,7 @@ import compose from 'ramda/src/compose';
 
 import Icon from '../Icon';
 import Image from '../Image';
-import {MarqueeDecorator, MarqueeController} from '../Marquee';
+import {MarqueeController, MarqueeDecorator} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './IconItem.module.less';
@@ -184,7 +184,7 @@ const IconItemBase = kind({
 		 * @public
 		 */
 		labelOn: PropTypes.oneOf(['focus', 'render']),
-		
+
 		/**
 		 * The order of the item.
 		 * Invalidates Marquee when the order changes.

--- a/IconItem/IconItem.js
+++ b/IconItem/IconItem.js
@@ -27,7 +27,7 @@ import compose from 'ramda/src/compose';
 
 import Icon from '../Icon';
 import Image from '../Image';
-import {Marquee, MarqueeController} from '../Marquee';
+import {MarqueeDecorator, MarqueeController} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './IconItem.module.less';
@@ -54,6 +54,15 @@ const ImageShape = PropTypes.shape({
 	}).isRequired,
 	src: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
 });
+
+const MarqueeBase = ({...rest}) => {
+	// eslint-disable-next-line enact/prop-types
+	delete rest.order;
+
+	return <div {...rest} />;
+};
+
+const Marquee = MarqueeDecorator({invalidateProps: ['remeasure', 'order']}, MarqueeBase);
 
 /**
  * A Sandstone styled base component for {@link sandstone/IconItem.IconItem|IconItem}.
@@ -175,6 +184,15 @@ const IconItemBase = kind({
 		 * @public
 		 */
 		labelOn: PropTypes.oneOf(['focus', 'render']),
+		
+		/**
+		 * The order of the item.
+		 * Invalidates Marquee when the order changes.
+		 *
+		 * @type {Number}
+		 * @private
+		 */
+		order: PropTypes.number,
 
 		/**
 		 * Title text showing below the icon.
@@ -215,7 +233,7 @@ const IconItemBase = kind({
 			darkLabel: labelColor === 'dark'
 		}),
 
-		children: ({background, children, css, icon, image, label, labelOn, title}) => {
+		children: ({background, children, css, icon, image, label, labelOn, order, title}) => {
 			if (children) return children;
 
 			let imageComponent;
@@ -246,7 +264,7 @@ const IconItemBase = kind({
 					</Cell>
 					{label ? (
 						<Cell shrink className={css.labelContainer}>
-							<Marquee alignment="center" className={css.label} marqueeOn="hover">{label}</Marquee>
+							<Marquee alignment="center" className={css.label} marqueeOn="focus" order={order}>{label}</Marquee>
 						</Cell>
 					) : null}
 				</Column>
@@ -256,7 +274,7 @@ const IconItemBase = kind({
 				title ? (
 					<Column>
 						{iconContent}
-						<Marquee alignment="center" className={css.title} marqueeOn="hover">{title}</Marquee>
+						<Marquee alignment="center" className={css.title} marqueeOn="focus" order={order}>{title}</Marquee>
 					</Column>
 				) : iconContent
 			);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -582,8 +582,6 @@ const EditableWrapper = (props) => {
 		selectedItem.children[1].ariaLabel = '';
 		finalizeEditing(orders);
 		if (selectItemBy === 'press') {
-			Spotlight.setPointerMode(false);
-			Spotlight.focus(focusTarget);
 			focusItem(focusTarget);
 		}
 		setTimeout(() => {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -582,6 +582,11 @@ const EditableWrapper = (props) => {
 		selectedItem.children[1].ariaLabel = '';
 		finalizeEditing(orders);
 		if (selectItemBy === 'press') {
+			if (getPointerMode()) {
+				Spotlight.setPointerMode(false);
+				Spotlight.focus(focusTarget);
+			}
+
 			focusItem(focusTarget);
 		}
 		setTimeout(() => {

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -64,7 +64,7 @@ const populateItems = ({index}) => {
 		} : null,
 		label: (function () {
 			if (index === 1) return 'USB';
-			else if (index === 6) return 'Gallery';
+			else if (index === 6) return 'Gallery label that has very long text';
 		})(),
 		labelColor: index === 6 ? 'dark' : null,
 		labelOn: index === 6 ? 'focus' : null,
@@ -288,8 +288,10 @@ export const EditableIcon = (args) => {
 											className={css.editableIconItem}
 											css={css}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
+											label={item.iconItemProps['label']}
 											onClick={action('onClickItem')}
 											onFocus={onFocusItem}
+											order={index}
 										/>
 									</div>
 								);

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -288,7 +288,6 @@ export const EditableIcon = (args) => {
 											className={css.editableIconItem}
 											css={css}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
-											label={item.iconItemProps['label']}
 											onClick={action('onClickItem')}
 											onFocus={onFocusItem}
 											order={index}


### PR DESCRIPTION
## Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When there is long `label` inside `IconItem` in editable `Scroller`, after done editing the marquee stops and it will never start again.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
When completing edit, the DOM changes its order and it makes the marquee stops. I guess it's from engine but unfortunately, I coundn't find the specific logic or part. As far as I investigate, JS code has nothing to do with stopping maruee.
To resolve this issue, I chose to let `Marquee` to invalidate its metrics to restart safely with `invalidateProps` of `MarqueeDecorator`. I've added `order` as `invalidateProps` and pass it to `Marquee` through `IconItem` in JSX so that let `Marquee` know when the editing is done.
For the case where the editing ended without DOM change, I changed `Spotlight.focus` call added from https://github.com/enactjs/sandstone/pull/1550/files#diff-22d263c3907b8e109699fc727d876991ef576e0c70458dd2e6d59e014f7e426cR573-R574 conditionally to prevent stopping marquee.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Currently there is no sample to test the problem. So you should change qa-sampler/IconItem.js to have `label` based on the change I made.

### Links
[//]: # (Related issues, references)
WRR-6050

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)