### PR TITLE
WRR-22683: Fixed first item wrongly marqueeing inside Dropdown list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/ContextualPopupDecorator` to spot content only after the state has been updated, on popup open
+- `sandstone/ContextualPopupDecorator` to focus content only after the state has been updated when popup opens
 - `sandstone/InputField` to receive focus properly when navigating with directional keys
 
 ## [2.9.11] - 2025-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/ContextualPopupDecorator` to spot content only after the state has been updated, on popup open
+
 ## [2.9.11] - 2025-03-27
 
 ### Fixed

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -667,8 +667,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.updateLeaveFor(current);
 			this.setState({
 				activator: current
-			});
-			this.spotPopupContent();
+			}, () => this.spotPopupContent());
 		};
 
 		handleClose = () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
First item in DropDownList had marquee, although focus was on the second item(the previously selected item)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Delayed focus being applied to the contextual popup content until the state has been updated, on popup open.
This allow marquee cancel job for the first popup spottable container to run properly, if spotlight needs to be moved to another container, on popup open


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-21604

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com