### PR TITLE
WRR-14835: `TooltipDecorator` to hide a tooltip when tapping outside of disabled components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ## [unreleased]
 
+### Fixed
+
+- `sandstone/TooltipDecorator` to hide a tooltip when tapping outside of disabled component
+
+## [2.9.6] - 2024-12-11
+
 ### Added
 
 - `sandstone/Icon` supported icon list, adding new icon `calibration`
@@ -12,7 +18,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` to focus properly when the spottable node is bigger than the size of viewport by voice control
 - `sandstone/Scroller` to prevent the native scrolling behavior caused by keydown events when a popup is open
-- `sandstone/TooltipDecorator` to hide a tooltip when tapping outside of disabled components
 
 ## [3.0.0-alpha.3] - 2024-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/Scroller` to focus properly when the spottable node is bigger than the size of viewport by voice control
 - `sandstone/Scroller` to prevent the native scrolling behavior caused by keydown events when a popup is open
+- `sandstone/TooltipDecorator` to hide a tooltip when tapping outside of disabled components
 
 ## [3.0.0-alpha.3] - 2024-12-02
 

--- a/TooltipDecorator/useTooltip.js
+++ b/TooltipDecorator/useTooltip.js
@@ -139,9 +139,8 @@ const useTooltip = (props) => {
 			if (clientRef.current && !clientRef.current.contains(ev.relatedTarget)) {
 				hideTooltip();
 			}
-			showTooltip(ev.currentTarget);
 		}
