### PR TITLE
WRR-22884: Fixed EditableScroller to not allow position change of hidden items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/InputField` to receive focus properly when navigating with directional keys
-- `limestone/Scroller` with `editable` prop to ignore hidden elements
+- `sandstone/Scroller` with `editable` prop to not move hidden items
 
 ## [2.9.11] - 2025-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `limestone/Scroller` with `editable` prop to ignore hidden elements
+
 ## [2.9.11] - 2025-03-27
 
 ### Fixed

--- a/Scroller/EditableWrapper.js
+++ b/Scroller/EditableWrapper.js
@@ -390,7 +390,7 @@ const EditableWrapper = (props) => {
 		const {selectedItem} = mutableRef.current;
 		const {rtl} = scrollContainerHandle.current;
 
-		if (selectedItem) {
+		if (selectedItem && !selectedItem.className.includes('hidden')) {
 			// Bail out when index is out of scope
 			if (toIndex < mutableRef.current.hideIndex && toIndex >= 0) {
 				const {fromIndex, itemWidth, moveDirection, prevToIndex, rearrangedItems} = mutableRef.current;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Alexandru Morariu alexandru.morariu@lgepartner.com

### Checklist

* [X] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
I fixed a bug for EditableScroller where the position of hidden items could be changed. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-22884

### Comments
