### PR TITLE
WRR-10531: Changed QuickGuidePanels to read out more details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Changed
+
+- `sandstone/QuickGuidePanels` to read out more details according to the latest UX guide
+
 ### Fixed
 
 - `sandstone/Scroller` to focus properly when the spottable node is bigger than the size of viewport by voice control

--- a/QuickGuidePanels/QuickGuidePanels.js
+++ b/QuickGuidePanels/QuickGuidePanels.js
@@ -265,11 +265,11 @@ const QuickGuidePanelsBase = kind({
 	},
 
 	computed: {
-		'aria-label': ({'aria-label': label, current, index}) => {
+		'aria-label': ({'aria-label': label, current, index, totalPanels}) => {
 			if (label) return label;
 
 			const stepNum = (typeof current === 'number' && current > 0) ? current : (index + 1);
-			const step = new IString($L('step {num}')).format({num: stepNum}) + ' ';
+			const step = new IString($L('Page {num} out of {total}')).format({num: stepNum, total: totalPanels}) + ' ';
 			return `${step}`;
 		},
 		closeButton: ({closeButtonAriaLabel, onClose, totalPanels}) => {

--- a/QuickGuidePanels/QuickGuidePanels.js
+++ b/QuickGuidePanels/QuickGuidePanels.js
@@ -266,11 +266,10 @@ const QuickGuidePanelsBase = kind({
 
 	computed: {
 		'aria-label': ({'aria-label': label, current, index, totalPanels}) => {
-			if (label) return label;
-
 			const stepNum = (typeof current === 'number' && current > 0) ? current : (index + 1);
 			const step = new IString($L('Page {num} out of {total}')).format({num: stepNum, total: totalPanels}) + ' ';
-			return `${step}`;
+
+			return `${step} ${label || ''}`;
 		},
 		closeButton: ({closeButtonAriaLabel, onClose, totalPanels}) => {
 			return (


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The UX Guide of QuickGuidePanels read out feautre is updated. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Instead of `Step ${num}` calcualte aria-label as `Page {num} out of {total}` in QuickGuidePanels.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-10531

### Comments
