### PR TITLE
WRR-22638: Fixed InputField to reset Spotlight Accelerator instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/InputField` to reset the Spotlight Accelerator instance at the appropriate time
+
 ## [2.9.11] - 2025-03-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/InputField` to reset the Spotlight Accelerator instance at the appropriate time
+- `sandstone/InputField` to receive focus properly when navigating with directional keys
 
 ## [2.9.11] - 2025-03-27
 

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -304,7 +304,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				if (shouldSpotlightMove) {
 					const direction = getDirection(keyCode);
-					const {getPointerMode, move, setPointerMode} = Spotlight;
+					const {getPointerMode, move, resetSpotlightAccelerate, setPointerMode} = Spotlight;
 
 					if (getPointerMode()) {
 						setPointerMode(false);
@@ -317,6 +317,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					if (move(direction)) {
 						// if successful, reset the internal state
 						this.blur();
+						resetSpotlightAccelerate();
 					} else {
 						// if there is no other spottable elements, focus `InputDecorator` instead
 						this.focusDecorator(currentTarget);

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -304,7 +304,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				if (shouldSpotlightMove) {
 					const direction = getDirection(keyCode);
-					const {getPointerMode, move, resetSpotlightAccelerate, setPointerMode} = Spotlight;
+					const {getPointerMode, move, resetSpotlightAccelerator, setPointerMode} = Spotlight;
 
 					if (getPointerMode()) {
 						setPointerMode(false);
@@ -317,7 +317,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					if (move(direction)) {
 						// if successful, reset the internal state
 						this.blur();
-						resetSpotlightAccelerate();
+						resetSpotlightAccelerator();
 					} else {
 						// if there is no other spottable elements, focus `InputDecorator` instead
 						this.focusDecorator(currentTarget);

--- a/samples/sampler/stories/qa/Input_InputField.js
+++ b/samples/sampler/stories/qa/Input_InputField.js
@@ -1,3 +1,4 @@
+import {Button} from '@enact/sandstone/Button';
 import {InputField, InputFieldBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
@@ -198,3 +199,19 @@ export const WithANumber = (args) => (
 select('size', WithANumber, propOptions.size, FieldConfig);
 
 WithANumber.storyName = 'with a number';
+
+export const InputFieldWithVKB = () => {
+	return (
+		<div>
+			<InputField autoFocus />
+			<Button>Hello</Button>
+		</div>
+	);
+};
+
+InputFieldWithVKB.storyName = 'with spotlight and VKB';
+InputFieldWithVKB.parameters = {
+	info: {
+		text: 'Observe when the spotlight is moved back to the inputField from another component.'
+	}
+};


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is an issue where the instance value of `SpotlightAccelerator` is not updated when passing spotlight as `inputField`. This causes the callback to not be called and the spotlight to not move.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added it as a private function so that reset can be called from onKeyDown of `InputFieldSpotlightDecorator`.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-22638

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)