### PR TITLE
WRR-21642: ContextualPopupDecorator: Fixed to reset ref when DOM is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=feature/WRR-21642 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=release/4.9.x.develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm uninstall @enact/ui-test-utils --prefix packages/i18n
     - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=release/4.9.x.develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRR-21642 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm uninstall @enact/ui-test-utils --prefix packages/i18n
     - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/ContextualPopupDecorator` to update popup position properly when Wrapped component updated
+
 ## [2.9.10] - 2025-02-24
 
 ### Fixed

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -84,7 +84,6 @@ const ContextualPopupContainer = SpotlightContainerDecorator(
 
 const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {noArrow, noSkin, openProp} = config;
-	const WrappedWithRef = WithRef(Wrapped);
 
 	return class extends Component {
 		static displayName = 'ContextualPopupDecorator';
@@ -743,6 +742,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		render () {
+			const WrappedWithRef = WithRef(Wrapped);
+
 			const {'data-webos-voice-exclusive': voiceExclusive, popupComponent: PopupComponent, popupClassName, noAutoDismiss, open, offset, popupProps, skin, spotlightRestrict, ...rest} = this.props;
 			const idFloatLayer = `${this.id}_floatLayer`;
 			let scrimType = rest.scrimType;

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -84,6 +84,7 @@ const ContextualPopupContainer = SpotlightContainerDecorator(
 
 const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 	const {noArrow, noSkin, openProp} = config;
+	const WrappedWithRef = WithRef(Wrapped);
 
 	return class extends Component {
 		static displayName = 'ContextualPopupDecorator';
@@ -278,6 +279,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.adjustedDirection = this.props.direction;
 			this.id = this.generateId();
 			this.clientSiblingRef = createRef(null);
+			this.findClientSiblingRef = createRef(null);
 
 			this.MARGIN = ri.scale(noArrow ? 0 : 12);
 			this.ARROW_WIDTH = noArrow ? 0 : ri.scale(60); // svg arrow width. used for arrow positioning
@@ -310,7 +312,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getSnapshotBeforeUpdate (prevProps, prevState) {
 			const snapshot = {
-				containerWidth: this.getContainerNodeWidth()
+				containerWidth: this.getContainerNodeWidth(),
+				clientSiblingWidth: this.getClientSiblingNodeWidth()
 			};
 
 			if (prevProps.open && !this.props.open) {
@@ -329,6 +332,10 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		componentDidUpdate (prevProps, prevState, snapshot) {
+			if (snapshot.clientSiblingWidth !== this.getClientSiblingNodeWidth()) {
+				this.clientSiblingRef.current = this.findClientSiblingRef.current();
+			}
+
 			if (prevProps.direction !== this.props.direction ||
 				snapshot.containerWidth !== this.getContainerNodeWidth() ||
 				(prevProps.open && this.props.open)) {
@@ -373,6 +380,10 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getContainerNodeWidth () {
 			return this.containerNode && this.containerNode.getBoundingClientRect().width || 0;
+		}
+
+		getClientSiblingNodeWidth () {
+			return this.clientSiblingRef.current && this.clientSiblingRef.current.getBoundingClientRect().width || 0;
 		}
 
 		updateLeaveFor (activator) {
@@ -742,8 +753,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		};
 
 		render () {
-			const WrappedWithRef = WithRef(Wrapped);
-
 			const {'data-webos-voice-exclusive': voiceExclusive, popupComponent: PopupComponent, popupClassName, noAutoDismiss, open, offset, popupProps, skin, spotlightRestrict, ...rest} = this.props;
 			const idFloatLayer = `${this.id}_floatLayer`;
 			let scrimType = rest.scrimType;
@@ -809,7 +818,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 							</ContextualPopupContainer>
 						</Fragment>
 					</FloatingLayer>
-					<WrappedWithRef {...rest} outermostRef={this.clientSiblingRef} referrerName="ContextualPopup" />
+					<WrappedWithRef {...rest} outermostRef={this.clientSiblingRef} findOutermostRef={this.findClientSiblingRef} referrerName="ContextualPopup" />
 				</div>
 			);
 		}

--- a/samples/sampler/stories/qa/ContextualMenuDecorator.js
+++ b/samples/sampler/stories/qa/ContextualMenuDecorator.js
@@ -5,9 +5,8 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {range, select} from '@enact/storybook-utils/addons/controls';
 import Layout, {Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
-
 import PropTypes from 'prop-types';
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 const Config = mergeComponentMetadata('ContextualMenuDecorator', ContextualMenuDecorator);
 const MenuButton = ContextualMenuDecorator({tooltipDestinationProp: 'decoration'}, Button);
@@ -178,17 +177,17 @@ Overflows.storyName = 'Overflows';
 const MenuItem = (props) => {
 	const {type, ...rest} = props;
 
-	const style = () => {
+	const style = useMemo((type) => {
 		if (type === 'vertical') {
 			return {height: '12.25rem', width: '16rem'};
 		}
 		return {width: '20rem'};
-	};
+	}, [type]);
 
 	return (
 		<ImageItem
 			{...rest}
-			style={style()}
+			style={style}
 			label="ImageItem"
 			orientation={type}
 		/>

--- a/samples/sampler/stories/qa/ContextualMenuDecorator.js
+++ b/samples/sampler/stories/qa/ContextualMenuDecorator.js
@@ -1,9 +1,13 @@
 import Button from '@enact/sandstone/Button';
 import ContextualMenuDecorator from '@enact/sandstone/ContextualMenuDecorator';
+import ImageItem from '@enact/sandstone/ImageItem';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {range, select} from '@enact/storybook-utils/addons/controls';
 import Layout, {Cell} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
+
+import PropTypes from 'prop-types';
+import {useCallback, useState} from 'react';
 
 const Config = mergeComponentMetadata('ContextualMenuDecorator', ContextualMenuDecorator);
 const MenuButton = ContextualMenuDecorator({tooltipDestinationProp: 'decoration'}, Button);
@@ -170,3 +174,46 @@ select('offset', Overflows, prop.offset, Config);
 select('popupWidth', Overflows, prop.popupWidth, Config);
 
 Overflows.storyName = 'Overflows';
+
+const MenuItem = (props) => {
+	const {type, ...rest} = props;
+
+	const style = () => {
+		if (type === 'vertical') {
+			return {height: '12.25rem', width: '16rem'};
+		}
+		return {width: '20rem'};
+	};
+
+	return (
+		<ImageItem
+			{...rest}
+			style={style()}
+			label="ImageItem"
+			orientation={type}
+		/>
+	);
+};
+
+MenuItem.propTypes = {
+	type: PropTypes.string.isRequired
+};
+
+const Menu = ContextualMenuDecorator(MenuItem);
+
+export const WithChangingComponent = () => {
+	const [type, setType] = useState('vertical');
+
+	const handleClick = useCallback(() => {
+		setType(state => (state === 'vertical' ? 'horizontal' : 'vertical'));
+	}, []);
+
+	return (
+		<div style={{textAlign: 'center', marginTop: ri.scaleToRem(260)}}>
+			<Button onClick={handleClick}>Change Type</Button>
+			<Menu type={type} menuItems={['Option1', 'Option2']} />
+		</div>
+	);
+};
+
+WithChangingComponent.storyName = 'with changing component';

--- a/samples/sampler/stories/qa/ContextualMenuDecorator.js
+++ b/samples/sampler/stories/qa/ContextualMenuDecorator.js
@@ -177,7 +177,7 @@ Overflows.storyName = 'Overflows';
 const MenuItem = (props) => {
 	const {type, ...rest} = props;
 
-	const style = useMemo((type) => {
+	const style = useMemo(() => {
 		if (type === 'vertical') {
 			return {height: '12.25rem', width: '16rem'};
 		}


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a bug where the position of the Contextual Popup is incorrect when a component wrapped with Contextual Decorator is updated.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to reset ref when DOM is updated in ContextualPopupDecorator.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-21642

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
