### PR TITLE
WRR-9115: `Scroller`: Fixed to focus properly when the spottable node is bigger than the viewport by scrolling with voice control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/PageViews` and `sandstone/QuickGuidePanels` dot page indicators to be aligned center
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`
-- `sandstone/Scroller` to focus properly when the spottable node is bigger than the size of viewport by voice control
 - `sandstone/Scroller` with `editable` prop to move an item via 5-way keys properly in pointer mode
 - `sandstone/Slider` to not show console error when dragging with touch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 - `sandstone/PageViews` and `sandstone/QuickGuidePanels` dot page indicators to be aligned center
 - `sandstone/PageViews` to not clip the shadow of navigation buttons when `fullContents` prop is `true`
 - `sandstone/Scroller` to focus content area properly on supported platforms when `focusableScrollbar` prop is `byEnter`
+- `sandstone/Scroller` to focus properly when the spottable node is bigger than the size of viewport by voice control
 - `sandstone/Scroller` with `editable` prop to move an item via 5-way keys properly in pointer mode
 
 ## [3.0.0-alpha.2] - 2024-10-08

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -3,7 +3,7 @@ import platform from '@enact/core/platform';
 import {onWindowReady} from '@enact/core/snapshot';
 import {clamp} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
-import {getPositionTargetOnFocus} from '@enact/spotlight/src/container';
+import {getDeepSpottableDescendants, getPositionTargetOnFocus} from '@enact/spotlight/src/container';
 import {getRect} from '@enact/spotlight/src/utils';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import {constants} from '@enact/ui/useScroll';
@@ -449,7 +449,7 @@ const useEventVoice = (props, instances) => {
 
 			/* if the focused element is out of the viewport, find another spottable element in the viewport */
 			if (spotItemBounds[last] <= viewportBounds[first] || spotItemBounds[first] >= viewportBounds[last]) {
-				const nodes = Spotlight.getSpottableDescendants(scrollContainerNode.dataset.spotlightId);
+				const nodes = getDeepSpottableDescendants(scrollContainerNode.dataset.spotlightId);
 				for (let i = 0; i < nodes.length; i++) {
 					const nodeBounds = nodes[i].getBoundingClientRect();
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When scrolling down with voice control in certain apps, focus is not restored.
Currently, when scrolling with voice control, focus is moved only when the bounds of the viewport include all bounds of the node.

Therefore, it is necessary to handle the case where the node's bounds are not all included in the viewport's bounds.
(when there is a large node that goes out of bounds, the upper part is visible but the lower part is cut off, etc.)



### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added focus logic for cases where the top of the node is long and the bottom of the node is long using node Bounds and viewports Bounds. Since I need to receive and check new nodes, I implemented it using a recursive function.



### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9115

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
