### PR TITLE
WRR-11058: Update editable scroller focus behavior to match the latest UX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
     - npm config set prefer-offline false
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
+    - git clone --branch=release/6.1.x.develop --depth 1 https://github.com/enactjs/cli ../cli
     - pushd ../cli
     - npm install
     - npm link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` with `editable` prop focus behavior to match the latest UX
+
 ## [2.9.6] - 2024-12-11
 
 ### Added

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -224,7 +224,7 @@ const EditableWrapper = (props) => {
 
 			setTimeout(() => {
 				if (item?.children[1]) {
-					item.children[1].ariaHidden = true;
+					item.children[1].ariaLabel = '';
 				}
 				if (!mutableRef.current.initialSelected) {
 					announceRef.current.announce(
@@ -582,9 +582,6 @@ const EditableWrapper = (props) => {
 		const {selectedItem, selectedItemLabel} = mutableRef.current;
 		const focusTarget = selectedItem.children[1];
 		const orders = finalizeOrders();
-
-		selectedItem.children[1].ariaLabel = '';
-		selectedItem.children[1].ariaHidden = false;
 
 		finalizeEditing(orders);
 		if (selectItemBy === 'press') {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -645,8 +645,6 @@ const EditableWrapper = (props) => {
 		const {focusedItem, selectedItem} = mutableRef.current;
 		const targetItemNode = findItemNode(target);
 
-		mutableRef.current.lastInputType = 'key';
-
 		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
 			if (!repeat) {
 				if (selectedItem) {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -139,9 +139,7 @@ const EditableWrapper = (props) => {
 		isDragging: false,
 
 		// initialSelected
-		initialSelected: editable?.initialSelected,
-
-		needToMoveItemByScrollEvent: false
+		initialSelected: editable?.initialSelected
 	});
 	const announceRef = useRef({});
 
@@ -556,7 +554,6 @@ const EditableWrapper = (props) => {
 			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
 			mutableRef.current.lastInputType = 'mouse';
-			mutableRef.current.needToMoveItemByScrollEvent = true;
 			moveItems(toIndex);
 		}
 	}, [getNextIndexFromPosition, moveItems]);
@@ -671,8 +668,8 @@ const EditableWrapper = (props) => {
 					Spotlight.focus(selectedItem.children[1]);
 				// If keyDown event target is button and next spot target is button, check whether focus leaves the scroll container.
 				} else {
-					// Set needToMoveItemByScrollEvent to false to prevent `handleMoveItemsByScroll` from being executed unexpectedly.
-					mutableRef.current.needToMoveItemByScrollEvent = false;
+					// Set lastInputType to 'key' to prevent `handleMoveItemsByScroll` from being executed unexpectedly.
+					mutableRef.current.lastInputType = 'key';
 					// Check if focus leaves scroll container.
 					handleFocusLeaveScrollContainer(ev, nextTarget);
 				}
@@ -771,7 +768,6 @@ const EditableWrapper = (props) => {
 					targetY: 0
 				});
 				mutableRef.current.lastInputType = 'touch';
-				mutableRef.current.needToMoveItemByScrollEvent = true;
 				moveItems(toIndex);
 			}
 		}
@@ -913,9 +909,8 @@ const EditableWrapper = (props) => {
 			const bodyWidth = document.body.getBoundingClientRect().width;
 			const {lastMouseClientX, selectedItem} = mutableRef.current;
 			const {isHoveringToScroll, rtl} = scrollContainerHandle.current;
-			if (selectedItem && mutableRef.current.lastInputType !== 'key' && mutableRef.current.needToMoveItemByScrollEvent && Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
+			if (selectedItem && mutableRef.current.lastInputType !== 'key' && Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
 				mutableRef.current.lastInputType = 'scroll';
-				mutableRef.current.needToMoveItemByScrollEvent = true;
 				if (isHoveringToScroll) {
 					const toIndex = getNextIndexFromPosition(lastMouseClientX, 0);
 					moveItems(!rtl ^ !(lastMouseClientX > bodyWidth / 2) ? toIndex + 1 : toIndex - 1);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -650,15 +650,18 @@ const EditableWrapper = (props) => {
 					setPointerMode(false);
 					Spotlight.focus(selectedItem.children[1]);
 				// Check if focus leaves scroll container.
-				} else if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {
-					setPointerMode(false);
-					Spotlight.move(getDirection(keyCode));
+				} else {
+					mutableRef.current.lastInputType = 'key';
+					if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {
+						setPointerMode(false);
+						Spotlight.move(getDirection(keyCode));
 
-					const orders = finalizeOrders();
-					finalizeEditing(orders);
+						const orders = finalizeOrders();
+						finalizeEditing(orders);
 
-					ev.preventDefault();
-					ev.stopPropagation();
+						ev.preventDefault();
+						ev.stopPropagation();
+					}
 				}
 			// Check if focus leaves scroll container.
 			} else if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId) && !repeat) {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -139,7 +139,9 @@ const EditableWrapper = (props) => {
 		isDragging: false,
 
 		// initialSelected
-		initialSelected: editable?.initialSelected
+		initialSelected: editable?.initialSelected,
+
+		needToMoveItemByScrollEvent: false
 	});
 	const announceRef = useRef({});
 
@@ -554,6 +556,7 @@ const EditableWrapper = (props) => {
 			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
 			mutableRef.current.lastInputType = 'mouse';
+			mutableRef.current.needToMoveItemByScrollEvent = true;
 			moveItems(toIndex);
 		}
 	}, [getNextIndexFromPosition, moveItems]);
@@ -668,8 +671,8 @@ const EditableWrapper = (props) => {
 					Spotlight.focus(selectedItem.children[1]);
 				// If keyDown event target is button and next spot target is button, check whether focus leaves the scroll container.
 				} else {
-					// Set lastInputType to 'key' to prevent `handleMoveItemsByScroll` from being executed unexpectedly.
-					mutableRef.current.lastInputType = 'key';
+					// Set needToMoveItemByScrollEvent to false to prevent `handleMoveItemsByScroll` from being executed unexpectedly.
+					mutableRef.current.needToMoveItemByScrollEvent = false;
 					// Check if focus leaves scroll container.
 					handleFocusLeaveScrollContainer(ev, nextTarget);
 				}
@@ -768,6 +771,7 @@ const EditableWrapper = (props) => {
 					targetY: 0
 				});
 				mutableRef.current.lastInputType = 'touch';
+				mutableRef.current.needToMoveItemByScrollEvent = true;
 				moveItems(toIndex);
 			}
 		}
@@ -909,8 +913,9 @@ const EditableWrapper = (props) => {
 			const bodyWidth = document.body.getBoundingClientRect().width;
 			const {lastMouseClientX, selectedItem} = mutableRef.current;
 			const {isHoveringToScroll, rtl} = scrollContainerHandle.current;
-			if (selectedItem && mutableRef.current.lastInputType !== 'key' && Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
+			if (selectedItem && mutableRef.current.lastInputType !== 'key' && mutableRef.current.needToMoveItemByScrollEvent && Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
 				mutableRef.current.lastInputType = 'scroll';
+				mutableRef.current.needToMoveItemByScrollEvent = true;
 				if (isHoveringToScroll) {
 					const toIndex = getNextIndexFromPosition(lastMouseClientX, 0);
 					moveItems(!rtl ^ !(lastMouseClientX > bodyWidth / 2) ? toIndex + 1 : toIndex - 1);

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -623,6 +623,7 @@ const EditableWrapper = (props) => {
 			completeEditingByKeyDown();
 			mutableRef.current.needToPreventEvent = true;
 		} else if (is('left', keyCode) || is('right', keyCode)) {
+			const nextTarget = getTargetByDirectionFromElement(getDirection(keyCode), target);
 			if (selectedItem) {
 				if (target.getAttribute('role') !== 'button') {
 					if (Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
@@ -635,14 +636,39 @@ const EditableWrapper = (props) => {
 					}
 					ev.preventDefault();
 					ev.stopPropagation();
-				}
-			} else {
-				const nextTarget = getTargetByDirectionFromElement(getDirection(keyCode), target);
-
+				} else if (nextTarget?.getAttribute('role') !== 'button') {
+					if (Number(selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
+						if (repeat) {
+							SpotlightAccelerator.processKey(ev, moveItemsByKeyDown);
+						} else {
+							SpotlightAccelerator.reset();
+							moveItemsByKeyDown(ev);
+						}
+					}
+					ev.preventDefault();
+					ev.stopPropagation();
+					setPointerMode(false);
+					Spotlight.focus(selectedItem.children[1]);
 				// Check if focus leaves scroll container.
-				if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId) && !repeat) {
-					reset();
+				} else if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {
+					setPointerMode(false);
+					Spotlight.move(getDirection(keyCode));
+
+					const orders = finalizeOrders();
+					finalizeEditing(orders);
+
+					ev.preventDefault();
+					ev.stopPropagation();
 				}
+			// Check if focus leaves scroll container.
+			} else if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId) && !repeat) {
+				setPointerMode(false);
+				Spotlight.move(getDirection(keyCode));
+
+				reset();
+
+				ev.preventDefault();
+				ev.stopPropagation();
 			}
 		} else if (is('up', keyCode) || is('down', keyCode)) {
 			if (selectedItem || focusedItem) {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -221,13 +221,17 @@ const EditableWrapper = (props) => {
 			mutableRef.current.prevToIndex = mutableRef.current.fromIndex;
 
 			updateArrowIcon(mutableRef.current.fromIndex);
-			if (!mutableRef.current.initialSelected) {
-				setTimeout(() => {
+
+			setTimeout(() => {
+				if (item?.children[1]) {
+					item.children[1].ariaHidden = true;
+				}
+				if (!mutableRef.current.initialSelected) {
 					announceRef.current.announce(
 						mutableRef.current.selectedItemLabel + $L('Press the left/right button to move or press the up button to select other options.')
 					);
-				}, completeAnnounceDelay);
-			}
+				}
+			}, completeAnnounceDelay);
 		}
 	}, [customCss.focused, customCss.selected, updateArrowIcon]);
 
@@ -580,6 +584,8 @@ const EditableWrapper = (props) => {
 		const orders = finalizeOrders();
 
 		selectedItem.children[1].ariaLabel = '';
+		selectedItem.children[1].ariaHidden = false;
+
 		finalizeEditing(orders);
 		if (selectItemBy === 'press') {
 			if (getPointerMode()) {

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -124,7 +124,7 @@ const EditableWrapper = (props) => {
 		// Last mouse position
 		lastMouseClientX: null,
 
-		// Last InputType which moves Items
+		// Last InputType
 		lastInputType: null,
 
 		// Timer for holding key input
@@ -449,7 +449,6 @@ const EditableWrapper = (props) => {
 			});
 		}
 
-		mutableRef.current.lastInputType = 'key';
 		mutableRef.current.lastInputDirection = is('left', keyCode) ? 'left' : 'right';
 		moveItems(toIndex);
 
@@ -559,11 +558,11 @@ const EditableWrapper = (props) => {
 	const handleMouseMove = useCallback((ev) => {
 		const {clientX} = ev;
 		mutableRef.current.lastMouseClientX = clientX;
+		mutableRef.current.lastInputType = 'mouse';
 
 		if (mutableRef.current.selectedItem && Number(mutableRef.current.selectedItem.style.order) - 1 < mutableRef.current.hideIndex) {
 			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
-			mutableRef.current.lastInputType = 'mouse';
 			moveItems(toIndex);
 		}
 	}, [getNextIndexFromPosition, moveItems]);
@@ -646,6 +645,8 @@ const EditableWrapper = (props) => {
 		const {focusedItem, selectedItem} = mutableRef.current;
 		const targetItemNode = findItemNode(target);
 
+		mutableRef.current.lastInputType = 'key';
+
 		if (is('enter', keyCode) && target.getAttribute('role') !== 'button') {
 			if (!repeat) {
 				if (selectedItem) {
@@ -678,8 +679,6 @@ const EditableWrapper = (props) => {
 					Spotlight.focus(selectedItem.children[1]);
 				// If keyDown event target is button and next spot target is button, check whether focus leaves the scroll container.
 				} else {
-					// Set lastInputType to 'key' to prevent `handleMoveItemsByScroll` from being executed unexpectedly.
-					mutableRef.current.lastInputType = 'key';
 					// Check if focus leaves scroll container.
 					handleFocusLeaveScrollContainer(ev, nextTarget);
 				}
@@ -721,6 +720,8 @@ const EditableWrapper = (props) => {
 	const handleGlobalKeyDownCapture = useCallback((ev) => {
 		const {focusedItem, selectedItem} = mutableRef.current;
 
+		mutableRef.current.lastInputType = 'key';
+
 		// If the pointer mode is `true` and the focused component is not contained in scrollContainerRef,
 		// only `handleGlobalKeyDownCapture` is called instead of `handleKeyDownCapture`
 		// Below is mainly for handling key pressed while pointer mode is `true`.
@@ -761,6 +762,8 @@ const EditableWrapper = (props) => {
 	}, [completeEditingByKeyDown, finalizeEditing, finalizeOrders, moveItemsByKeyDown, scrollContainerRef, startEditing]);
 
 	const handleTouchMove = useCallback((ev) => {
+		mutableRef.current.lastInputType = 'touch';
+
 		if (mutableRef.current.selectedItem) {
 			// Prevent scrolling by dragging when item is selected
 			ev.preventDefault();
@@ -774,7 +777,6 @@ const EditableWrapper = (props) => {
 			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
 			if (toIndex !== mutableRef.current.prevToIndex) {
-				mutableRef.current.lastInputType = 'touch';
 				moveItems(toIndex);
 			}
 		}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -4,7 +4,6 @@ import IconItem from '@enact/sandstone/IconItem';
 import Scroller from '@enact/sandstone/Scroller';
 import $L from '@enact/sandstone/internal/$L';
 import Spotlight from '@enact/spotlight';
-import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
@@ -78,7 +77,6 @@ for (let i = 0; i < 20; i++) {
 	itemsArr.push(populateItems({index: i}));
 }
 
-const Container = SpotlightContainerDecorator('div');
 const TouchableDiv = Touchable('div');
 
 export const EditableIcon = (args) => {
@@ -233,103 +231,101 @@ export const EditableIcon = (args) => {
 
 	return (
 		<div ref={divRef}>
-			<Container>
-				{editMode ? <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="arrowhookleft" /> : <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="edit" />}
-				{editMode ?
+			{editMode ? <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="arrowhookleft" /> : <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="edit" />}
+			{editMode ?
+				<Scroller
+					direction="horizontal"
+					editable={{
+						centered: args['editableCentered'],
+						css,
+						hideIndex: mutableRef.current.hideIndex,
+						onComplete: handleComplete,
+						removeItemFuncRef: removeItem,
+						hideItemFuncRef: hideItem,
+						showItemFuncRef: showItem,
+						blurItemFuncRef: blurItem,
+						focusItemFuncRef: focusItem,
+						initialSelected: mutableRef.current.initialSelected,
+						selectItemBy: 'press'
+					}}
+					focusableScrollbar={args['focusableScrollbar']}
+					horizontalScrollbar={args['horizontalScrollbar']}
+					hoverToScroll={args['hoverToScroll']}
+					key={args['scrollMode']}
+					noScrollByWheel={args['noScrollByWheel']}
+					onClick={action('onClickScroller')}
+					onKeyDown={action('onKeyDown')}
+					onScrollStart={action('onScrollStart')}
+					onScrollStop={action('onScrollStop')}
+					scrollMode={args['scrollMode']}
+					spotlightDisabled={args['spotlightDisabled']}
+					verticalScrollbar={args['verticalScrollbar']}
+				>
+					{
+						items.map((item, index) => {
+							return (
+								<div
+									aria-label={`Icon ${item.index}`}
+									className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})}
+									data-index={item.index}
+									disabled={item.iconItemProps['disabled'] || item.hidden}
+									key={item.index}
+									onMouseLeave={onMouseLeaveItem}
+									style={{order: index + 1}}
+								>
+									<div className={css.removeButtonContainer}>
+										{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+										{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+										{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+									</div>
+									<IconItem
+										{...item.iconItemProps}
+										aria-label={`Icon ${item.index}`}
+										className={css.editableIconItem}
+										css={css}
+										disabled={item.iconItemProps['disabled'] || item.hidden}
+										onClick={action('onClickItem')}
+										onFocus={onFocusItem}
+										order={index}
+									/>
+								</div>
+							);
+						})
+					}
+				</Scroller> :
+				<TouchableDiv
+					onHoldStart={handleHoldStart}
+					onMouseDown={handleMouseDown}
+					onKeyDown={handleKeyDown}
+					onKeyUp={handleKeyUp}
+				>
 					<Scroller
 						direction="horizontal"
-						editable={{
-							centered: args['editableCentered'],
-							css,
-							hideIndex: mutableRef.current.hideIndex,
-							onComplete: handleComplete,
-							removeItemFuncRef: removeItem,
-							hideItemFuncRef: hideItem,
-							showItemFuncRef: showItem,
-							blurItemFuncRef: blurItem,
-							focusItemFuncRef: focusItem,
-							initialSelected: mutableRef.current.initialSelected,
-							selectItemBy: 'press'
-						}}
-						focusableScrollbar={args['focusableScrollbar']}
-						horizontalScrollbar={args['horizontalScrollbar']}
-						hoverToScroll={args['hoverToScroll']}
-						key={args['scrollMode']}
-						noScrollByWheel={args['noScrollByWheel']}
 						onClick={action('onClickScroller')}
 						onKeyDown={action('onKeyDown')}
+						onScroll={handleScroll}
 						onScrollStart={action('onScrollStart')}
 						onScrollStop={action('onScrollStop')}
-						scrollMode={args['scrollMode']}
-						spotlightDisabled={args['spotlightDisabled']}
-						verticalScrollbar={args['verticalScrollbar']}
 					>
-						{
+						<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
 							items.map((item, index) => {
 								return (
-									<div
-										aria-label={`Icon ${item.index}`}
-										className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})}
-										data-index={item.index}
-										disabled={item.iconItemProps['disabled'] || item.hidden}
-										key={item.index}
-										onMouseLeave={onMouseLeaveItem}
-										style={{order: index + 1}}
-									>
-										<div className={css.removeButtonContainer}>
-											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
-										</div>
+									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+										<div className={css.removeButtonContainer} />
 										<IconItem
 											{...item.iconItemProps}
-											aria-label={`Icon ${item.index}`}
-											className={css.editableIconItem}
-											css={css}
+											aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
+											className={css.iconItem}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
 											onClick={action('onClickItem')}
-											onFocus={onFocusItem}
-											order={index}
 										/>
 									</div>
 								);
-							})
-						}
-					</Scroller> :
-					<TouchableDiv
-						onHoldStart={handleHoldStart}
-						onMouseDown={handleMouseDown}
-						onKeyDown={handleKeyDown}
-						onKeyUp={handleKeyUp}
-					>
-						<Scroller
-							direction="horizontal"
-							onClick={action('onClickScroller')}
-							onKeyDown={action('onKeyDown')}
-							onScroll={handleScroll}
-							onScrollStart={action('onScrollStart')}
-							onScrollStop={action('onScrollStop')}
-						>
-							<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
-								items.map((item, index) => {
-									return (
-										<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
-											<div className={css.removeButtonContainer} />
-											<IconItem
-												{...item.iconItemProps}
-												aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
-												className={css.iconItem}
-												disabled={item.iconItemProps['disabled'] || item.hidden}
-												onClick={action('onClickItem')}
-											/>
-										</div>
-									);
-								})}
-							</div>
-						</Scroller>
-					</TouchableDiv>
-				}
-			</Container>
+							})}
+						</div>
+					</Scroller>
+				</TouchableDiv>
+			}
 		</div>
 	);
 };

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -79,7 +79,6 @@ for (let i = 0; i < 20; i++) {
 }
 
 const Container = SpotlightContainerDecorator('div');
-const ContainerDivWithLeaveForConfig = SpotlightContainerDecorator({leaveFor: {left: '', right: ''}}, 'div');
 const TouchableDiv = Touchable('div');
 
 export const EditableIcon = (args) => {
@@ -277,11 +276,11 @@ export const EditableIcon = (args) => {
 										onMouseLeave={onMouseLeaveItem}
 										style={{order: index + 1}}
 									>
-										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
+										<div className={css.removeButtonContainer}>
 											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
 											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
-										</ContainerDivWithLeaveForConfig>
+										</div>
 										<IconItem
 											{...item.iconItemProps}
 											aria-label={`Icon ${item.index}`}

--- a/samples/sampler/stories/qa/IconItem.js
+++ b/samples/sampler/stories/qa/IconItem.js
@@ -4,6 +4,7 @@ import IconItem from '@enact/sandstone/IconItem';
 import Scroller from '@enact/sandstone/Scroller';
 import $L from '@enact/sandstone/internal/$L';
 import Spotlight from '@enact/spotlight';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
@@ -77,6 +78,7 @@ for (let i = 0; i < 20; i++) {
 	itemsArr.push(populateItems({index: i}));
 }
 
+const Container = SpotlightContainerDecorator('div');
 const TouchableDiv = Touchable('div');
 
 export const EditableIcon = (args) => {
@@ -231,101 +233,103 @@ export const EditableIcon = (args) => {
 
 	return (
 		<div ref={divRef}>
-			{editMode ? <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="arrowhookleft" /> : <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="edit" />}
-			{editMode ?
-				<Scroller
-					direction="horizontal"
-					editable={{
-						centered: args['editableCentered'],
-						css,
-						hideIndex: mutableRef.current.hideIndex,
-						onComplete: handleComplete,
-						removeItemFuncRef: removeItem,
-						hideItemFuncRef: hideItem,
-						showItemFuncRef: showItem,
-						blurItemFuncRef: blurItem,
-						focusItemFuncRef: focusItem,
-						initialSelected: mutableRef.current.initialSelected,
-						selectItemBy: 'press'
-					}}
-					focusableScrollbar={args['focusableScrollbar']}
-					horizontalScrollbar={args['horizontalScrollbar']}
-					hoverToScroll={args['hoverToScroll']}
-					key={args['scrollMode']}
-					noScrollByWheel={args['noScrollByWheel']}
-					onClick={action('onClickScroller')}
-					onKeyDown={action('onKeyDown')}
-					onScrollStart={action('onScrollStart')}
-					onScrollStop={action('onScrollStop')}
-					scrollMode={args['scrollMode']}
-					spotlightDisabled={args['spotlightDisabled']}
-					verticalScrollbar={args['verticalScrollbar']}
-				>
-					{
-						items.map((item, index) => {
-							return (
-								<div
-									aria-label={`Icon ${item.index}`}
-									className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})}
-									data-index={item.index}
-									disabled={item.iconItemProps['disabled'] || item.hidden}
-									key={item.index}
-									onMouseLeave={onMouseLeaveItem}
-									style={{order: index + 1}}
-								>
-									<div className={css.removeButtonContainer}>
-										{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
-										{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
-										{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
-									</div>
-									<IconItem
-										{...item.iconItemProps}
-										aria-label={`Icon ${item.index}`}
-										className={css.editableIconItem}
-										css={css}
-										disabled={item.iconItemProps['disabled'] || item.hidden}
-										onClick={action('onClickItem')}
-										onFocus={onFocusItem}
-										order={index}
-									/>
-								</div>
-							);
-						})
-					}
-				</Scroller> :
-				<TouchableDiv
-					onHoldStart={handleHoldStart}
-					onMouseDown={handleMouseDown}
-					onKeyDown={handleKeyDown}
-					onKeyUp={handleKeyUp}
-				>
+			<Container>
+				{editMode ? <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="arrowhookleft" /> : <Button style={{marginLeft: '36px'}} onClick={onClickModeButton} icon="edit" />}
+				{editMode ?
 					<Scroller
 						direction="horizontal"
+						editable={{
+							centered: args['editableCentered'],
+							css,
+							hideIndex: mutableRef.current.hideIndex,
+							onComplete: handleComplete,
+							removeItemFuncRef: removeItem,
+							hideItemFuncRef: hideItem,
+							showItemFuncRef: showItem,
+							blurItemFuncRef: blurItem,
+							focusItemFuncRef: focusItem,
+							initialSelected: mutableRef.current.initialSelected,
+							selectItemBy: 'press'
+						}}
+						focusableScrollbar={args['focusableScrollbar']}
+						horizontalScrollbar={args['horizontalScrollbar']}
+						hoverToScroll={args['hoverToScroll']}
+						key={args['scrollMode']}
+						noScrollByWheel={args['noScrollByWheel']}
 						onClick={action('onClickScroller')}
 						onKeyDown={action('onKeyDown')}
-						onScroll={handleScroll}
 						onScrollStart={action('onScrollStart')}
 						onScrollStop={action('onScrollStop')}
+						scrollMode={args['scrollMode']}
+						spotlightDisabled={args['spotlightDisabled']}
+						verticalScrollbar={args['verticalScrollbar']}
 					>
-						<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
+						{
 							items.map((item, index) => {
 								return (
-									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
-										<div className={css.removeButtonContainer} />
+									<div
+										aria-label={`Icon ${item.index}`}
+										className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})}
+										data-index={item.index}
+										disabled={item.iconItemProps['disabled'] || item.hidden}
+										key={item.index}
+										onMouseLeave={onMouseLeaveItem}
+										style={{order: index + 1}}
+									>
+										<div className={css.removeButtonContainer}>
+											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
+											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
+											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
+										</div>
 										<IconItem
 											{...item.iconItemProps}
-											aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
-											className={css.iconItem}
+											aria-label={`Icon ${item.index}`}
+											className={css.editableIconItem}
+											css={css}
 											disabled={item.iconItemProps['disabled'] || item.hidden}
 											onClick={action('onClickItem')}
+											onFocus={onFocusItem}
+											order={index}
 										/>
 									</div>
 								);
-							})}
-						</div>
-					</Scroller>
-				</TouchableDiv>
-			}
+							})
+						}
+					</Scroller> :
+					<TouchableDiv
+						onHoldStart={handleHoldStart}
+						onMouseDown={handleMouseDown}
+						onKeyDown={handleKeyDown}
+						onKeyUp={handleKeyUp}
+					>
+						<Scroller
+							direction="horizontal"
+							onClick={action('onClickScroller')}
+							onKeyDown={action('onKeyDown')}
+							onScroll={handleScroll}
+							onScrollStart={action('onScrollStart')}
+							onScrollStop={action('onScrollStop')}
+						>
+							<div className={classNames(css.scrollerWrapper, css.wrapper, {[css.centered]: args['editableCentered']})}> {
+								items.map((item, index) => {
+									return (
+										<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}}>
+											<div className={css.removeButtonContainer} />
+											<IconItem
+												{...item.iconItemProps}
+												aria-label={`Icon ${item.index} ${$L('Press and hold the OK button to edit.')}`}
+												className={css.iconItem}
+												disabled={item.iconItemProps['disabled'] || item.hidden}
+												onClick={action('onClickItem')}
+											/>
+										</div>
+									);
+								})}
+							</div>
+						</Scroller>
+					</TouchableDiv>
+				}
+			</Container>
 		</div>
 	);
 };

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -15,7 +15,6 @@ import ri from '@enact/ui/resolution';
 import Touchable from '@enact/ui/Touchable';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import compose from 'ramda/src/compose';
 import {useCallback, useState, useRef, useLayoutEffect} from 'react';
 
@@ -198,7 +197,6 @@ for (let i = 0; i < 20; i++) {
 	itemsArr.push(populateItems({index: i}));
 }
 
-const ContainerDivWithLeaveForConfig = SpotlightContainerDecorator({leaveFor: {left: '', right: ''}}, 'div');
 const TouchableDiv = Touchable('div');
 
 export const WithEditableScroller = (args) => {
@@ -401,11 +399,11 @@ export const WithEditableScroller = (args) => {
 							iconItems.map((item, index) => {
 								return (
 									<div key={item.index} className={classNames(css.itemWrapper, {[css.hidden]: item.hidden})} aria-label={`Icon ${item.index}`} data-index={item.index} style={{order: index + 1}} disabled={item.iconItemProps['disabled'] || item.hidden}>
-										<ContainerDivWithLeaveForConfig className={css.removeButtonContainer}>
+										<div className={css.removeButtonContainer}>
 											{item.hidden ? null : <Button aria-label="Delete" className={css.removeButton} onClick={onClickRemoveButton} icon="trash" />}
 											{item.hidden ? null : <Button aria-label="Hide" className={css.removeButton} onClick={onClickHideButton} icon="minus" />}
 											{item.hidden ? <Button aria-label="Show" className={css.removeButton} onClick={onClickShowButton} icon="plus" /> : null}
-										</ContainerDivWithLeaveForConfig>
+										</div>
 										<IconItem
 											{...item.iconItemProps}
 											spotlightId={`item_${index}`}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus behavior of the editable scroller is updated
(1) After moving focus to the top button(item is not selected), focus will be moved by pressing the ← or → keys
![241217_focusbehavior_1](https://github.com/user-attachments/assets/087fb706-9cc3-4f72-8e71-d726c7d137cb)
(2) After entering the item edit mode, item can be moved by pressing the ← or → keys while focusing on the top button
![241217_focusbehavior_2](https://github.com/user-attachments/assets/232bed3f-1c7b-4326-837e-ec8b4405ae47)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix `handleKeyDownCapture` to move focus according to updated UX guide

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
(1) To fix the issue as the gif below, I added 6084876fa63612a46d892ecf9162886ea6f91150 commit. 
![241217_lastInputType](https://github.com/user-attachments/assets/8f52fd55-13db-4b1d-8aff-455de6a2cb47)
The issue occurs when focus moves to the `hide` button, scroll event occurred and then `handleMoveItemsByScroll` executed.
I added to set `lastInputType` to `key` to prevent `handleMoveItemsByScroll` from being executed.

(2) Since there is no guide for these cases, I implemented it as follows.
![241217_edge_1](https://github.com/user-attachments/assets/2f4e3e62-f22a-46d2-8495-5e9a0ab8a505)
![241217_edge_2](https://github.com/user-attachments/assets/61977af5-85fa-48c2-9b09-e17afb4ffd47)
![241217_edge_3](https://github.com/user-attachments/assets/b7615cba-5b41-44ac-9fbd-b5aee1c3eb0e)
![241217_edge_4](https://github.com/user-attachments/assets/747690ce-0e94-4285-a509-cf4646389cd1)

(3) I cannot use Spotlight.getLastInputType() in editableWrapper.js because it is later synced. so we had to define `lastInputType` in mutableRef. 

(4) I added 92fd7fcb63fee36d4dcfbfcae6bf2b74e00da38f, 73d5a95d261491e35ec7334f6692a8f8d78a7080 commit to fix the a11y issue which caused by the logic which manually focus the item. 

### Links
[//]: # (Related issues, references)
WRR-11058

### Comments
