### PR TITLE
WRR-15666: Fix $L string in QuickGuidePanels to be translated properly

### DIFF
--- a/QuickGuidePanels/QuickGuidePanels.js
+++ b/QuickGuidePanels/QuickGuidePanels.js
@@ -267,7 +267,7 @@ const QuickGuidePanelsBase = kind({
 	computed: {
 		'aria-label': ({'aria-label': label, current, index, totalPanels}) => {
 			const stepNum = (typeof current === 'number' && current > 0) ? current : (index + 1);
-			const step = new IString($L('Page {num} out of {total}')).format({num: stepNum, total: totalPanels}) + ' ';
+			const step = new IString($L('Page {current} out of {total}')).format({current: stepNum, total: totalPanels}) + ' ';
 
 			return `${step} ${label || ''}`;
 		},


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Because the $L string of `PageViews` and `QuickGuidePanels` was different, there was an issue where the translation did not work properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update `QuickGuidePanels` $L string to be translated. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-15666

### Comments
