### PR TITLE
WRR-19603: Fixed focus regain when focus is lost after voice control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/Scroller` to regains focus even when focus is lost by voice control
+- `sandstone/Scroller` to restore focus when focus is lost after scroll by voice control
 
 ## [2.9.9] - 2025-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Scroller` to regains focus even when focus is lost by voice control
+
 ## [2.9.9] - 2025-02-13
 
 ### Fixed

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -459,6 +459,10 @@ const useEventVoice = (props, instances) => {
 					}
 				}
 			}
+		} else {
+			// There should be an element that receives focus even if spot Item disappears from the virtuallist or scroller.
+			const backupNodes = getDeepSpottableDescendants(scrollContainerNode.dataset.spotlightId);
+			Spotlight.focus(backupNodes[0]);
 		}
 	};
 

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -440,27 +440,29 @@ const useEventVoice = (props, instances) => {
 			spotItem = Spotlight.getCurrent(),
 			scrollContainerNode = scrollContainerRef.current;
 
-		if (utilDOM.containsDangerously(scrollContainerNode, spotItem)) {
-			const viewportBounds = scrollContainerNode.getBoundingClientRect();
-			const spotItemBounds = spotItem.getBoundingClientRect();
-			const isVertical = mutableRef.current.voiceControlDirection === 'vertical';
-			const first = isVertical ? 'top' : 'left';
-			const last = isVertical ? 'bottom' : 'right';
+		if (spotItem) {
+			if (utilDOM.containsDangerously(scrollContainerNode, spotItem)) {
+				const viewportBounds = scrollContainerNode.getBoundingClientRect();
+				const spotItemBounds = spotItem.getBoundingClientRect();
+				const isVertical = mutableRef.current.voiceControlDirection === 'vertical';
+				const first = isVertical ? 'top' : 'left';
+				const last = isVertical ? 'bottom' : 'right';
 
-			/* if the focused element is out of the viewport, find another spottable element in the viewport */
-			if (spotItemBounds[last] <= viewportBounds[first] || spotItemBounds[first] >= viewportBounds[last]) {
-				const nodes = getDeepSpottableDescendants(scrollContainerNode.dataset.spotlightId);
-				for (let i = 0; i < nodes.length; i++) {
-					const nodeBounds = nodes[i].getBoundingClientRect();
+				/* if the focused element is out of the viewport, find another spottable element in the viewport */
+				if (spotItemBounds[last] <= viewportBounds[first] || spotItemBounds[first] >= viewportBounds[last]) {
+					const nodes = getDeepSpottableDescendants(scrollContainerNode.dataset.spotlightId);
+					for (let i = 0; i < nodes.length; i++) {
+						const nodeBounds = nodes[i].getBoundingClientRect();
 
-					if (nodeBounds[first] >= viewportBounds[first] && nodeBounds[last] <= viewportBounds[last]) {
-						Spotlight.focus(nodes[i]);
-						break;
+						if (nodeBounds[first] >= viewportBounds[first] && nodeBounds[last] <= viewportBounds[last]) {
+							Spotlight.focus(nodes[i]);
+							break;
+						}
 					}
 				}
 			}
-		} else {
-			// There should be an element that receives focus even if spot Item disappears from the virtuallist or scroller.
+		} else if (scrollContainerNode) {
+			// There should be an element that receives focus even if spot Item disappears from the virtuallist or scroller
 			const backupNodes = getDeepSpottableDescendants(scrollContainerNode.dataset.spotlightId);
 			Spotlight.focus(backupNodes[0]);
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Focus disappears when scrolling with voice control.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
In Virtuallist, the activeElement may disappear after voice control. In this case, I implemented a backup logic to find a spot item (of index 0) again and give it focus.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
When you refocus, the scroll may move.

### Links
[//]: # (Related issues, references)
WRR-19603

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
