### PR TITLE
WRR-9101: Fixed `Input` keypad layout in largeText mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/IconItem` to restart marquee after done editing in `sandstone/Scroller` with `editable` prop
-- `sandstone/Input` to have 3 columns of keys with in large text mode when `type` prop is `number` or `passwordnumber`, and `popupType` prop is `overlay` or screen is portrait mode
+- `sandstone/Input` keypad layout when `type` prop is `number` or `passwordnumber` and the screen is in portrait mode or `popupType` prop is `overlay` and in large text mode
 - `sandstone/PageViews` and `sandstone/QuickGuidePanels` dot page indicators to be aligned center
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/IconItem` to restart marquee after done editing in `sandstone/Scroller` with `editable` prop
+- `sandstone/Input` to have 3 columns of keys with in large text mode when `type` prop is `number` or `passwordnumber`, and `popupType` prop is `overlay` or screen is portrait mode
 - `sandstone/PageViews` and `sandstone/QuickGuidePanels` dot page indicators to be aligned center
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -132,8 +132,8 @@
 				width: @sand-portrait-input-fullscreen-keypad-width;
 			}
 
-			:global(.enact-orientation-portrait):global(.largeText) & {
-				width: @sand-portrait-input-fullscreen-keypad-large-width;
+			:global(.enact-orientation-portrait):global(.enact-text-large) & {
+				width: @sand-portrait-input-fullscreen-keypad-width-large;
 			}
 		}
 
@@ -233,8 +233,8 @@
 			margin: @sand-input-overlay-keypad-margin;
 			width: @sand-input-overlay-keypad-width;
 
-			:global(.largeText) & {
-				width: @sand-input-overlay-keypad-large-width;
+			:global(.enact-text-large) & {
+				width: @sand-input-overlay-keypad-width-large;
 			}
 		}
 

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -132,7 +132,7 @@
 				width: @sand-portrait-input-fullscreen-keypad-width;
 			}
 
-			:global(.largeText) & {
+			:global(.enact-orientation-portrait):global(.largeText) & {
 				width: @sand-portrait-input-fullscreen-keypad-large-width;
 			}
 		}

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -232,6 +232,10 @@
 		.keypad {
 			margin: @sand-input-overlay-keypad-margin;
 			width: @sand-input-overlay-keypad-width;
+
+			:global(.largeText) & {
+				width: @sand-input-overlay-keypad-large-width;
+			}
 		}
 
 		.buttonArea {

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -131,6 +131,10 @@
 				margin: @sand-portrait-input-fullscreen-keypad-margin;
 				width: @sand-portrait-input-fullscreen-keypad-width;
 			}
+
+			:global(.largeText) & {
+				width: @sand-portrait-input-fullscreen-keypad-large-width;
+			}
 		}
 
 		.key {

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -659,7 +659,7 @@
 @sand-input-fullscreen-back-button-top: 132px;
 @sand-input-fullscreen-back-button-start: 96px;
 @sand-portrait-input-fullscreen-keypad-width: 702px;
-@sand-portrait-input-fullscreen-keypad-large-width: 846px;
+@sand-portrait-input-fullscreen-keypad-width-large: 846px;
 @sand-portrait-input-fullscreen-keypad-margin: 600px auto 0 auto;
 @sand-portrait-input-fullscreen-keypad-key-margin: 45px;
 @sand-portrait-input-fullscreen-text-inputarea-margin: 672px 0 0 0;
@@ -676,7 +676,7 @@
 @sand-input-overlay-numberfield-letter-spacing: 36px;
 @sand-input-overlay-keypad-margin: 132px auto 0 auto;
 @sand-input-overlay-keypad-width: ((@sand-component-spacing + @sand-button-height + @sand-component-spacing) * 3);
-@sand-input-overlay-keypad-large-width: ((@sand-component-spacing + (@sand-button-height * 4/3) + @sand-component-spacing) * 3);
+@sand-input-overlay-keypad-width-large: ((@sand-component-spacing + (@sand-button-height-large) + @sand-component-spacing) * 3);
 @sand-input-overlay-buttonarea-margin: 84px 0 0 0;
 @sand-input-overlay-submitbutton-margin: 84px auto 0 auto;
 @sand-input-overlay-invalid-tooltip-width: 738px;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -676,6 +676,7 @@
 @sand-input-overlay-numberfield-letter-spacing: 36px;
 @sand-input-overlay-keypad-margin: 132px auto 0 auto;
 @sand-input-overlay-keypad-width: ((@sand-component-spacing + @sand-button-height + @sand-component-spacing) * 3);
+@sand-input-overlay-keypad-large-width: ((@sand-component-spacing + (@sand-button-height * 4/3) + @sand-component-spacing) * 3);
 @sand-input-overlay-buttonarea-margin: 84px 0 0 0;
 @sand-input-overlay-submitbutton-margin: 84px auto 0 auto;
 @sand-input-overlay-invalid-tooltip-width: 738px;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -659,6 +659,7 @@
 @sand-input-fullscreen-back-button-top: 132px;
 @sand-input-fullscreen-back-button-start: 96px;
 @sand-portrait-input-fullscreen-keypad-width: 702px;
+@sand-portrait-input-fullscreen-keypad-large-width: 846px;
 @sand-portrait-input-fullscreen-keypad-margin: 600px auto 0 auto;
 @sand-portrait-input-fullscreen-keypad-key-margin: 45px;
 @sand-portrait-input-fullscreen-text-inputarea-margin: 672px 0 0 0;

--- a/tests/screenshot/apps/components/Input.js
+++ b/tests/screenshot/apps/components/Input.js
@@ -33,6 +33,12 @@ const InputTests = [
 	// RTL overlay number input tests
 	...withConfig({locale: 'ar-SA'}, [
 		...withProps({popupType: 'overlay'}, BaseTests.slice(5))
+	]),
+
+	// Large text mode
+	...withConfig({textSize: 'large'}, [
+		...withProps({popupType: 'fullscreen'}, BaseTests),
+		...withProps({popupType: 'overlay'}, BaseTests)
 	])
 ];
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
With portrait fullscreen or overlay type, keypad of number type input should have 3 columns.
But in largeText mode, keypad has 2 columns now. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This is because width is set to exactly fit normal mode. 
I added keypad width values for largeText mode in portrait fullscreen & overlay type.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9101

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)