### PR TITLE
WRR-14337: Update editable scroller to support touch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` with `editable` prop to support touch input
+
 ## [2.7.20] - 2024-12-17
 
 ### Added

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -743,14 +743,7 @@ const EditableWrapper = (props) => {
 		}
 
 		if (selectedItem) {
-			// Cancel mouse event to deselect a selected item when it is tapped
-			ev.preventDefault();
-
-			// Finalize orders and forward `onComplete` event
-			const orders = finalizeOrders();
-			finalizeEditing(orders);
-
-			if (lastInputType === 'scroll') {
+			if (lastInputType === 'scroll' && mutableRef.current.isDragging) {
 				const offset = itemWidth * (!rtl ^ !(lastMouseClientX > scrollContentCenter) ? 1 : -1);
 				scrollContainerHandle.current.start({
 					targetX: scrollContentNode.scrollLeft + offset,
@@ -772,7 +765,7 @@ const EditableWrapper = (props) => {
 		mutableRef.current.isDraggingItem = false;
 		mutableRef.current.isDragging = false;
 		scrollContainerRef.current.style.setProperty('--scroller-hover-to-scroll-by-touch', 'none');
-	}, [getNextIndexFromPosition, finalizeEditing, finalizeOrders, findItemNode, scrollContainerHandle, scrollContainerRef, scrollContentRef, selectItemBy, startEditing]);
+	}, [getNextIndexFromPosition, findItemNode, scrollContainerHandle, scrollContainerRef, scrollContentRef, selectItemBy, startEditing]);
 
 	const handleDragStart = useCallback((ev) => {
 		const {selectedItem} = mutableRef.current;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -743,6 +743,13 @@ const EditableWrapper = (props) => {
 		}
 
 		if (selectedItem) {
+			// Cancel mouse event to deselect a selected item when it is tapped
+			ev.preventDefault();
+
+			// Finalize orders and forward `onComplete` event
+			const orders = finalizeOrders();
+			finalizeEditing(orders);
+
 			if (lastInputType === 'scroll' && mutableRef.current.isDragging) {
 				const offset = itemWidth * (!rtl ^ !(lastMouseClientX > scrollContentCenter) ? 1 : -1);
 				scrollContainerHandle.current.start({
@@ -765,7 +772,7 @@ const EditableWrapper = (props) => {
 		mutableRef.current.isDraggingItem = false;
 		mutableRef.current.isDragging = false;
 		scrollContainerRef.current.style.setProperty('--scroller-hover-to-scroll-by-touch', 'none');
-	}, [getNextIndexFromPosition, findItemNode, scrollContainerHandle, scrollContainerRef, scrollContentRef, selectItemBy, startEditing]);
+	}, [getNextIndexFromPosition, finalizeEditing, finalizeOrders, findItemNode, scrollContainerHandle, scrollContainerRef, scrollContentRef, selectItemBy, startEditing]);
 
 	const handleDragStart = useCallback((ev) => {
 		const {selectedItem} = mutableRef.current;

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -544,6 +544,16 @@ const EditableWrapper = (props) => {
 		return Math.floor((clientXFromContent - moveTolerance) / itemWidth);
 	}, [scrollContainerHandle, scrollContentRef]);
 
+	const handlePointerDown = useCallback((ev) => {
+		const {selectedItem} = mutableRef.current;
+
+		if (selectedItem) {
+			if (ev.target.hasPointerCapture(ev.pointerId)) {
+				ev.target.releasePointerCapture(ev.pointerId);
+			}
+		}
+	}, []);
+
 	const handleMouseMove = useCallback((ev) => {
 		const {clientX} = ev;
 		mutableRef.current.lastMouseClientX = clientX;
@@ -708,23 +718,23 @@ const EditableWrapper = (props) => {
 		if (mutableRef.current.isDraggingItem && !ev.target.className.includes('Button')) {
 			const {clientX} = ev.targetTouches[0];
 			mutableRef.current.lastMouseClientX = clientX;
+			scrollContainerRef.current.style.setProperty('--scroller-hover-to-scroll-by-touch', 'auto');
 
 			const toIndex = getNextIndexFromPosition(clientX, 0.33);
 
 			if (toIndex !== mutableRef.current.prevToIndex) {
-				scrollContainerHandle.current.start({
-					targetX: clientX,
-					targetY: 0
-				});
 				mutableRef.current.lastInputType = 'touch';
 				moveItems(toIndex);
 			}
 		}
-
-	}, [getNextIndexFromPosition, moveItems, scrollContainerHandle]);
+	}, [getNextIndexFromPosition, moveItems, scrollContainerRef]);
 
 	const handleTouchEnd = useCallback((ev) => {
-		const {selectedItem} = mutableRef.current;
+		const {itemWidth, lastInputType, lastMouseClientX, selectedItem} = mutableRef.current;
+		const {rtl} = scrollContainerHandle.current;
+		const scrollContentNode = scrollContentRef.current;
+		const scrollContentCenter = scrollContentNode.getBoundingClientRect().width / 2;
+
 		const {clientX} = ev.changedTouches[0];
 		const targetItemIndex = getNextIndexFromPosition(clientX, 0);
 
@@ -739,6 +749,14 @@ const EditableWrapper = (props) => {
 			// Finalize orders and forward `onComplete` event
 			const orders = finalizeOrders();
 			finalizeEditing(orders);
+
+			if (lastInputType === 'scroll') {
+				const offset = itemWidth * (!rtl ^ !(lastMouseClientX > scrollContentCenter) ? 1 : -1);
+				scrollContainerHandle.current.start({
+					targetX: scrollContentNode.scrollLeft + offset,
+					targetY: 0
+				});
+			}
 		} else if (!mutableRef.current.isDragging) {
 			// Cancel mouse event to select a item when it is tapped
 			ev.preventDefault();
@@ -753,7 +771,8 @@ const EditableWrapper = (props) => {
 		}
 		mutableRef.current.isDraggingItem = false;
 		mutableRef.current.isDragging = false;
-	}, [getNextIndexFromPosition, finalizeEditing, finalizeOrders, findItemNode, selectItemBy, startEditing]);
+		scrollContainerRef.current.style.setProperty('--scroller-hover-to-scroll-by-touch', 'none');
+	}, [getNextIndexFromPosition, finalizeEditing, finalizeOrders, findItemNode, scrollContainerHandle, scrollContainerRef, scrollContentRef, selectItemBy, startEditing]);
 
 	const handleDragStart = useCallback((ev) => {
 		const {selectedItem} = mutableRef.current;
@@ -925,6 +944,7 @@ const EditableWrapper = (props) => {
 			onKeyUpCapture={handleKeyUpCapture}
 			onMouseDown={handleMouseDown}
 			onMouseMove={handleMouseMove}
+			onPointerDown={handlePointerDown}
 			onDragStart={handleDragStart}
 			onTouchEnd={handleTouchEnd}
 			ref={wrapperRef}

--- a/useScroll/HoverToScroll.js
+++ b/useScroll/HoverToScroll.js
@@ -7,8 +7,6 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
-import {getLastInputType} from '../ThemeDecorator';
-
 import css from './HoverToScroll.module.less';
 
 const {epsilon} = constants;
@@ -117,35 +115,33 @@ const HoverToScrollBase = (props) => {
 			const {axis, clientSize, maxPosition, scrollPosition} = getBoundsPropertyNames(direction);
 			const bounds = scrollContainer.getScrollBounds();
 
-			return function ({pointerType}) {
-				if (pointerType === 'mouse') {
-					const distance =
-						(position === 'before' ? -1 : 1) * // scroll direction
-						bounds[clientSize] * // scroll page size
-						hoverToScrollMultiplier[direction]; // a scrolling speed factor
+			return function () {
+				const distance =
+					(position === 'before' ? -1 : 1) * // scroll direction
+					bounds[clientSize] * // scroll page size
+					hoverToScrollMultiplier[direction]; // a scrolling speed factor
 
-					mutableRef.current.hoveredPosition = position;
-					mutableRef.current.stopScrollByHover = false;
+				mutableRef.current.hoveredPosition = position;
+				mutableRef.current.stopScrollByHover = false;
 
-					const scrollByHover = () => {
-						if (!mutableRef.current.stopScrollByHover && getLastInputType() === 'mouse') {
-							scrollContainer.scrollTo({
-								position: {
-									[axis]: clamp(
-										0,
-										bounds[maxPosition],
-										scrollContainer[scrollPosition] + distance
-									)
-								},
-								animate: false
-							});
-							startRaf(scrollByHover);
-						} else {
-							stopRaf(); // for other type input during hovering
-						}
-					};
-					startRaf(scrollByHover);
-				}
+				const scrollByHover = () => {
+					if (!mutableRef.current.stopScrollByHover) {
+						scrollContainer.scrollTo({
+							position: {
+								[axis]: clamp(
+									0,
+									bounds[maxPosition],
+									scrollContainer[scrollPosition] + distance
+								)
+							},
+							animate: false
+						});
+						startRaf(scrollByHover);
+					} else {
+						stopRaf(); // for other type input during hovering
+					}
+				};
+				startRaf(scrollByHover);
 			};
 		} else {
 			return nop;

--- a/useScroll/HoverToScroll.module.less
+++ b/useScroll/HoverToScroll.module.less
@@ -10,6 +10,9 @@
 	:global(.spotlight-input-mouse) & {
 		pointer-events: auto;
 	}
+	:global(.spotlight-input-touch) & {
+		pointer-events: var(--scroller-hover-to-scroll-by-touch, none)
+	}
 	&.vertical {
 		width: 100%;
 		height: @sand-scroll-hover-area-size;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Update editable scroller to support drag and drop in touch mode

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Cherry-pick dd3917b8078cda1ef7ba5d99c8bd44ea988e1ac8 to support touch mode in editable scroller
Fix editable scroller to enable hover-to-scroll by touch 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-14337

### Comments
