### PR TITLE
WRR-14027: Added UI test when PageViews' autoFocus is 'none'

### DIFF
--- a/tests/ui/apps/PageViews/PageViewsAutoFocus-View.js
+++ b/tests/ui/apps/PageViews/PageViewsAutoFocus-View.js
@@ -1,0 +1,35 @@
+import {BasicArranger} from '../../../../internal/Panels';
+import Item from '../../../../Item';
+import {PageViews} from '../../../../PageViews';
+import Panels, {Panel, Header} from '../../../../Panels';
+import ThemeDecorator from '../../../../ThemeDecorator';
+import spotlight from '@enact/spotlight';
+
+// NOTE: Forcing pointer mode off so we can be sure that regardless of webOS pointer mode the app
+// runs the same way
+spotlight.setPointerMode(false);
+
+const PageViewsWithAutoFocus = props => (
+	<Panels {...props}>
+		<Panel autoFocus="none">
+			<Header title="PageViews with autoFocus" />
+			<PageViews autoFocus="none" arranger={BasicArranger} pageIndicatorType="dot">
+				<PageViews.Page id="PageViewsPage1" aria-label="This is a description for page 1">
+					<div style={{padding: '24px', width: '50%'}}>
+						<Item id="PageViewsItem1">Item 1</Item>
+						<Item>Item 2</Item>
+					</div>
+				</PageViews.Page>
+				<PageViews.Page id="PageViewsPage2" aria-label="This is a description for page 2">
+					<div style={{padding: '24px', width: '50%'}}>
+						<Item id="PageViewsItem3">Item 3</Item>
+						<Item>Item 4</Item>
+					</div>
+				</PageViews.Page>
+			</PageViews>
+		</Panel>
+	</Panels>
+);
+
+export default ThemeDecorator({noAutoFocus: true}, PageViewsWithAutoFocus);
+

--- a/tests/ui/apps/PageViews/PageViewsAutoFocus-View.js
+++ b/tests/ui/apps/PageViews/PageViewsAutoFocus-View.js
@@ -1,4 +1,3 @@
-import {BasicArranger} from '../../../../internal/Panels';
 import Item from '../../../../Item';
 import {PageViews} from '../../../../PageViews';
 import Panels, {Panel, Header} from '../../../../Panels';
