### PR TITLE
WRR-17701: Fix editable scroller to move focus by holding directional key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 - `sandstone/TooltipDecorator` to hide a tooltip when tapping outside of disabled component
 - `sandstone/Scroller` with `editable` prop focus behavior to match the latest UX
+- `sandstone/Scroller` with `editable` prop to move focus properly when holding directional key
 
 ## [2.9.7] - 2025-01-16
 

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -627,10 +627,9 @@ const EditableWrapper = (props) => {
 	}, [moveItemsByKeyDown]);
 
 	const handleFocusLeaveScrollContainer = useCallback((ev, nextTarget) => {
-		const {keyCode} = ev;
 		if (nextTarget && !getContainersForNode(nextTarget).includes(mutableRef.current.spotlightId)) {
 			setPointerMode(false);
-			Spotlight.move(getDirection(keyCode));
+			Spotlight.focus(nextTarget);
 
 			const orders = finalizeOrders();
 			finalizeEditing(orders);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When pressing(holding) directional key(e.g., up key) in editable scroller, focus needs to move continusly

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
As I analyzed, focus failed to move in `handleFocusLeaveScrollContainer` because focus is prevented if 5-way is being held and the next element isn't wrapped by the current element's container. 
related code: https://github.com/enactjs/enact/blob/master/packages/spotlight/src/spotlight.js#L354
So I changed the Spotlight.move() function to Spotlight.focus(nextTarget) to avoid this issue. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-17701

### Comments
