### PR TITLE
WRR-9101: Fixed `Input` keypad layout in largeText mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Input` keypad layout when `type` prop is `number` or `passwordnumber` and the screen is in portrait mode or `popupType` prop is `overlay` and in large text mode
+
 ## [2.9.4] - 2024-10-29
 
 ### Fixed

--- a/Input/Input.module.less
+++ b/Input/Input.module.less
@@ -131,6 +131,10 @@
 				margin: @sand-portrait-input-fullscreen-keypad-margin;
 				width: @sand-portrait-input-fullscreen-keypad-width;
 			}
+
+			:global(.enact-orientation-portrait):global(.enact-text-large) & {
+				width: @sand-portrait-input-fullscreen-keypad-width-large;
+			}
 		}
 
 		.key {
@@ -228,6 +232,10 @@
 		.keypad {
 			margin: @sand-input-overlay-keypad-margin;
 			width: @sand-input-overlay-keypad-width;
+
+			:global(.enact-text-large) & {
+				width: @sand-input-overlay-keypad-width-large;
+			}
 		}
 
 		.buttonArea {

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -659,6 +659,7 @@
 @sand-input-fullscreen-back-button-top: 132px;
 @sand-input-fullscreen-back-button-start: 96px;
 @sand-portrait-input-fullscreen-keypad-width: 702px;
+@sand-portrait-input-fullscreen-keypad-width-large: 846px;
 @sand-portrait-input-fullscreen-keypad-margin: 600px auto 0 auto;
 @sand-portrait-input-fullscreen-keypad-key-margin: 45px;
 @sand-portrait-input-fullscreen-text-inputarea-margin: 672px 0 0 0;
@@ -675,6 +676,7 @@
 @sand-input-overlay-numberfield-letter-spacing: 36px;
 @sand-input-overlay-keypad-margin: 132px auto 0 auto;
 @sand-input-overlay-keypad-width: ((@sand-component-spacing + @sand-button-height + @sand-component-spacing) * 3);
+@sand-input-overlay-keypad-width-large: ((@sand-component-spacing + (@sand-button-height-large) + @sand-component-spacing) * 3);
 @sand-input-overlay-buttonarea-margin: 84px 0 0 0;
 @sand-input-overlay-submitbutton-margin: 84px auto 0 auto;
 @sand-input-overlay-invalid-tooltip-width: 738px;

--- a/tests/screenshot/apps/components/Input.js
+++ b/tests/screenshot/apps/components/Input.js
@@ -33,6 +33,12 @@ const InputTests = [
 	// RTL overlay number input tests
 	...withConfig({locale: 'ar-SA'}, [
 		...withProps({popupType: 'overlay'}, BaseTests.slice(5))
+	]),
+
+	// Large text mode
+	...withConfig({textSize: 'large'}, [
+		...withProps({popupType: 'fullscreen'}, BaseTests),
+		...withProps({popupType: 'overlay'}, BaseTests)
 	])
 ];
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
With portrait fullscreen or overlay type, keypad of number type input should have 3 columns.
But in largeText mode, keypad has 2 columns now.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
This is because width is set to exactly fit normal mode.
I added keypad width values for largeText mode in portrait fullscreen & overlay type.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9101

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)