### PR TITLE
WRR-9415: Replace .vendor-opacity mixin with the standard opacity attribute

### DIFF
--- a/IconItem/IconItem.module.less
+++ b/IconItem/IconItem.module.less
@@ -89,7 +89,7 @@
 		}
 
 		.disabled ({
-			.vendor-opacity(@sand-iconitem-disabled-opacity);
+			opacity: @sand-iconitem-disabled-opacity;
 		});
 
 		.sand-focus-highlight(content);

--- a/ImageItem/ImageItem.module.less
+++ b/ImageItem/ImageItem.module.less
@@ -178,7 +178,7 @@
 			.sand-spotlight-focus-text-colors();
 
 			.disabled ({
-				.vendor-opacity(@sand-disabled-opacity);
+				opacity: @sand-disabled-opacity;
 			});
 
 			&::before {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some components are using enact/ui's .vendor-opacity() mixin but we don't need it. We normally use the standard opacity CSS attribute and just two components are using the mixin as their code is copied from the old codebase.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace .vendor-opacity() mixin with the standard opacity CSS attribute.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9415

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)