### PR TITLE
WRR-21724: Fixed `help` icon in Hebrew locale to not flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/Icon` to not flip `help` icon in he-IL locale when `flip` prop is `auto`
+
 ## [2.9.10] - 2025-02-24
 
 ### Fixed

--- a/Icon/Icon.js
+++ b/Icon/Icon.js
@@ -71,6 +71,15 @@ const IconBase = kind({
 		flip: PropTypes.oneOf(['auto', 'both', 'horizontal', 'vertical']),
 
 		/**
+		 * The current locale as a
+		 * {@link https://tools.ietf.org/html/rfc5646|BCP 47 language tag}.
+		 *
+		 * @type {String}
+		 * @private
+		*/
+		locale: PropTypes.string,
+
+		/**
 		 * Indicates the content's text direction is right-to-left.
 		 *
 		 * This is set automatically when using {@link ui/Icon.Icon}.
@@ -111,8 +120,11 @@ const IconBase = kind({
 		className: ({size, styler}) => styler.append(
 			(typeof size === 'string' ? size : null)
 		),
-		flip: ({flip, rtl}) => {
+		flip: ({children, flip, locale, rtl}) => {
 			if (flip === 'auto') {
+				if (locale === 'he-IL' && children === 'help') {
+					return null;
+				}
 				return rtl ? 'horizontal' : null;
 			}
 
@@ -125,6 +137,7 @@ const IconBase = kind({
 	},
 
 	render: ({css, size, ...rest}) => {
+		delete rest.locale;
 		delete rest.rtl;
 
 		return UiIconBase.inline({
@@ -416,7 +429,7 @@ const IconBase = kind({
 const IconDecorator = compose(
 	Pure,
 	Skinnable,
-	I18nContextDecorator({rtlProp: 'rtl'})
+	I18nContextDecorator({localeProp: 'locale', rtlProp: 'rtl'})
 );
 
 /**

--- a/Icon/tests/Icon-specs.js
+++ b/Icon/tests/Icon-specs.js
@@ -95,4 +95,22 @@ describe('Icon Specs', () => {
 		// Tests must run at a tiny simulated screen size.
 		expect(icon).toHaveStyle({'--icon-size': '8rem'});
 	});
+
+	test('should support RTL flip', () => {
+		render(<Icon data-testid="icon" rtl flip="auto">star</Icon>);
+
+		const expected = "flipHorizontal";
+		const icon = screen.getByTestId('icon');
+
+		expect(icon).toHaveClass(expected);
+	});
+
+	test('should not support RTL flip when locale is he-IL and children is \'help\'', () => {
+		render(<Icon data-testid="icon" rtl flip="auto" locale="he-IL">help</Icon>);
+
+		const expected = "flipHorizontal";
+		const icon = screen.getByTestId('icon');
+
+		expect(icon).not.toHaveClass(expected);
+	});
 });


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In hebrew locale, 'help' icon should not flip horizontal when flip prop is auto.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Check if the locale and children is he-IL and help when deciding whether to flip.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-21724

### Comments
