### PR TITLE
WRR-17900: Fixed `PageViews` to focus spottable components on the same line with arrows for navigation when `fullContents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/PageViews` to focus spottable components on the same line with arrows for navigation when `fullContents`
 - `sandstone/TooltipDecorator` to hide a tooltip when tapping outside of disabled component
 
 ## [2.9.7] - 2025-01-16

--- a/PageViews/PageViews.module.less
+++ b/PageViews/PageViews.module.less
@@ -22,6 +22,11 @@
 		height: @sand-button-height;
 		top: ~"calc(50% - "@sand-button-height / 2 ~")";
 		z-index: 10;
+		pointer-events: none;
+
+		& [role='button'] {
+			pointer-events: auto;
+		}
 	}
 
 	&.number .navButton {
@@ -59,6 +64,11 @@
 		align-self: center;
 		bottom: @sand-pageviews-full-steps-position-bottom;
 		min-height: @sand-pageviews-full-steps-area-min-height;
+		pointer-events: none;
+
+		& [role='button'] {
+			pointer-events: auto;
+		}
 	}
 
 	.contentsArea {

--- a/tests/ui/apps/PageViews/PageViews-View.js
+++ b/tests/ui/apps/PageViews/PageViews-View.js
@@ -1,4 +1,3 @@
-import {BasicArranger} from '../../../../internal/Panels';
 import Item from '../../../../Item';
 import {PageViews} from '../../../../PageViews';
 import ThemeDecorator from '../../../../ThemeDecorator';
@@ -9,7 +8,7 @@ import spotlight from '@enact/spotlight';
 spotlight.setPointerMode(false);
 
 const app = (props) => <div {...props}>
-	<PageViews arranger={BasicArranger} fullContents={false} pageIndicatorType="dot">
+	<PageViews fullContents={false} pageIndicatorType="dot">
 		<PageViews.Page id="PageViewsPage1" aria-label="This is a description for page 1">
 			<div style={{padding: '24px', width: '50%'}}>
 				<Item id="PageViewsItem1">Item 1</Item>

--- a/tests/ui/apps/PageViews/PageViewsPointerEvents-View.js
+++ b/tests/ui/apps/PageViews/PageViewsPointerEvents-View.js
@@ -1,0 +1,31 @@
+import Button from '../../../../Button';
+import {PageViews} from '../../../../PageViews';
+import ThemeDecorator from '../../../../ThemeDecorator';
+import spotlight from '@enact/spotlight';
+import ri from '@enact/ui/resolution';
+
+// NOTE: Forcing pointer mode off so we can be sure that regardless of webOS pointer mode the app
+// runs the same way
+spotlight.setPointerMode(false);
+
+const app = (props) => <div {...props}>
+	<PageViews fullContents style={{width: ri.scaleToRem(750), height: ri.scaleToRem(750)}}>
+		<PageViews.Page >
+			<div style={{display: 'flex', flexDirection: 'column'}}>
+				<Button>Button 0</Button>
+				<Button>Button 1</Button>
+				<Button id="PageViewsButton2">Button 2</Button>
+				<Button>Button 3</Button>
+				<Button>Button 4</Button>
+				<Button>Button 5</Button>
+				<Button>Button 6</Button>
+				<Button>Button 7</Button>
+			</div>
+		</PageViews.Page>
+		<PageViews.Page>
+			<Button style={{height: '100%', width: '100%'}}>world</Button>
+		</PageViews.Page>
+	</PageViews>
+</div>;
+
+export default ThemeDecorator(app);

--- a/tests/ui/specs/PageViews/PageViews-specs.js
+++ b/tests/ui/specs/PageViews/PageViews-specs.js
@@ -74,4 +74,17 @@ describe('PageViews', function () {
 			expect(await actual).toBe(expected);
 		});
 	});
+
+	describe('pointerEvents', function () {
+
+		beforeEach(async function () {
+			await Page.open('PointerEvents');
+		});
+
+		it('should focus the button on the same line with arrow for next page', async function () {
+			await $('#PageViewsButton2').moveTo();
+
+			expect(await $('#PageViewsButton2').isFocused()).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When spottable components on the same line with arrows for navigation when `fullContents` of `PageViews`, the component cannot get the focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The reason why the issue is that PageView has an extra DOM for aligning arrows for navigation above the content and it blocks the spottable components to focus.
I added `pointer-events: none` for the DOM that doesn't need to consume the events.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-17900

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)