### PR TITLE
WRR-11077: Fixed Scroller to prevent the native scrolling behavior caused by keydown events when the popup is opened

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRR-11077 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=feature/WRR-11077 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to prevent the native scrolling behavior caused by keydown events when a popup is open
+
 ## [3.0.0-alpha.3] - 2024-12-02
 
 ### Added

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -1284,3 +1284,35 @@ export const WithContentContainerOnFocus = () => {
 };
 
 WithContentContainerOnFocus.storyName = 'With Content Container';
+
+export const WithFixedPopupPanels = () => {
+	const [open, setOpenState] = useState(false);
+
+	const handleOpen = useCallback(() => {
+		setOpenState(true);
+	}, [setOpenState]);
+
+	const handleClose = useCallback(() => {
+		setOpenState(false);
+	}, [setOpenState]);
+
+	return (
+		<>
+			<Scroller>
+				<Button onClick={handleOpen}>
+					Open FixedPopupPanels
+				</Button>
+				<div style={{height: ri.scaleToRem(2400)}} />
+			</Scroller>
+			<FixedPopupPanels open={open} onClose={handleClose}>
+				<FixedPopupPanels.Panel>
+					<Header title="Panel" />
+					<Item>Item A</Item>
+					<Item>Item B</Item>
+				</FixedPopupPanels.Panel>
+			</FixedPopupPanels>
+		</>
+	);
+};
+
+WithFixedPopupPanels.storyName = 'With FixedPopupPanels'

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -1315,4 +1315,4 @@ export const WithFixedPopupPanels = () => {
 	);
 };
 
-WithFixedPopupPanels.storyName = 'With FixedPopupPanels'
+WithFixedPopupPanels.storyName = 'With FixedPopupPanels';

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -1290,11 +1290,11 @@ export const WithFixedPopupPanels = () => {
 
 	const handleOpen = useCallback(() => {
 		setOpenState(true);
-	}, [setOpenState]);
+	}, []);
 
 	const handleClose = useCallback(() => {
 		setOpenState(false);
-	}, [setOpenState]);
+	}, []);
 
 	return (
 		<>
@@ -1305,11 +1305,11 @@ export const WithFixedPopupPanels = () => {
 				<div style={{height: ri.scaleToRem(2400)}} />
 			</Scroller>
 			<FixedPopupPanels open={open} onClose={handleClose}>
-				<FixedPopupPanels.Panel>
+				<Panel>
 					<Header title="Panel" />
 					<Item>Item A</Item>
 					<Item>Item B</Item>
-				</FixedPopupPanels.Panel>
+				</Panel>
 			</FixedPopupPanels>
 		</>
 	);

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -10,7 +10,7 @@
 
 import {forward} from '@enact/core/handle';
 import platform from '@enact/core/platform';
-import Spotlight from '@enact/spotlight';
+import Spotlight, {getDirection} from '@enact/spotlight';
 import {spottableClass} from '@enact/spotlight/Spottable';
 import {getContainerId} from '@enact/spotlight/src/container';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
@@ -270,6 +270,13 @@ const useThemeScroll = (props, instances) => {
 		}
 	}
 
+	function preventScroll (ev) {
+		if (Spotlight.isPaused() && getDirection(ev.keyCode)) {
+			ev.preventDefault();
+			ev.stopPropagation();
+		}
+	}
+
 	// Return
 
 	return {
@@ -285,6 +292,7 @@ const useThemeScroll = (props, instances) => {
 		handleTouchStart,
 		handleWheel,
 		removeEventListeners,
+		preventScroll,
 		scrollbarProps,
 		scrollStopOnScroll,
 		scrollTo,
@@ -405,6 +413,7 @@ const useScroll = (props) => {
 		handleTouchStart,
 		handleWheel,
 		removeEventListeners,
+		preventScroll, // scrollMode 'native'
 		scrollbarProps,
 		scrollStopOnScroll, // scrollMode 'native'
 		scrollTo,
@@ -417,6 +426,7 @@ const useScroll = (props) => {
 	if (scrollMode === 'translate') {
 		scrollProps.stop = stop;
 	} else {
+		scrollProps.preventScroll = preventScroll;
 		scrollProps.scrollStopOnScroll = scrollStopOnScroll;
 		scrollProps.start = start;
 	}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the Scroller has a button that opens FixedPopupPanel. The issue is that when press the down key at the moment the popup is opened the scroller behind the FixedPopupPanel scrolls down.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To fix this issue, we have to prevent the native scrolling behavior caused by keydown events.
I created preventScroll function which call `preventDefault` when a keydown event is caused by a directional key and the spotlight is paused.
I added this preventScroll function to useThemeScroll so that it can be passed to ui/Scroller and used as prop.

Also I added the issue case in Scroller qa-sampler

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-11077

### Comments
