### PR TITLE
WRR-12807: Added VirtualList qa-sampler for changing `dataSize` and `itemSizes`

### DIFF
--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -549,9 +549,9 @@ const variableItemSizes = fixedItemSizes.map((size, index) => {
 });
 
 // eslint-disable-next-line enact/prop-types, enact/display-name
-const renderVirtualListItem = (data) => ({index, ...rest}) => {
+const renderVirtualListItem = (data, onClick = {}) => ({index, ...rest}) => {
 	return (
-		<Item {...rest} style={{width:data[index], margin: ri.scaleToRem(15)}}>
+		<Item {...rest} style={{width: data[index], margin: ri.scaleToRem(15)}} onClick={onClick(index)}>
 			{`item ${index}`}
 		</Item>
 	);
@@ -622,5 +622,48 @@ export const WithChangingItemSizes = () => {
 
 WithChangingItemSizes.storyName = 'with changing item sizes';
 WithChangingItemSizes.parameters = {
+	propTables: [Config]
+};
+
+const initializeItemSizes = (size) => {
+	const data = new Array(size).fill(ri.scale(390));
+	return data.map((val, index) => index % 2  ? val * 2  : val);
+}
+
+export const WithChangingDataSizeAndItemSizes = () => {
+	const [data, setData] = useState(initializeItemSizes(16));
+
+	const handleRestore = useCallback(() => {
+        setData(initializeItemSizes(16));
+    }, []);
+
+	const handleItemClick = useCallback(index => () => {
+        setData(data.filter((_, i) => i !== index));
+    }, [data]);
+
+	return (
+		<Column>
+			<Cell shrink>
+				<Button size="small" onClick={handleRestore}>Restore items</Button>
+			</Cell>
+			<br />
+			<br />
+			<Cell>
+				<VirtualList
+					dataSize={data.length}
+					direction="horizontal"
+					itemRenderer={renderVirtualListItem(data, handleItemClick)}
+					itemSize={{
+						size: data,
+						minSize: Math.min(...data)
+					}}
+				/>
+			</Cell>
+		</Column>
+	);
+};
+
+WithChangingDataSizeAndItemSizes.storyName = 'with changing dataSize and itemSizes';
+WithChangingDataSizeAndItemSizes.parameters = {
 	propTables: [Config]
 };

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -549,7 +549,7 @@ const variableItemSizes = fixedItemSizes.map((size, index) => {
 });
 
 // eslint-disable-next-line enact/prop-types, enact/display-name
-const renderVirtualListItem = (data, onClick = {}) => ({index, ...rest}) => {
+const renderVirtualListItem = (data, onClick = () => {}) => ({index, ...rest}) => {
 	return (
 		<Item {...rest} style={{width: data[index], margin: ri.scaleToRem(15)}} onClick={onClick(index)}>
 			{`item ${index}`}

--- a/samples/sampler/stories/qa/VirtualList.js
+++ b/samples/sampler/stories/qa/VirtualList.js
@@ -545,7 +545,7 @@ WithContainerItemsHaveSpottableControls.parameters = {
 
 const fixedItemSizes = new Array(16).fill(ri.scale(390));
 const variableItemSizes = fixedItemSizes.map((size, index) => {
-	return index % 2  ? size * 2  : size;
+	return index % 2 ? size * 2 : size;
 });
 
 // eslint-disable-next-line enact/prop-types, enact/display-name
@@ -627,19 +627,19 @@ WithChangingItemSizes.parameters = {
 
 const initializeItemSizes = (size) => {
 	const data = new Array(size).fill(ri.scale(390));
-	return data.map((val, index) => index % 2  ? val * 2  : val);
-}
+	return data.map((val, index) => index % 2 ? val * 2 : val);
+};
 
 export const WithChangingDataSizeAndItemSizes = () => {
 	const [data, setData] = useState(initializeItemSizes(16));
 
 	const handleRestore = useCallback(() => {
-        setData(initializeItemSizes(16));
-    }, []);
+		setData(initializeItemSizes(16));
+	}, []);
 
 	const handleItemClick = useCallback(index => () => {
-        setData(data.filter((_, i) => i !== index));
-    }, [data]);
+		setData(data.filter((_, i) => i !== index));
+	}, [data]);
 
 	return (
 		<Column>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To verify https://github.com/enactjs/enact/pull/3299, we need a qa-sampler.
This PR adds a VirtualList qa-sampler for changing both `dataSize` and `itemSizes`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a VirtualList qa-sampler for changing both `dataSize` and `itemSizes`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-12807

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)