### PR TITLE
WRR-13229: Fixed spotlight move when Popup is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/ContextualPopupDecorator` to update popup position properly when the DOM tree changes
+- `sandstone/Popup` to wait for state update before changing spotlight focus, on popup hide
 
 ## [2.7.21] - 2024-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Popup` to wait for state update before changing spotlight focus, on popup hide
+
 ## [3.0.0-alpha.4] - 2025-01-21
 
 - Update dependencies including React 19.0.0
@@ -27,7 +33,6 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/ContextualPopupDecorator` to update popup position properly when the DOM tree changes
-- `sandstone/Popup` to wait for state update before changing spotlight focus, on popup hide
 
 ## [2.7.21] - 2024-12-31
 

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -586,11 +586,11 @@ class Popup extends Component {
 		this.setState({
 			floatLayerOpen: false,
 			activator: null
+		}, () => {
+			if (!ev.currentTarget || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
+				this.spotActivator(this.state.activator);
+			}
 		});
-
-		if (!ev.currentTarget || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
-			this.spotActivator(this.state.activator);
-		}
 	};
 
 	handlePopupShow = (ev) => {

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -584,12 +584,12 @@ class Popup extends Component {
 		forwardHide(ev, this.props);
 
 		this.setState({
-			floatLayerOpen: false,
-			activator: null
+			floatLayerOpen: false
 		}, () => {
 			if (!ev.currentTarget || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
 				this.spotActivator(this.state.activator);
 			}
+			this.setState({activator: null});
 		});
 	};
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
FixedPopupPanels blinks in sampler when open and close the popup.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue seems to come from Popup. The spotlight move outside the popup did not happen after the state update, but in parallel, coming in conflict with the transition animation of Popup content

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The solution triggers an extra rerender of the Popup component, but I could not find a better solution for the bug
Code coverage seems to decrease, but the moved lines of code were not covered by tests before and the scenario cannot be tested with testing-library. It is covered by ui-tests.

### Links
[//]: # (Related issues, references)
WRR-13229

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))