### PR TITLE
WRR-6683: Remove logic to focus a slider when dragging with touch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/ContextualPopupDecorator` to update popup position properly when the screen orientation change
 - `sandstone/Input` keypad layout when `type` prop is `number` or `passwordnumber` and the screen is in portrait mode or `popupType` prop is `overlay` and in large text mode
+- `sandstone/Slider` to properly focus slider when dragging with touch
 
 ## [2.9.4] - 2024-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/ContextualPopupDecorator` to update popup position properly when the screen orientation change
 - `sandstone/Input` keypad layout when `type` prop is `number` or `passwordnumber` and the screen is in portrait mode or `popupType` prop is `overlay` and in large text mode
-- `sandstone/Slider` to properly focus slider when dragging with touch
+- `sandstone/Slider` to not show console error when dragging with touch
 
 ## [2.9.4] - 2024-10-29
 

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -1,5 +1,6 @@
 import {forward, forwardCustom} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
+import {WithRef} from '@enact/core/internal/WithRef';
 import platform from '@enact/core/platform';
 import Pause from '@enact/spotlight/Pause';
 import IString from 'ilib/lib/IString';
@@ -39,6 +40,7 @@ const defaultConfig = {
 // * Managing focused state to show/hide tooltip
 const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {emitSpotlightEvents} = config;
+	const WrappedWithRef = WithRef(Wrapped);
 
 	return class extends Component {
 		static displayName = 'SliderBehaviorDecorator';
@@ -110,7 +112,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		focusSlider () {
-			let slider = this.sliderRef.current.node;
+			let slider = this.sliderRef.current;
 			if (slider.getAttribute('role') !== 'slider') {
 				slider = slider.querySelector('[role="slider"]');
 			}
@@ -176,7 +178,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			return (
-				<Wrapped
+				<WrappedWithRef
 					role="slider"
 					{...props}
 					active={this.state.active}
@@ -187,7 +189,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					onDragStart={this.handleDragStart}
 					onDragEnd={this.handleDragEnd}
 					onFocus={this.handleFocus}
-					ref={this.sliderRef}
+					outermostRef={this.sliderRef}
 				/>
 			);
 		}

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -1,11 +1,9 @@
 import {forward, forwardCustom} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
-import {WithRef} from '@enact/core/internal/WithRef';
-import platform from '@enact/core/platform';
 import Pause from '@enact/spotlight/Pause';
 import IString from 'ilib/lib/IString';
 import PropTypes from 'prop-types';
-import {Component, createRef} from 'react';
+import {Component} from 'react';
 
 import $L from '../internal/$L';
 
@@ -40,7 +38,6 @@ const defaultConfig = {
 // * Managing focused state to show/hide tooltip
 const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {emitSpotlightEvents} = config;
-	const WrappedWithRef = WithRef(Wrapped);
 
 	return class extends Component {
 		static displayName = 'SliderBehaviorDecorator';
@@ -71,7 +68,6 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.handleFocus = this.handleFocus.bind(this);
 			this.handleSpotlightEvents = this.handleSpotlightEvents.bind(this);
 			this.bounds = {};
-			this.sliderRef = createRef();
 
 			this.state = {
 				active: false,
@@ -111,14 +107,6 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			return valueText;
 		}
 
-		focusSlider () {
-			let slider = this.sliderRef.current;
-			if (slider.getAttribute('role') !== 'slider') {
-				slider = slider.querySelector('[role="slider"]');
-			}
-			slider.focus();
-		}
-
 		handleActivate () {
 			forwardCustom('onActivate')(null, this.props);
 			this.setState(toggleActive);
@@ -133,10 +121,6 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		handleDragStart () {
-			// on platforms with a touchscreen, we want to focus slider when dragging begins
-			if (platform.touchScreen) {
-				this.focusSlider();
-			}
 			this.paused.pause();
 			this.setState({dragging: true});
 		}
@@ -178,7 +162,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			return (
-				<WrappedWithRef
+				<Wrapped
 					role="slider"
 					{...props}
 					active={this.state.active}
@@ -189,7 +173,6 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					onDragStart={this.handleDragStart}
 					onDragEnd={this.handleDragEnd}
 					onFocus={this.handleFocus}
-					outermostRef={this.sliderRef}
 				/>
 			);
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a user drags a slider with touch to move the slider, a console error occurs.
![image](https://github.com/user-attachments/assets/2778fd09-2162-4710-93d0-8033530bc63c)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The console error occurs because a _ref_ is not properly passed to ui/Slider so I created the patch first. But, after investigation and tests, I concluded that the logic using the _ref_ is actually not needed anymore. Therefore, I want to remove the issued logic.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The issued logic is to focus a slider knob even a user touch slightly out of the slider knob to show a focus effect on the knob. We don't need this in the current Sandstone.

### Links
[//]: # (Related issues, references)
WRR-6683

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

