### PR TITLE
WRR-4972: Fixed `PageViews` and `QuickGuidePanels` dot page indicators to be aligned center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/PageViews` dot page indicators to align center
+- `sandstone/PageViews` and `sandstone/QuickGuidePanels` dot page indicators to be aligned center
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` with `editable` prop to move an item via 5-way keys properly in pointer mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/PageViews` dot page indicators to align center
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`
 - `sandstone/Scroller` with `editable` prop to move an item via 5-way keys properly in pointer mode

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -22,11 +22,6 @@ import {PageViewsRouter} from './PageViewsRouter';
 
 import componentCss from './PageViews.module.less';
 
-const PageIndicator = ({className}) => {
-	const mergedClasses = classNames(componentCss.pageIndicator, className);
-	return (<div className={mergedClasses} />);
-};
-
 /**
  * A PageViews that has page indicator with corresponding pages.
  *
@@ -271,7 +266,6 @@ const PageViewsBase = kind({
 								css={css}
 								current={index + 1}
 								highlightCurrentOnly
-								iconComponent={PageIndicator}
 								total={totalIndex}
 							/>
 						</Row> :

--- a/PageViews/PageViews.js
+++ b/PageViews/PageViews.js
@@ -22,6 +22,11 @@ import {PageViewsRouter} from './PageViewsRouter';
 
 import componentCss from './PageViews.module.less';
 
+const PageIndicator = ({className}) => {
+	const mergedClasses = classNames(componentCss.pageIndicator, className);
+	return (<div className={mergedClasses} />);
+};
+
 /**
  * A PageViews that has page indicator with corresponding pages.
  *
@@ -78,7 +83,7 @@ const PageViewsBase = kind({
 		 * * `contentsArea` - The contentsArea component class
 		 * * `navButton` - The navButton component class
 		 * * `navButtonContainer` - Applied to the container containing navButtons in fullContents mode
-		 * * `steps` - The step component class
+		 * * `stepsRow` - The step component class
 		 *
 		 * @type {Object}
 		 * @public
@@ -261,18 +266,16 @@ const PageViewsBase = kind({
 			return (
 				<>
 					{pageIndicatorType !== 'number' ?
-						<Row className={classNames(css.steps, {[css.hidden]: !isStepVisible})}>
+						<Row className={classNames(css.stepsRow, {[css.hidden]: !isStepVisible})}>
 							<Steps
+								css={css}
 								current={index + 1}
-								currentIcon="circle"
-								futureIcon="circle"
 								highlightCurrentOnly
-								pastIcon="circle"
+								iconComponent={PageIndicator}
 								total={totalIndex}
-								size={30}
 							/>
 						</Row> :
-						<Row className={css.steps}>
+						<Row className={css.stepsRow}>
 							<Cell className={css.navButtonCell} shrink>
 								{isPrevButtonVisible ? <Button aria-label={$L('Previous')} className={css.navButton} icon="arrowlargeleft" iconFlip="auto" id="PrevNavButton" onClick={onPrevClick} size="small" /> : null}
 							</Cell>

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -1,5 +1,6 @@
 // PageViews.module.less
 //
+@import '../styles/skin.less';
 @import "../styles/variables.less";
 
 .pageViews {
@@ -32,7 +33,7 @@
 		width: @sand-pageviews-number-navigation-button-area-width;
 	}
 
-	.steps {
+	.stepsRow {
 		align-items: center;
 		justify-content: center;
 		text-align: center;
@@ -42,7 +43,7 @@
 		}
 	}
 
-	&.number .steps {
+	&.number .stepsRow {
 		min-height: @sand-pageviews-number-steps-area-min-height;
 		.pageNumber {
 			width: @sand-pageviews-number-steps-number-width;
@@ -52,16 +53,33 @@
 		}
 	}
 
-	&.dot .steps {
-		min-height: @sand-pageviews-dot-steps-area-min-height;
+	&.dot {
+		.steps {
+			display: flex;
+			align-items: center;
+			min-height: @sand-pageviews-dot-steps-area-min-height;
+		}
+
+		.pageIndicator {
+			width: @sand-pageviews-dot-stpes-page-indicator-size;
+			height: @sand-pageviews-dot-stpes-page-indicator-size;
+			margin: @sand-pageviews-dot-stpes-page-indicator-margin;
+			border-radius: @sand-pageviews-dot-stpes-page-indicator-border-radius;
+
+			&.current {
+				width: @sand-pageviews-dot-stpes-page-indicator-current-size;
+				height: @sand-pageviews-dot-stpes-page-indicator-current-size;
+				margin: @sand-pageviews-dot-stpes-page-indicator-current-margin;
+			}
+		}
 	}
 
-	&.fullContents .steps {
+	&.fullContents .stepsRow {
 		position: absolute;
 		align-self: center;
 	}
 
-	&.fullContents.indicatorBottom .steps {
+	&.fullContents.indicatorBottom .stepsRow {
 		bottom: @sand-pageviews-full-contents-bottom-steps-bottom;
 	}
 
@@ -77,4 +95,14 @@
 	.horizontalLayout {
 		height: 100%;
 	}
+
+	.applySkins({
+		.pageIndicator {
+			background-color: @sand-pageviews-page-indicator-bg-color;
+
+			&.current {
+				background-color: @sand-pageviews-page-indicator-current-bg-color;
+			}
+		}
+	})
 }

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -1,6 +1,5 @@
 // PageViews.module.less
 //
-@import '../styles/skin.less';
 @import "../styles/variables.less";
 
 .pageViews {
@@ -53,25 +52,10 @@
 		}
 	}
 
-	&.dot {
-		.steps {
-			display: flex;
-			align-items: center;
-			min-height: @sand-pageviews-dot-steps-area-min-height;
-		}
-
-		.pageIndicator {
-			width: @sand-pageviews-dot-stpes-page-indicator-size;
-			height: @sand-pageviews-dot-stpes-page-indicator-size;
-			margin: @sand-pageviews-dot-stpes-page-indicator-margin;
-			border-radius: @sand-pageviews-dot-stpes-page-indicator-border-radius;
-
-			&.current {
-				width: @sand-pageviews-dot-stpes-page-indicator-current-size;
-				height: @sand-pageviews-dot-stpes-page-indicator-current-size;
-				margin: @sand-pageviews-dot-stpes-page-indicator-current-margin;
-			}
-		}
+	&.dot .steps {
+		display: flex;
+		align-items: center;
+		min-height: @sand-pageviews-dot-steps-area-min-height;
 	}
 
 	&.fullContents .stepsRow {
@@ -95,14 +79,4 @@
 	.horizontalLayout {
 		height: 100%;
 	}
-
-	.applySkins({
-		.pageIndicator {
-			background-color: @sand-pageviews-page-indicator-bg-color;
-
-			&.current {
-				background-color: @sand-pageviews-page-indicator-current-bg-color;
-			}
-		}
-	})
 }

--- a/QuickGuidePanels/QuickGuidePanels.js
+++ b/QuickGuidePanels/QuickGuidePanels.js
@@ -337,14 +337,10 @@ const QuickGuidePanelsBase = kind({
 
 			return (
 				<Steps
-					className={css.steps}
+					css={css}
 					current={currentStep}
-					currentIcon="circle"
-					futureIcon="circle"
 					highlightCurrentOnly
-					pastIcon="circle"
 					total={totalSteps}
-					size={30}
 				/>
 			);
 		}

--- a/QuickGuidePanels/QuickGuidePanels.module.less
+++ b/QuickGuidePanels/QuickGuidePanels.module.less
@@ -11,8 +11,10 @@
 		.steps {
 			display: flex;
 			justify-content: center;
+			align-items: center;
 			width: 100%;
 			margin-top: @sand-quickguidepanels-steps-margin-top;
+			min-height: @sand-quickguidepanels-steps-min-height;
 		}
 
 		.close {

--- a/Steps/Steps.js
+++ b/Steps/Steps.js
@@ -202,6 +202,7 @@ const StepsBase = kind({
 	},
 
 	computed: {
+		iconComponent: ({highlightCurrentOnly, iconComponent}) => ((highlightCurrentOnly && iconComponent === Icon) ? PageIndicator : iconComponent),
 		steps: ({current, pastIcon, currentIcon, futureIcon, highlightCurrentOnly, skip, skipIcon, total, styler}) => {
 			skip = coerceArray(skip);
 			return Array.from(Array(total)).map((el, index) => {
@@ -237,10 +238,11 @@ const StepsBase = kind({
 		}
 	},
 
-	render: ({highlightCurrentOnly, iconComponent, size, steps, ...rest}) => {
+	render: ({iconComponent, size, steps, ...rest}) => {
 		delete rest.current;
 		delete rest.currentIcon;
 		delete rest.futureIcon;
+		delete rest.highlightCurrentOnly;
 		delete rest.pastIcon;
 		delete rest.skip;
 		delete rest.skipIcon;
@@ -249,7 +251,7 @@ const StepsBase = kind({
 			<Repeater
 				{...rest}
 				component="div"
-				childComponent={highlightCurrentOnly ? PageIndicator : iconComponent}
+				childComponent={iconComponent}
 				itemProps={{size}}
 			>
 				{steps}

--- a/Steps/Steps.js
+++ b/Steps/Steps.js
@@ -17,6 +17,7 @@ import kind from '@enact/core/kind';
 import {coerceArray} from '@enact/core/util';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import Repeater from '@enact/ui/Repeater';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 
@@ -24,6 +25,11 @@ import Icon from '../Icon';
 import Skinnable from '../Skinnable';
 
 import componentCss from './Steps.module.less';
+
+const PageIndicator = ({className}) => {
+	const mergedClasses = classNames(componentCss.pageIndicator, className);
+	return (<div className={mergedClasses} />);
+};
 
 /**
  * Renders a sandstone-styled steps component only basic behavior.
@@ -231,11 +237,10 @@ const StepsBase = kind({
 		}
 	},
 
-	render: ({iconComponent, size, steps, ...rest}) => {
+	render: ({highlightCurrentOnly, iconComponent, size, steps, ...rest}) => {
 		delete rest.current;
 		delete rest.currentIcon;
 		delete rest.futureIcon;
-		delete rest.highlightCurrentOnly;
 		delete rest.pastIcon;
 		delete rest.skip;
 		delete rest.skipIcon;
@@ -244,7 +249,7 @@ const StepsBase = kind({
 			<Repeater
 				{...rest}
 				component="div"
-				childComponent={iconComponent}
+				childComponent={highlightCurrentOnly ? PageIndicator : iconComponent}
 				itemProps={{size}}
 			>
 				{steps}

--- a/Steps/Steps.module.less
+++ b/Steps/Steps.module.less
@@ -1,6 +1,7 @@
 // Steps.module.less
 //
 @import "../styles/mixins.less";
+@import '../styles/skin.less';
 @import "../styles/variables.less";
 
 .steps {
@@ -33,4 +34,27 @@
 			opacity: @sand-steps-step-future-opacity;
 		}
 	}
+
+	.pageIndicator {
+		width: @sand-steps-pageindicator-size;
+		height: @sand-steps-pageindicator-size;
+		margin: @sand-steps-pageindicator-margin;
+		border-radius: @sand-steps-pageindicator-border-radius;
+
+		&.current {
+			width: @sand-steps-pageindicator-current-size;
+			height: @sand-steps-pageindicator-current-size;
+			margin: @sand-steps-pageindicator-current-margin;
+		}
+	}
+
+	.applySkins({
+		.pageIndicator {
+			background-color: @sand-steps-pageindicator-bg-color;
+
+			&.current {
+				background-color: @sand-steps-pageindicator-current-bg-color;
+			}
+		}
+	});
 }

--- a/Steps/Steps.module.less
+++ b/Steps/Steps.module.less
@@ -2,7 +2,6 @@
 //
 @import "../styles/mixins.less";
 @import "../styles/variables.less";
-@import "../styles/skin.less";
 
 .steps {
 	margin: @sand-steps-margin;
@@ -17,13 +16,6 @@
 		}
 
 		&.highlightCurrentOnly {
-			font-size: @sand-steps-step-highlight-current-only-font-size;
-			margin: @sand-steps-step-highlight-current-only-margin;
-
-			&.current {
-				font-size: @sand-steps-step-highlight-current-only-current-font-size;
-			}
-
 			&.future {
 				opacity: @sand-steps-step-highlight-current-only-future-opacity;
 			}
@@ -42,14 +34,3 @@
 		}
 	}
 }
-
-.applySkins({
-	.step {
-		&.highlightCurrentOnly {
-			color: @sand-steps-step-highlight-current-only-color;
-			&.current {
-				color: @sand-steps-step-highlight-current-only-current-color;
-			}
-		}
-	}
-});

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -310,11 +310,6 @@
 @sand-mediaslider-disabled-bar-opacity: 0.3;
 @sand-mediaslider-fill-bg-color: @sand-progress-color;
 
-// PageViews
-// ---------------------------------------
-@sand-pageviews-page-indicator-bg-color: rgb(111, 118, 128, 1);
-@sand-pageviews-page-indicator-current-bg-color: @sand-component-text-color;
-
 // Picker
 // ---------------------------------------
 @sand-picker-text-color: @sand-text-color;
@@ -414,6 +409,11 @@
 @sand-spinner-bg-color: @sand-component-bg-color;
 @sand-spinner-text-color: @sand-component-text-color;
 @sand-spinner-text-shadow-color: @sand-shadow-color;
+
+// Steps
+// ---------------------------------------
+@sand-steps-pageindicator-bg-color: rgb(111, 118, 128, 1);
+@sand-steps-pageindicator-current-bg-color: @sand-component-text-color;
 
 // Switch
 // ---------------------------------------

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -310,6 +310,11 @@
 @sand-mediaslider-disabled-bar-opacity: 0.3;
 @sand-mediaslider-fill-bg-color: @sand-progress-color;
 
+// PageViews
+// ---------------------------------------
+@sand-pageviews-page-indicator-bg-color: rgb(111, 118, 128, 1);
+@sand-pageviews-page-indicator-current-bg-color: @sand-component-text-color;
+
 // Picker
 // ---------------------------------------
 @sand-picker-text-color: @sand-text-color;
@@ -409,11 +414,6 @@
 @sand-spinner-bg-color: @sand-component-bg-color;
 @sand-spinner-text-color: @sand-component-text-color;
 @sand-spinner-text-shadow-color: @sand-shadow-color;
-
-// Steps
-// ---------------------------------------
-@sand-steps-step-highlight-current-only-color: rgb(111, 118, 128, 1);
-@sand-steps-step-highlight-current-only-current-color: @sand-component-text-color;
 
 // Switch
 // ---------------------------------------

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -762,11 +762,6 @@
 @sand-pageviews-navigation-button-area-width: 216px;
 @sand-pageviews-steps-area-min-height: 132px;
 @sand-pageviews-dot-steps-area-min-height: @sand-pageviews-steps-area-min-height;
-@sand-pageviews-dot-stpes-page-indicator-size: 18px;
-@sand-pageviews-dot-stpes-page-indicator-margin: 0 15px;
-@sand-pageviews-dot-stpes-page-indicator-border-radius: 999px;
-@sand-pageviews-dot-stpes-page-indicator-current-size: 30px;
-@sand-pageviews-dot-stpes-page-indicator-current-margin: 0 9px;
 @sand-pageviews-full-contents-bottom-steps-bottom: 0;
 @sand-pageviews-number-navigation-button-area-width: 108px;
 @sand-pageviews-number-steps-area-min-height: 252px;
@@ -866,10 +861,11 @@
 		@sand-heading-title-line-height
 	)[@result]
 ) + 10px;
-@sand-quickguidepanels-close-button-margin-end:   150px;
-@sand-quickguidepanels-navigation-button-margin:  0 12px;
-@sand-quickguidepanels-container-margin-top:      828px;
-@sand-quickguidepanels-steps-margin-top:          90px;
+@sand-quickguidepanels-close-button-margin-end: 150px;
+@sand-quickguidepanels-navigation-button-margin: 0 12px;
+@sand-quickguidepanels-container-margin-top: 828px;
+@sand-quickguidepanels-steps-margin-top: 90px;
+@sand-quickguidepanels-steps-min-height: 48px;
 
 // RadioItem
 // ---------------------------------------
@@ -948,6 +944,11 @@
 @sand-steps-step-current-opacity: 1;
 @sand-steps-step-future-opacity: 0.2;
 @sand-steps-step-highlight-current-only-future-opacity: 1;
+@sand-steps-pageindicator-size: 18px;
+@sand-steps-pageindicator-margin: 0 15px;
+@sand-steps-pageindicator-border-radius: 999px;
+@sand-steps-pageindicator-current-size: 30px;
+@sand-steps-pageindicator-current-margin: 0 9px;
 
 // Switch
 // ---------------------------------------

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -162,8 +162,6 @@
 @sand-picker-font-size:             54px;
 @sand-picker-joined-font-size:      66px;
 @sand-steps-step-number-font-size:  54px;
-@sand-steps-step-highlight-current-only-font-size:         24px;
-@sand-steps-step-highlight-current-only-current-font-size: 42px;
 @sand-switch-icon-font-size:        84px;
 @sand-switch-icon-font-size-large:  138px;
 @sand-tablayout-tab-font-size:      66px;
@@ -764,6 +762,11 @@
 @sand-pageviews-navigation-button-area-width: 216px;
 @sand-pageviews-steps-area-min-height: 132px;
 @sand-pageviews-dot-steps-area-min-height: @sand-pageviews-steps-area-min-height;
+@sand-pageviews-dot-stpes-page-indicator-size: 18px;
+@sand-pageviews-dot-stpes-page-indicator-margin: 0 15px;
+@sand-pageviews-dot-stpes-page-indicator-border-radius: 999px;
+@sand-pageviews-dot-stpes-page-indicator-current-size: 30px;
+@sand-pageviews-dot-stpes-page-indicator-current-margin: 0 9px;
 @sand-pageviews-full-contents-bottom-steps-bottom: 0;
 @sand-pageviews-number-navigation-button-area-width: 108px;
 @sand-pageviews-number-steps-area-min-height: 252px;
@@ -941,7 +944,6 @@
 @sand-steps-step-number-font-weight: 600;
 @sand-steps-margin: 0;
 @sand-steps-step-margin: 0 @sand-component-spacing;
-@sand-steps-step-highlight-current-only-margin: 9px;
 @sand-steps-step-past-opacity: 1;
 @sand-steps-step-current-opacity: 1;
 @sand-steps-step-future-opacity: 0.2;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The dot type page indicators in `PageViews` seems not center aligned.
![image](https://github.com/user-attachments/assets/0f9baf04-7fb1-4e2a-a1fc-c274bba4d033)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We've tried to adjust align with the icon font but it's hard to implement with font.
So I implemented with pure div with CSS style instead of Icon component.
![image](https://github.com/user-attachments/assets/c17e548e-6468-47bd-95ac-c3441ade5b58)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I've modified `QuickGuidePanels` too since it's also using `Steps` to show page indicators. I think we need to make a new component "PageIndicator" rather than using `Steps` eventually. I'll make another ticket for this.

### Links
[//]: # (Related issues, references)
WRR-4972

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)