### PR TITLE
WRR-13229: Fixed spotlight move when Popup is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/PageViews` to focus spottable components on the same line with arrows for navigation when `fullContents`
+- `sandstone/Popup` to wait for state update before changing spotlight focus, on popup hide
 - `sandstone/Scroller` with `editable` prop focus behavior to match the latest UX
 - `sandstone/Scroller` with `editable` prop to move focus properly when holding directional key
 - `sandstone/TooltipDecorator` to hide a tooltip when tapping outside of disabled component

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -583,12 +583,12 @@ class Popup extends Component {
 		forwardHide(ev, this.props);
 
 		this.setState({
-			floatLayerOpen: false,
-			activator: null
+			floatLayerOpen: false
 		}, () => {
 			if (!ev.currentTarget || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
 				this.spotActivator(this.state.activator);
 			}
+			this.setState({activator: null});
 		});
 	};
 

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -585,11 +585,11 @@ class Popup extends Component {
 		this.setState({
 			floatLayerOpen: false,
 			activator: null
+		}, () => {
+			if (!ev.currentTarget || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
+				this.spotActivator(this.state.activator);
+			}
 		});
-
-		if (!ev.currentTarget || ev.currentTarget.getAttribute('data-spotlight-id') === this.state.containerId) {
-			this.spotActivator(this.state.activator);
-		}
 	};
 
 	handlePopupShow = (ev) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
FixedPopupPanels blinks in sampler when open and close the popup.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue seems to come from Popup. The spotlight move outside the popup did not happen after the state update, but in parallel, coming in conflict with the transition animation of Popup content

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The solution triggers an extra rerender of the Popup component, but I could not find a better solution for the bug
Code coverage seems to decrease, but the moved lines of code were not covered by tests before and the scenario cannot be tested with testing-library. It is covered by ui-tests.

### Links
[//]: # (Related issues, references)
WRR-13229

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))