### PR TITLE
WRR-24070: Fixed InputField to reset 5WayKeyHold value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/InputField` to receive focus properly when not wrapped in the same SpotlightContainerDecorator
+- `sandstone/InputField` to receive focus properly when not contained in the same SpotlightContainerDecorator
 
 ## [2.9.12] - 2025-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `sandstone/InputField` to receive focus properly when not wrapped in the same SpotlightContainerDecorator
+
 ## [2.9.12] - 2025-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/InputField` to receive focus properly when not contained in the same SpotlightContainer
+- `sandstone/Input.InputField` to receive focus properly when not contained in the same SpotlightContainer
 
 ## [2.9.12] - 2025-04-16
 
 ### Fixed
 
 - `sandstone/ContextualPopupDecorator` to focus content only after the state has been updated when popup opens
-- `sandstone/InputField` to receive focus properly when navigating with directional keys
+- `sandstone/Input.InputField` to receive focus properly when navigating with directional keys
 - `sandstone/Scroller` with `editable` prop to not move hidden items
 
 ## [2.9.11] - 2025-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
-- `sandstone/InputField` to receive focus properly when not contained in the same SpotlightContainerDecorator
+- `sandstone/InputField` to receive focus properly when not contained in the same SpotlightContainer
 
 ## [2.9.12] - 2025-04-16
 

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -304,7 +304,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				if (shouldSpotlightMove) {
 					const direction = getDirection(keyCode);
-					const {getPointerMode, move, resetSpotlightAccelerator, setPointerMode} = Spotlight;
+					const {getPointerMode, move, resetSpotlightAcceleratorAndHoldKey, setPointerMode} = Spotlight;
 
 					if (getPointerMode()) {
 						setPointerMode(false);
@@ -317,7 +317,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					if (move(direction)) {
 						// if successful, reset the internal state
 						this.blur();
-						resetSpotlightAccelerator();
+						resetSpotlightAcceleratorAndHoldKey();
 					} else {
 						// if there is no other spottable elements, focus `InputDecorator` instead
 						this.focusDecorator(currentTarget);

--- a/Input/InputFieldSpotlightDecorator.js
+++ b/Input/InputFieldSpotlightDecorator.js
@@ -304,7 +304,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				if (shouldSpotlightMove) {
 					const direction = getDirection(keyCode);
-					const {getPointerMode, move, resetSpotlightAcceleratorAndHoldKey, setPointerMode} = Spotlight;
+					const {getPointerMode, move, resetKeyHoldState, setPointerMode} = Spotlight;
 
 					if (getPointerMode()) {
 						setPointerMode(false);
@@ -317,7 +317,7 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					if (move(direction)) {
 						// if successful, reset the internal state
 						this.blur();
-						resetSpotlightAcceleratorAndHoldKey();
+						resetKeyHoldState();
 					} else {
 						// if there is no other spottable elements, focus `InputDecorator` instead
 						this.focusDecorator(currentTarget);

--- a/samples/sampler/stories/qa/Input_InputField.js
+++ b/samples/sampler/stories/qa/Input_InputField.js
@@ -3,6 +3,7 @@ import {InputField, InputFieldBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
+import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 
 import {iconNames, divMargin, propOptions, inputData} from './common/Input_Common';
 
@@ -213,5 +214,26 @@ InputFieldWithVKB.storyName = 'with spotlight and VKB';
 InputFieldWithVKB.parameters = {
 	info: {
 		text: 'Observe when the spotlight is moved back to the inputField from another component.'
+	}
+};
+
+const SpotlightContainer = SpotlightContainerDecorator('div');
+
+export const InputFieldWithSpotlightContainer = () => {
+	return (
+		<div>
+			<InputField autoFocus />
+                <SpotlightContainer>
+                    <Button>Previous</Button>
+                </SpotlightContainer>
+            <Button>Next</Button>
+		</div>
+	);
+};
+
+InputFieldWithSpotlightContainer.storyName = 'with spotlight and VKB';
+InputFieldWithSpotlightContainer.parameters = {
+	info: {
+		text: 'Observe when the spotlight is moved to Next Button.'
 	}
 };

--- a/samples/sampler/stories/qa/Input_InputField.js
+++ b/samples/sampler/stories/qa/Input_InputField.js
@@ -231,7 +231,7 @@ export const InputFieldWithSpotlightContainer = () => {
 	);
 };
 
-InputFieldWithSpotlightContainer.storyName = 'with spotlight and VKB';
+InputFieldWithSpotlightContainer.storyName = 'with not same SpotlightContainer and VKB';
 InputFieldWithSpotlightContainer.parameters = {
 	info: {
 		text: 'Observe when the spotlight is moved to Next Button.'

--- a/samples/sampler/stories/qa/Input_InputField.js
+++ b/samples/sampler/stories/qa/Input_InputField.js
@@ -231,7 +231,7 @@ export const InputFieldWithSpotlightContainer = () => {
 	);
 };
 
-InputFieldWithSpotlightContainer.storyName = 'with not same SpotlightContainer and VKB';
+InputFieldWithSpotlightContainer.storyName = 'with SpotlightContainer and VKB';
 InputFieldWithSpotlightContainer.parameters = {
 	info: {
 		text: 'Observe when the spotlight is moved to Next Button.'

--- a/samples/sampler/stories/qa/Input_InputField.js
+++ b/samples/sampler/stories/qa/Input_InputField.js
@@ -223,10 +223,10 @@ export const InputFieldWithSpotlightContainer = () => {
 	return (
 		<div>
 			<InputField autoFocus />
-                <SpotlightContainer>
-                    <Button>Previous</Button>
-                </SpotlightContainer>
-            <Button>Next</Button>
+			<SpotlightContainer>
+				<Button>Previous</Button>
+			</SpotlightContainer>
+			<Button>Next</Button>
 		</div>
 	);
 };


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is an issue where Spotlight does not move if there is an InputField and it is not wrapped with the same SpotlightContainerDecorator. this is because the 5WayKeyHold value is not updated when passing spotlight as inputField. This causes the callback to not be called and the spotlight to not move.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to reset 5WayKeyHold by extending the `resetSpotlightAccelerator` function to `resetSpotlightAcceleratorAndHoldKey`


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-24070

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)