@@ -13,7 +12,7 @@ const PageViewsWithAutoFocus = props => (
 	<Panels {...props}>
 		<Panel autoFocus="none">
 			<Header title="PageViews with autoFocus" />
-			<PageViews autoFocus="none" arranger={BasicArranger} pageIndicatorType="dot">
+			<PageViews autoFocus="none" pageIndicatorType="dot">
 				<PageViews.Page id="PageViewsPage1" aria-label="This is a description for page 1">
 					<div style={{padding: '24px', width: '50%'}}>
 						<Item id="PageViewsItem1">Item 1</Item>

--- a/tests/ui/specs/PageViews/PageViews-specs.js
+++ b/tests/ui/specs/PageViews/PageViews-specs.js
@@ -67,7 +67,7 @@ describe('PageViews', function () {
 			await Page.open('AutoFocus');
 		});
 
-		it('should focus nothing when `autoFocus="none"` and the first screen', async function () {
+		it('should focus nothing when `autoFocus="none"` and it`s the first page', async function () {
 			const expected = null;
 			const actual = Page.focusedText;
 

--- a/tests/ui/specs/PageViews/PageViews-specs.js
+++ b/tests/ui/specs/PageViews/PageViews-specs.js
@@ -2,10 +2,6 @@ const Page = require('./PageViewsPage');
 
 describe('PageViews', function () {
 
-	beforeEach(async function () {
-		await Page.open();
-	});
-
 	const {
 		pageViewsPage1,
 		pageViewsPage2,
@@ -13,48 +9,69 @@ describe('PageViews', function () {
 		pageViewsItem3
 	} = Page.components;
 
-	describe('focus management', function () {
-		it('should focus item on load', async function () {
-			expect(await pageViewsItem1.self.isFocused()).toBe(true);
+	describe('default', function () {
+
+		beforeEach(async function () {
+			await Page.open();
 		});
 
-		it('should focus item after switching page', async function () {
-			await Page.spotlightRight();
-			await Page.spotlightSelect();
-			await browser.pause(500);
+		describe('focus management', function () {
+			it('should focus item on load', async function () {
+				expect(await pageViewsItem1.self.isFocused()).toBe(true);
+			});
 
-			expect(await pageViewsItem3.self.isFocused()).toBe(true);
+			it('should focus item after switching page', async function () {
+				await Page.spotlightRight();
+				await Page.spotlightSelect();
+				await browser.pause(500);
+
+				expect(await pageViewsItem3.self.isFocused()).toBe(true);
+			});
+		});
+
+		describe('5-way', function () {
+			it('should change page when selecting next/previous button', async function () {
+				expect(await pageViewsPage1.isPageExist).toBe(true);
+
+				await Page.spotlightRight();
+				await Page.spotlightSelect();
+
+				expect(await pageViewsPage2.isPageExist).toBe(true);
+
+				await browser.pause(500);
+				await Page.spotlightLeft();
+				await Page.spotlightSelect();
+
+				expect(await pageViewsPage1.isPageExist).toBe(true);
+			});
+		});
+
+		describe('pointer', function () {
+			it('should change page when clicking next/previous button', async function () {
+				expect(await pageViewsPage1.isPageExist).toBe(true);
+
+				await pageViewsPage1.nextButton.click();
+
+				expect(await pageViewsPage2.isPageExist).toBe(true);
+
+				await pageViewsPage2.prevButton.click();
+
+				expect(await pageViewsPage1.isPageExist).toBe(true);
+			});
 		});
 	});
 
-	describe('5-way', function () {
-		it('should change page when selecting next/previous button', async function () {
-			expect(await pageViewsPage1.isPageExist).toBe(true);
+	describe('autoFocus', function () {
 
-			await Page.spotlightRight();
-			await Page.spotlightSelect();
-
-			expect(await pageViewsPage2.isPageExist).toBe(true);
-
-			await browser.pause(500);
-			await Page.spotlightLeft();
-			await Page.spotlightSelect();
-
-			expect(await pageViewsPage1.isPageExist).toBe(true);
+		beforeEach(async function () {
+			await Page.open('AutoFocus');
 		});
-	});
 
-	describe('pointer', function () {
-		it('should change page when clicking next/previous button', async function () {
-			expect(await pageViewsPage1.isPageExist).toBe(true);
+		it('should focus nothing when `autoFocus="none"` and the first screen', async function () {
+			const expected = null;
+			const actual = Page.focusedText;
 
-			await pageViewsPage1.nextButton.click();
-
-			expect(await pageViewsPage2.isPageExist).toBe(true);
-
-			await pageViewsPage2.prevButton.click();
-
-			expect(await pageViewsPage1.isPageExist).toBe(true);
+			expect(await actual).toBe(expected);
 		});
 	});
 });

--- a/tests/ui/specs/PageViews/PageViewsPage.js
+++ b/tests/ui/specs/PageViews/PageViewsPage.js
@@ -50,8 +50,14 @@ class PageViewsPage extends Page {
 		};
 	}
 
-	async open (urlExtra) {
-		await super.open('PageViews-View', urlExtra);
+	async open (specification = '', urlExtra) {
+		await super.open(`PageViews${specification}-View`, urlExtra);
+	}
+
+	get focusedText () {
+		return browser.execute(() => {
+			return document.activeElement === document.body ? null : document.activeElement.textContent;
+		});
 	}
 }
 


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I Implemented UI test for WRR-5417. 
Needed to test when autoFocus='none' in PageViews.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check if there is an activeElement when autoFocus='none' for PageViews, autoFocus='none' for Panel, 
and noAutoFocus=true is set in ThemeDecorator's config.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-14027

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
