### PR TITLE
WRR-8543: Fixed editable `Scroller` not to use static classname

### DIFF
--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -268,7 +268,7 @@ const EditableWrapper = (props) => {
 	}, [customCss.focused, findItemNode]);
 
 	const handleClickCapture = useCallback((ev) => {
-		if (ev.target.className.includes('Button')) {
+		if (ev.target.parentNode.parentNode.getAttribute('role') === 'button') {
 			return;
 		}
 		// Consume the event to prevent Item behavior
@@ -280,7 +280,7 @@ const EditableWrapper = (props) => {
 	}, []);
 
 	const handleMouseDown = useCallback((ev) => {
-		if (ev.target.className.includes('Button')) {
+		if (ev.target.parentNode.parentNode.getAttribute('role') === 'button') {
 			return;
 		}
 		if (mutableRef.current.selectedItem) {
@@ -732,7 +732,7 @@ const EditableWrapper = (props) => {
 			ev.preventDefault();
 		}
 
-		if (mutableRef.current.isDraggingItem && !ev.target.className.includes('Button')) {
+		if (mutableRef.current.isDraggingItem && ev.target.parentNode.parentNode.getAttribute('role') !== 'button') {
 			const {clientX} = ev.targetTouches[0];
 			mutableRef.current.lastMouseClientX = clientX;
 
@@ -755,7 +755,7 @@ const EditableWrapper = (props) => {
 		const {clientX} = ev.changedTouches[0];
 		const targetItemIndex = getNextIndexFromPosition(clientX, 0);
 
-		if (ev.target.className.includes('Button') && Number(selectedItem?.style.order) - 1 === targetItemIndex) {
+		if (ev.target.parentNode.parentNode.getAttribute('role') === 'button' && Number(selectedItem?.style.order) - 1 === targetItemIndex) {
 			return;
 		}
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -268,7 +268,7 @@ const EditableWrapper = (props) => {
 	}, [customCss.focused, findItemNode]);
 
 	const handleClickCapture = useCallback((ev) => {
-		if (ev.target.parentNode.parentNode.getAttribute('role') === 'button') {
+		if (ev.target?.parentNode?.parentNode.getAttribute('role') === 'button') {
 			return;
 		}
 		// Consume the event to prevent Item behavior
@@ -280,7 +280,7 @@ const EditableWrapper = (props) => {
 	}, []);
 
 	const handleMouseDown = useCallback((ev) => {
-		if (ev.target.parentNode.parentNode.getAttribute('role') === 'button') {
+		if (ev.target?.parentNode?.parentNode.getAttribute('role') === 'button') {
 			return;
 		}
 		if (mutableRef.current.selectedItem) {
@@ -732,7 +732,7 @@ const EditableWrapper = (props) => {
 			ev.preventDefault();
 		}
 
-		if (mutableRef.current.isDraggingItem && ev.target.parentNode.parentNode.getAttribute('role') !== 'button') {
+		if (mutableRef.current.isDraggingItem && ev.target?.parentNode?.parentNode.getAttribute('role') !== 'button') {
 			const {clientX} = ev.targetTouches[0];
 			mutableRef.current.lastMouseClientX = clientX;
 
@@ -755,7 +755,7 @@ const EditableWrapper = (props) => {
 		const {clientX} = ev.changedTouches[0];
 		const targetItemIndex = getNextIndexFromPosition(clientX, 0);
 
-		if (ev.target.parentNode.parentNode.getAttribute('role') === 'button' && Number(selectedItem?.style.order) - 1 === targetItemIndex) {
+		if (ev.target?.parentNode?.parentNode.getAttribute('role') === 'button' && Number(selectedItem?.style.order) - 1 === targetItemIndex) {
 			return;
 		}
 

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -160,7 +160,7 @@ export const EditableIcon = (args) => {
 	}, [setEditMode]);
 
 	const handleMouseDown = useCallback((ev) => {
-		if (!ev.target.className.includes('Button')) {
+		if (ev.target.parentNode.parentNode.getAttribute('role') !== 'button') {
 			const targetItemNode = findItemNode(ev.target);
 			if (targetItemNode && targetItemNode.style.order) {
 				mutableRef.current.initialSelected.itemIndex = targetItemNode.style.order;

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -160,7 +160,7 @@ export const EditableIcon = (args) => {
 	}, [setEditMode]);
 
 	const handleMouseDown = useCallback((ev) => {
-		if (ev.target.parentNode.parentNode.getAttribute('role') !== 'button') {
+		if (ev.target?.parentNode?.parentNode.getAttribute('role') !== 'button') {
 			const targetItemNode = findItemNode(ev.target);
 			if (targetItemNode && targetItemNode.style.order) {
 				mutableRef.current.initialSelected.itemIndex = targetItemNode.style.order;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Current editable `Scroller` uses static classname checking like `ev.target.className.includes('Button')`.
This would not work when https://github.com/enactjs/cli/pull/361 merged.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the code uses static classname to see `role` instead.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-8543

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