-	}, [hideTooltip, props, showTooltip]);
+	}, [hideTooltip, props]);
 
 	const onFocus = useCallback((ev) => {
 		forward('onFocus', ev, props);

--- a/samples/sampler/stories/qa/Tooltip.js
+++ b/samples/sampler/stories/qa/Tooltip.js
@@ -15,7 +15,6 @@ import {Component} from 'react';
 import Section from './components/KitchenSinkSection';
 
 const Config = mergeComponentMetadata('TooltipDecorator', TooltipDecorator, Tooltip, TooltipBase);
-const TooltipButton = TooltipDecorator({tooltipDestinationProp: 'decoration'}, Button);
 
 const prop = {
 	tooltipPosition: {
@@ -67,14 +66,14 @@ class TooltipTest extends Component {
 			<div>
 				Focus the button and click it before 5s has elapsed, and observe the console for errors
 				{this.state.showButton ? (
-					<TooltipButton
+					<Button
 						onClick={this.handleClick}
 						tooltipDelay={5000}
 						tooltipText="Tooltip position!"
 						tooltipRelative
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				) : null}
 			</div>
 		);
@@ -319,7 +318,7 @@ export const TooltipOverflows = (args) => {
 			<Cell shrink>
 				<Layout align="center space-between">
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -328,10 +327,10 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Top Left
-						</TooltipButton>
+						</Button>
 					</Cell>
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -340,10 +339,10 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Top
-						</TooltipButton>
+						</Button>
 					</Cell>
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -352,14 +351,14 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Top Right
-						</TooltipButton>
+						</Button>
 					</Cell>
 				</Layout>
 			</Cell>
 			<Cell shrink>
 				<Layout align="center space-between">
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -368,10 +367,10 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Left
-						</TooltipButton>
+						</Button>
 					</Cell>
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -380,10 +379,10 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Center
-						</TooltipButton>
+						</Button>
 					</Cell>
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -392,14 +391,14 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Right
-						</TooltipButton>
+						</Button>
 					</Cell>
 				</Layout>
 			</Cell>
 			<Cell shrink>
 				<Layout align="center space-between">
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -408,10 +407,10 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Bottom Left
-						</TooltipButton>
+						</Button>
 					</Cell>
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -420,10 +419,10 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Bottom
-						</TooltipButton>
+						</Button>
 					</Cell>
 					<Cell shrink>
-						<TooltipButton
+						<Button
 							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
@@ -432,7 +431,7 @@ export const TooltipOverflows = (args) => {
 							tooltipRelative={tooltipRelative}
 						>
 							Bottom Right
-						</TooltipButton>
+						</Button>
 					</Cell>
 				</Layout>
 			</Cell>
@@ -440,13 +439,13 @@ export const TooltipOverflows = (args) => {
 	);
 };
 
+boolean('disabled', TooltipOverflows, Config);
 select('button alignment', TooltipOverflows, {'': null, start: 'start', end: 'end'}, Config);
 number('tooltipDelay', TooltipOverflows, Config, 500);
 text('tooltipText', TooltipOverflows, Config, 'tooltip position!');
 select('tooltipPosition', TooltipOverflows, prop.tooltipPosition, Config, 'above');
 object('tooltipProps', TooltipOverflows, Config, prop.ariaObject);
 boolean('tooltipRelative', TooltipOverflows, Config);
-boolean('disabled', TooltipOverflows, Config);
 
 TooltipOverflows.storyName = 'tooltip overflows';
 
@@ -472,7 +471,7 @@ export const LongTooltipMarquees = (args) => {
 
 			<Row wrap>
 				<Section title="Transparent Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee checked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -482,10 +481,10 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Section title="Balloon Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee checked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -495,10 +494,10 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Section title="Transparent Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee unchecked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -507,10 +506,10 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Section title="Balloon Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee unchecked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -519,7 +518,7 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 			</Row>
 
@@ -530,7 +529,7 @@ export const LongTooltipMarquees = (args) => {
 
 			<Row wrap>
 				<Section title="Transparent Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee checked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -541,10 +540,10 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Section title="Balloon Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee checked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -555,10 +554,10 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Section title="Transparent Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee unchecked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -568,10 +567,10 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Section title="Balloon Tooltip" size="50%">
-					<TooltipButton
+					<Button
 						alt="Marquee unchecked"
 						disabled={disabled}
 						tooltipDelay={500}
@@ -581,7 +580,7 @@ export const LongTooltipMarquees = (args) => {
 						tooltipWidth={1000}
 					>
 						Click me
-					</TooltipButton>
+					</Button>
 				</Section>
 				<Heading spacing="large" size="large" showLine />
 			</Row>

--- a/samples/sampler/stories/qa/Tooltip.js
+++ b/samples/sampler/stories/qa/Tooltip.js
@@ -305,6 +305,7 @@ export const TooltipOverflows = (args) => {
 	const tooltipPosition = args['tooltipPosition'];
 	const tooltipProps = args['tooltipProps'];
 	const tooltipRelative = args['tooltipRelative'];
+	const disabled = args['disabled'];
 	return (
 		<Layout
 			orientation="vertical"
@@ -319,6 +320,7 @@ export const TooltipOverflows = (args) => {
 				<Layout align="center space-between">
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -330,6 +332,7 @@ export const TooltipOverflows = (args) => {
 					</Cell>
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -341,6 +344,7 @@ export const TooltipOverflows = (args) => {
 					</Cell>
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -356,6 +360,7 @@ export const TooltipOverflows = (args) => {
 				<Layout align="center space-between">
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -367,6 +372,7 @@ export const TooltipOverflows = (args) => {
 					</Cell>
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -378,6 +384,7 @@ export const TooltipOverflows = (args) => {
 					</Cell>
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -393,6 +400,7 @@ export const TooltipOverflows = (args) => {
 				<Layout align="center space-between">
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -404,6 +412,7 @@ export const TooltipOverflows = (args) => {
 					</Cell>
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -415,6 +424,7 @@ export const TooltipOverflows = (args) => {
 					</Cell>
 					<Cell shrink>
 						<TooltipButton
+							disabled={disabled}
 							tooltipDelay={tooltipDelay}
 							tooltipText={tooltipText}
 							tooltipPosition={tooltipPosition}
@@ -436,6 +446,7 @@ text('tooltipText', TooltipOverflows, Config, 'tooltip position!');
 select('tooltipPosition', TooltipOverflows, prop.tooltipPosition, Config, 'above');
 object('tooltipProps', TooltipOverflows, Config, prop.ariaObject);
 boolean('tooltipRelative', TooltipOverflows, Config);
+boolean('disabled', TooltipOverflows, Config);
 
 TooltipOverflows.storyName = 'tooltip overflows';
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After tapping a disabled component with a tooltip once, a tooltip does not disappear even by tapping other components or empty space. This issue occurs only by touch inputs.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
There was a bug that show a tooltip again after hiding only for disabled components. I fixed the logic not to show again a tooltip.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-14835

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)