### PR TITLE
WRR-16145: ContextualPopupDecorator: Modified to update position when DOM tree changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/ContextualPopupDecorator` to update popup position properly when the DOM tree changes
+
 ## [2.9.6] - 2024-12-11
 
 ### Added

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -633,7 +633,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			if (this.mutationObserver) {
 				if (node) {
-					this.mutationObserver.observe(document.body, {attributes: true, childList: true, subtree: true});
+					this.mutationObserver.observe(document.body, {attributes: false, childList: true, subtree: true});
 				} else {
 					this.mutationObserver.disconnect();
 				}

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -1,4 +1,4 @@
-/* global ResizeObserver */
+/* global MutationObserver ResizeObserver */
 
 /**
  * A higher-order component to add a Sandstone styled popup to a component.
@@ -301,6 +301,12 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 					this.positionContextualPopup();
 				});
 			}
+
+			if (typeof MutationObserver === 'function') {
+				this.mutationObserver = new MutationObserver(() => {
+					this.positionContextualPopup();
+				});
+			}
 		}
 
 		getSnapshotBeforeUpdate (prevProps, prevState) {
@@ -354,6 +360,11 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (this.resizeObserver) {
 				this.resizeObserver.disconnect();
 				this.resizeObserver = null;
+			}
+
+			if (this.mutationObserver) {
+				this.mutationObserver.disconnect();
+				this.mutationObserver = null;
 			}
 		}
 
@@ -617,6 +628,14 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 					this.resizeObserver.observe(node?.parentElement?.parentElement);
 				} else {
 					this.resizeObserver.disconnect();
+				}
+			}
+
+			if (this.mutationObserver) {
+				if (node) {
+					this.mutationObserver.observe(document.body, {attributes: true, childList: true, subtree: true});
+				} else {
+					this.mutationObserver.disconnect();
 				}
 			}
 		};

--- a/samples/qa-dropdown/src/views/MainPanel.js
+++ b/samples/qa-dropdown/src/views/MainPanel.js
@@ -2,28 +2,30 @@ import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Dropdown from '@enact/sandstone/Dropdown';
 import {Panel, WizardPanels} from '@enact/sandstone/WizardPanels';
+import ri from '@enact/ui/resolution';
 import {useCallback, useState} from 'react';
 
 const MainPanel = () => {
-	const [openLanguage, setOpenLanguage] = useState(false);
-	const [openDropdown, setOpenDropdown] = useState(false);
+	const [open1, setOpen1] = useState(false);
+	const [open2, setOpen2] = useState(false);
 	const [removed, setRemove] = useState(false);
 
-	const handleOpen = useCallback(() => setOpenLanguage(true), []);
-	const handleClose = useCallback(() => setOpenLanguage(false), []);
-	const handleDropdown = useCallback(() => {
-		setOpenDropdown(true);
+	const handleOpen1 = useCallback(() => setOpen1(true), []);
+	const handleClose1 = useCallback(() => setOpen1(false), []);
+
+	const handleOpen2 = useCallback(() => {
+		setOpen2(true);
 
 		setTimeout(() => {
 			setRemove(true);
 		}, 2000);
 	}, []);
-	const handleDropdownClose = useCallback(() => setOpenDropdown(false), []);
+	const handleClose2 = useCallback(() => setOpen2(false), []);
 
 	return (
 		<WizardPanels>
 			<Panel title="QA Sample - Dropdown">
-				<Dropdown onClose={handleClose} onOpen={handleOpen} open={openLanguage} size="large" title="language">
+				<Dropdown onClose={handleClose1} onOpen={handleOpen1} open={open1} size="large" title="language">
 					{['English', 'Korean', 'Spanish', 'Amharic', 'Thai', 'Arabic', 'Urdu', 'Simplified Chinese', 'Traditional Chinese', 'Vietnamese']}
 				</Dropdown>
 				<Button size="large">
@@ -32,11 +34,11 @@ const MainPanel = () => {
 			</Panel>
 			<Panel>
 				{!removed && (
-					<div style={{margin: '20px'}}>
-						<BodyText>This is the line that will be removed.</BodyText>
+					<div style={{margin: ri.scaleToRem(20)}}>
+						<BodyText>This line will remove after opening the dropdown.</BodyText>
 					</div>
 				)}
-				<Dropdown onClose={handleDropdownClose} onOpen={handleDropdown} open={openDropdown}>{['a', 'b', 'c']}</Dropdown>
+				<Dropdown onClose={handleClose2} onOpen={handleOpen2} open={open2}>{['a', 'b', 'c']}</Dropdown>
 			</Panel>
 		</WizardPanels>
 	);

--- a/samples/qa-dropdown/src/views/MainPanel.js
+++ b/samples/qa-dropdown/src/views/MainPanel.js
@@ -1,23 +1,42 @@
+import BodyText from '@enact/sandstone/BodyText';
 import Button from '@enact/sandstone/Button';
 import Dropdown from '@enact/sandstone/Dropdown';
 import {Panel, WizardPanels} from '@enact/sandstone/WizardPanels';
 import {useCallback, useState} from 'react';
 
 const MainPanel = () => {
-	const [open, setOpen] = useState(false);
+	const [openLanguage, setOpenLanguage] = useState(false);
+	const [openDropdown, setOpenDropdown] = useState(false);
+	const [removed, setRemove] = useState(false);
 
-	const handleOpen = useCallback(() => setOpen(true), []);
-	const handleClose = useCallback(() => setOpen(false), []);
+	const handleOpen = useCallback(() => setOpenLanguage(true), []);
+	const handleClose = useCallback(() => setOpenLanguage(false), []);
+	const handleDropdown = useCallback(() => {
+		setOpenDropdown(true);
+
+		setTimeout(() => {
+			setRemove(true);
+		}, 2000);
+	}, []);
+	const handleDropdownClose = useCallback(() => setOpenDropdown(false), []);
 
 	return (
 		<WizardPanels>
 			<Panel title="QA Sample - Dropdown">
-				<Dropdown onClose={handleClose} onOpen={handleOpen} open={open} size="large" title="language">
+				<Dropdown onClose={handleClose} onOpen={handleOpen} open={openLanguage} size="large" title="language">
 					{['English', 'Korean', 'Spanish', 'Amharic', 'Thai', 'Arabic', 'Urdu', 'Simplified Chinese', 'Traditional Chinese', 'Vietnamese']}
 				</Dropdown>
 				<Button size="large">
 					Enter
 				</Button>
+			</Panel>
+			<Panel>
+				{!removed && (
+					<div style={{margin: '20px'}}>
+						<BodyText>This is the line that will be removed.</BodyText>
+					</div>
+				)}
+				<Dropdown onClose={handleDropdownClose} onOpen={handleDropdown} open={openDropdown}>{['a', 'b', 'c']}</Dropdown>
 			</Panel>
 		</WizardPanels>
 	);

--- a/samples/qa-dropdown/src/views/MainPanel.js
+++ b/samples/qa-dropdown/src/views/MainPanel.js
@@ -35,7 +35,7 @@ const MainPanel = () => {
 			<Panel>
 				{!removed && (
 					<div style={{margin: ri.scaleToRem(20)}}>
-						<BodyText>This line will remove after opening the dropdown.</BodyText>
+						<BodyText>This line will be removed after opening the dropdown.</BodyText>
 					</div>
 				)}
 				<Dropdown onClose={handleClose2} onOpen={handleOpen2} open={open2}>{['a', 'b', 'c']}</Dropdown>

--- a/samples/sampler/stories/qa/Dropdown.js
+++ b/samples/sampler/stories/qa/Dropdown.js
@@ -8,7 +8,7 @@ import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import PropTypes from 'prop-types';
-import {Component} from 'react';
+import {Component, useEffect, useState} from 'react';
 
 const Config = mergeComponentMetadata(
 	'Dropdown',
@@ -333,3 +333,28 @@ InScroller.parameters = {
 };
 
 InScroller.storyName = 'in Scroller (PLAT-137855)';
+
+export const WithChaningPositionWhileDropdownOpen = () => {
+    const [isRemoved, remove] = useState(false);
+
+    useEffect(() => {
+        setTimeout(() => {
+            remove(true);
+        }, 2000);
+    }, []);
+
+    return (
+		<div>
+			{!isRemoved && (
+				<div style={{margin: '20px'}}>
+					<div>This is the line that will be removed.</div>
+				</div>
+			)}
+			<div>
+				<Dropdown open>{['a', 'b', 'c']}</Dropdown>
+			</div>
+		</div>
+    );
+};
+
+WithChaningPositionWhileDropdownOpen.storyName = 'with changing position while dropdown open';

--- a/samples/sampler/stories/qa/Dropdown.js
+++ b/samples/sampler/stories/qa/Dropdown.js
@@ -8,7 +8,7 @@ import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 import UIButton, {ButtonBase as UIButtonBase} from '@enact/ui/Button';
 import PropTypes from 'prop-types';
-import {Component, useEffect, useState} from 'react';
+import {Component} from 'react';
 
 const Config = mergeComponentMetadata(
 	'Dropdown',
@@ -333,28 +333,3 @@ InScroller.parameters = {
 };
 
 InScroller.storyName = 'in Scroller (PLAT-137855)';
-
-export const WithChaningPositionWhileDropdownOpen = () => {
-	const [isRemoved, remove] = useState(false);
-
-	useEffect(() => {
-		setTimeout(() => {
-			remove(true);
-		}, 2000);
-	}, []);
-
-	return (
-		<div>
-			{!isRemoved && (
-				<div style={{margin: '20px'}}>
-					<div>This is the line that will be removed.</div>
-				</div>
-			)}
-			<div>
-				<Dropdown open>{['a', 'b', 'c']}</Dropdown>
-			</div>
-		</div>
-	);
-};
-
-WithChaningPositionWhileDropdownOpen.storyName = 'with changing position while dropdown open';

--- a/samples/sampler/stories/qa/Dropdown.js
+++ b/samples/sampler/stories/qa/Dropdown.js
@@ -335,15 +335,15 @@ InScroller.parameters = {
 InScroller.storyName = 'in Scroller (PLAT-137855)';
 
 export const WithChaningPositionWhileDropdownOpen = () => {
-    const [isRemoved, remove] = useState(false);
+	const [isRemoved, remove] = useState(false);
 
-    useEffect(() => {
-        setTimeout(() => {
-            remove(true);
-        }, 2000);
-    }, []);
+	useEffect(() => {
+		setTimeout(() => {
+			remove(true);
+		}, 2000);
+	}, []);
 
-    return (
+	return (
 		<div>
 			{!isRemoved && (
 				<div style={{margin: '20px'}}>
@@ -354,7 +354,7 @@ export const WithChaningPositionWhileDropdownOpen = () => {
 				<Dropdown open>{['a', 'b', 'c']}</Dropdown>
 			</div>
 		</div>
-    );
+	);
 };
 
 WithChaningPositionWhileDropdownOpen.storyName = 'with changing position while dropdown open';


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After the dropdown is opened, if the DOM tree changes, the position of the dropdown will not change.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Because Dropdown component uses ContextualPopupDecorator, I added mutationObserver to ContextualPopupDecrator to detect changes in the DOM tree. Since we don't know which part of the DOM will change, I attach an observer to document.body and update the location when there is a change.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-16145

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
