### PR TITLE
WRR-11059: update TabLayout storybook sample's icons

### DIFF
--- a/samples/sampler/stories/helper/icons.js
+++ b/samples/sampler/stories/helper/icons.js
@@ -194,4 +194,27 @@ export const drawingIcons = [
 	'pen'
 ].sort();
 
+export const tabIcons = [
+	'appscontents',
+	'bookmark',
+	'browser',
+	'closedcaption',
+	'folder',
+	'guide',
+	'heart',
+	'help',
+	'info',
+	'location',
+	'movies',
+	'music',
+	'network',
+	'notification',
+	'power',
+	'sound',
+	'speaker',
+	'star',
+	'support',
+	'timer'
+].sort();
+
 export default Object.keys(icons).sort();

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -10,7 +10,7 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {range, select} from '@enact/storybook-utils/addons/controls';
 import {Component, useState} from 'react';
 
-import icons from '../helper/icons';
+import {tabIcons} from '../helper/icons';
 
 TabLayout.displayName = 'TabLayout';
 const Config = mergeComponentMetadata('TabLayout', TabLayoutBase, TabLayout);
@@ -81,7 +81,7 @@ export const WithVariableNumberOfTabs = (args) => {
 				orientation={args['orientation']}
 			>
 				{Array.from({length: tabs}, (v, i) => (
-					<TabLayout.Tab title={`Tab ${i}`} icon={icons[i % icons.length]} key={`tab${i}`}>
+					<TabLayout.Tab title={`Tab ${i}`} icon={tabIcons[i % tabIcons.length]} key={`tab${i}`}>
 						<Scroller key={'view' + i}>
 							<Button>Tab {i} Top</Button>
 							<BodyText>
@@ -245,7 +245,7 @@ export const WithDisabledTabs = (args) => {
 				{Array.from({length: tabs}, (v, i) => (
 					<TabLayout.Tab
 						disabled={i % 2 === 1}
-						icon={icons[i % icons.length]}
+						icon={tabIcons[i % tabIcons.length]}
 						title={`Tab ${i}`}
 						key={`tab${i}`}
 					>
@@ -329,7 +329,7 @@ export const WithAllDisabledTabs = (args) => {
 				orientation={args['orientation']}
 			>
 				{Array.from({length: tabs}, (v, i) => (
-					<TabLayout.Tab disabled icon={icons[i % icons.length]} title={`Tab ${i}`} key={`tab${i}`}>
+					<TabLayout.Tab disabled icon={tabIcons[i % tabIcons.length]} title={`Tab ${i}`} key={`tab${i}`}>
 						<Scroller key={'view' + i}>
 							<Button>Tab {i} Top</Button>
 							<BodyText>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As TabLayout sampler uses an icon list that is changing by font update, our screenshot tests are affected.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I made a fixed list for TabLayout sampler so that a list of icons would not be affected by font changes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-11059

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)