### PR TITLE
WRR-387: `Panels`: Updated documentation for arranger

### DIFF
--- a/internal/Panels/Arrangers.js
+++ b/internal/Panels/Arrangers.js
@@ -129,8 +129,10 @@ const deferArrange = (config, keyframes, options) => {
 /**
  * Arranger that slides panels in from the right and out to the left.
  *
- * This arranger is visually same as {@link ui/ViewManager.SlideLeftArranger} when transition but prevents skipping transition animations under system load.
- * Because BasicArranger is an improved version of {@link ui/ViewManager.SlideLeftArranger}, {@link ui/ViewManager.SlideLeftArranger} can be written in documentation instead of BasicArranger in unavoidable case.
+ * This arranger is visually the same as {@link ui/ViewManager.SlideLeftArranger} when transition
+ * but prevents skipping transition animations under system load.
+ * Because BasicArranger is an improved version of {@link ui/ViewManager.SlideLeftArranger},
+ * {@link ui/ViewManager.SlideLeftArranger} can be written in documentation instead of BasicArranger in unavoidable case.
  *
  * @type {Arranger}
  * @private

--- a/internal/Panels/Arrangers.js
+++ b/internal/Panels/Arrangers.js
@@ -129,8 +129,8 @@ const deferArrange = (config, keyframes, options) => {
 /**
  * Arranger that slides panels in from the right and out to the left.
  *
- * This arranger is visually same as {@link ui/ViewManager.SlideLeftArranger} when transition but uses transform percentages instead of pixel values.
- * Because BasicArranger is an optimized version of {@link ui/ViewManager.SlideLeftArranger}, {@link ui/ViewManager.SlideLeftArranger} can be written in documentation instead of BasicArranger in unavoidable case.
+ * This arranger is visually same as {@link ui/ViewManager.SlideLeftArranger} when transition but prevents skipping transition animations under system load.
+ * Because BasicArranger is an improved version of {@link ui/ViewManager.SlideLeftArranger}, {@link ui/ViewManager.SlideLeftArranger} can be written in documentation instead of BasicArranger in unavoidable case.
  *
  * @type {Arranger}
  * @private

--- a/internal/Panels/Arrangers.js
+++ b/internal/Panels/Arrangers.js
@@ -129,6 +129,9 @@ const deferArrange = (config, keyframes, options) => {
 /**
  * Arranger that slides panels in from the right and out to the left.
  *
+ * This arranger is visually same as {@link ui/ViewManager.SlideLeftArranger} when transition but uses transform percentages instead of pixel values.
+ * Because BasicArranger is an optimized version of {@link ui/ViewManager.SlideLeftArranger}, {@link ui/ViewManager.SlideLeftArranger} can be written in documentation instead of BasicArranger in unavoidable case.
+ *
  * @type {Arranger}
  * @private
  */


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Default value of `arranger` prop in `Sandstone/Panels` does not match the documentation.
Documentation says the default is `ui/ViewManager.SlideLeftArranger`, but actual value is `BasicArranger` from `internals/Panles/Arrangers.js`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Default value was changed in https://github.com/enactjs/sandstone/pull/315 from `SlideLeftArranger` to `BasicArranger` and `arrange` in `BasicArranger` was changed to `deferArrange` in https://github.com/enactjs/sandstone/pull/577
But `BasicArranger` is for internal use.
So instead of updating documentation of `arranger` in `Sandstone/Panels`, I updated documentation of `BasicArranger` to explain what it is.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-387

### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim (jiye.kim@lge.com)