### PR TITLE
WRR-789: Clean up default props in sandstone sampler

### DIFF
--- a/Panels/Header.js
+++ b/Panels/Header.js
@@ -334,6 +334,8 @@ const HeaderBase = kind({
 	},
 
 	defaultProps: {
+		backButtonBackgroundOpacity: 'transparent',
+		closeButtonBackgroundOpacity: 'transparent',
 		marqueeOn: 'render',
 		noSubtitle: false,
 		type: 'standard'

--- a/QuickGuidePanels/index.js
+++ b/QuickGuidePanels/index.js
@@ -12,9 +12,10 @@
  * @module sandstone/QuickGuidePanels
  * @exports Panel
  * @exports QuickGuidePanels
+ * @exports QuickGuidePanelsBase
  */
 
-import {QuickGuidePanels} from './QuickGuidePanels';
+import {QuickGuidePanels, QuickGuidePanelsBase} from './QuickGuidePanels';
 import {Panel} from './Panel';
 
 /**
@@ -29,5 +30,6 @@ QuickGuidePanels.Panel = Panel;
 export default QuickGuidePanels;
 export {
 	Panel,
-	QuickGuidePanels
+	QuickGuidePanels,
+	QuickGuidePanelsBase
 };

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -277,6 +277,10 @@ const RangePickerBase = kind({
 		wrap: PropTypes.bool
 	},
 
+	defaultProps: {
+		orientation: 'horizontal'
+	},
+
 	styles: {
 		css: componentCss,
 		className: 'rangePicker',

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -56,6 +56,7 @@ const sliderDefaultProps = {
 	keyFrequency: [1],
 	max: 100,
 	min: 0,
+	orientation: 'horizontal',
 	step: 1,
 	wheelInterval: 0
 };

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -10,6 +10,7 @@ import iconNames from '../helper/icons';
 // Button's prop `minWidth` defaults to true and we only want to show `minWidth={false}` in the JSX. In order to hide `minWidth` when `true`, we use the normal storybook boolean control and return `void 0` when `true`.
 Button.displayName = 'Button';
 const Config = mergeComponentMetadata('Button', UIButtonBase, UIButton, ButtonBase, Button);
+Config.defaultProps.tooltipType = 'balloon';
 
 // Set up some defaults for info and controls
 const prop = {
@@ -22,7 +23,7 @@ const prop = {
 	iconFlip: ['', 'auto', 'both', 'horizontal', 'vertical'],
 	iconPosition: ['', 'before', 'after'],
 	icons: ['', ...iconNames],
-	minWidth: {'undefined/null (automatic)': '', 'true (enforce)': true, 'false (ignore)': 'false'},
+	minWidth: {'undefined/null (automatic)': '', 'true (enforce)': 'true', 'false (ignore)': 'false'},
 	size: ['', 'small', 'large'],
 	tooltipType: ['', 'balloon', 'transparent']
 };
@@ -76,7 +77,7 @@ boolean('disabled', _Button, Config);
 select('icon', _Button, prop.icons, Config);
 select('iconFlip', _Button, prop.iconFlip, Config);
 select('iconPosition', _Button, prop.iconPosition, Config);
-select('minWidth', _Button, prop.minWidth, Config);
+select('minWidth', _Button, prop.minWidth, Config, '');
 boolean('roundBorder', _Button, Config);
 boolean('selected', _Button, Config);
 boolean('shadowed', _Button, Config);

--- a/samples/sampler/stories/default/FlexiblePopupPanels.js
+++ b/samples/sampler/stories/default/FlexiblePopupPanels.js
@@ -19,6 +19,10 @@ const propOptions = {
 
 const Config = mergeComponentMetadata('FlexiblePopupPanels', FlexiblePopupPanelsBase, FlexiblePopupPanels);
 const PanelConfig = mergeComponentMetadata('Panel', PanelBase, Panel);
+Config.defaultProps = {
+	scrimType: 'translucent',
+	spotlightRestrict: 'self-only'
+};
 
 export default {
 	title: 'Sandstone/FlexiblePopupPanels',
@@ -115,13 +119,12 @@ boolean('noAnimation', _FlexiblePopupPanels, Config);
 boolean('noAutoDismiss', _FlexiblePopupPanels, Config);
 boolean('noCloseButton', _FlexiblePopupPanels, Config);
 select('prevButtonVisibility', _FlexiblePopupPanels, propOptions.buttonVisibility, Config);
-select('scrimType', _FlexiblePopupPanels, ['none', 'translucent', 'transparent'], Config, 'translucent');
+select('scrimType', _FlexiblePopupPanels, ['none', 'translucent', 'transparent'], Config);
 select(
 	'spotlightRestrict',
 	_FlexiblePopupPanels,
 	['self-first', 'self-only'],
-	Config,
-	'self-only'
+	Config
 );
 select('size', _FlexiblePopupPanels, propOptions.size, PanelConfig);
 boolean('custom first Panel prevButton', _FlexiblePopupPanels, PanelConfig);

--- a/samples/sampler/stories/default/FlexiblePopupPanels.js
+++ b/samples/sampler/stories/default/FlexiblePopupPanels.js
@@ -20,6 +20,8 @@ const propOptions = {
 const Config = mergeComponentMetadata('FlexiblePopupPanels', FlexiblePopupPanelsBase, FlexiblePopupPanels);
 const PanelConfig = mergeComponentMetadata('Panel', PanelBase, Panel);
 Config.defaultProps = {
+	nextButtonVisibility: 'auto',
+	prevButtonVisibility: 'auto',
 	scrimType: 'translucent',
 	spotlightRestrict: 'self-only'
 };

--- a/samples/sampler/stories/default/Header.js
+++ b/samples/sampler/stories/default/Header.js
@@ -96,16 +96,14 @@ select(
 	'backButtonBackgroundOpacity',
 	PanelsHeader,
 	['opaque', 'transparent'],
-	Config,
-	'transparent'
+	Config
 );
 boolean('centered', PanelsHeader, Config);
 select(
 	'closeButtonBackgroundOpacity',
 	PanelsHeader,
 	['opaque', 'transparent'],
-	Config,
-	'transparent'
+	Config
 );
 select('marqueeOn', PanelsHeader, prop.marqueeOn, Config);
 boolean('noCloseButton', PanelsHeader, Config);

--- a/samples/sampler/stories/default/Marquee.js
+++ b/samples/sampler/stories/default/Marquee.js
@@ -1,8 +1,17 @@
 import Marquee from '@enact/sandstone/Marquee';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, number, select, text} from '@enact/storybook-utils/addons/controls';
+import {Marquee as uiMarquee} from '@enact/ui/Marquee';
 import ri from '@enact/ui/resolution';
 
+const Config = mergeComponentMetadata('Marquee', uiMarquee);
 Marquee.displayName = 'Marquee';
+
+const props = {
+	alignment: [null, 'left', 'right', 'center'],
+	forceDirection: [null, 'rtl', 'ltr'],
+	marqueeOn: ['focus', 'hover', 'render']
+};
 
 export default {
 	title: 'Sandstone/Marquee',
@@ -48,15 +57,15 @@ export const _Marquee = (args) => {
 	);
 };
 
-boolean('disabled', _Marquee, Marquee);
-select('alignment', _Marquee, [null, 'left', 'right', 'center'], Marquee);
-select('forceDirection', _Marquee, [null, 'rtl', 'ltr'], Marquee);
-number('marqueeDelay', _Marquee, Marquee, 1000);
-boolean('marqueeDisabled', _Marquee, Marquee);
-select('marqueeOn', _Marquee, ['hover', 'render'], Marquee, 'render');
-number('marqueeResetDelay', _Marquee, Marquee, 1000);
-text('marqueeSpacing', _Marquee, Marquee, '50%');
-number('marqueeSpeed', _Marquee, Marquee, 60);
+boolean('disabled', _Marquee, Config);
+select('alignment', _Marquee, [null, 'left', 'right', 'center'], Config);
+select('forceDirection', _Marquee, [null, 'rtl', 'ltr'], Config);
+number('marqueeDelay', _Marquee, Config, 1000);
+boolean('marqueeDisabled', _Marquee, Config);
+select('marqueeOn', _Marquee, ['hover', 'render'], Config, 'render');
+number('marqueeResetDelay', _Marquee, Config, 1000);
+text('marqueeSpacing', _Marquee, Config, '50%');
+number('marqueeSpeed', _Marquee, Config, 60);
 text(
 	'children',
 	_Marquee,

--- a/samples/sampler/stories/default/Marquee.js
+++ b/samples/sampler/stories/default/Marquee.js
@@ -58,14 +58,14 @@ export const _Marquee = (args) => {
 };
 
 boolean('disabled', _Marquee, Config);
-select('alignment', _Marquee, [null, 'left', 'right', 'center'], Config);
-select('forceDirection', _Marquee, [null, 'rtl', 'ltr'], Config);
-number('marqueeDelay', _Marquee, Config, 1000);
+select('alignment', _Marquee, props.alignment, Config);
+select('forceDirection', _Marquee, props.forceDirection, Config);
+number('marqueeDelay', _Marquee, Config);
 boolean('marqueeDisabled', _Marquee, Config);
-select('marqueeOn', _Marquee, ['hover', 'render'], Config, 'render');
-number('marqueeResetDelay', _Marquee, Config, 1000);
-text('marqueeSpacing', _Marquee, Config, '50%');
-number('marqueeSpeed', _Marquee, Config, 60);
+select('marqueeOn', _Marquee, props.marqueeOn, Config, 'render');
+number('marqueeResetDelay', _Marquee, Config);
+text('marqueeSpacing', _Marquee, Config);
+number('marqueeSpeed', _Marquee, Config);
 text(
 	'children',
 	_Marquee,

--- a/samples/sampler/stories/default/PageViews.js
+++ b/samples/sampler/stories/default/PageViews.js
@@ -7,6 +7,8 @@ import {Cell, Row, Column} from '@enact/ui/Layout';
 PageViews.displayName = 'PageViews';
 
 const Config = mergeComponentMetadata('PageViews', PageViews);
+Config.defaultProps.pageIndicatorType = 'dot';
+
 const propOptions = {
 	pageIndicatorType: ['dot', 'number']
 };

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -19,6 +19,9 @@ import compose from 'ramda/src/compose';
 import {svgGenerator} from '../helper/svg';
 
 const Config = mergeComponentMetadata('Panels', Panels);
+Config.defaultProps.backButtonBackgroundOpacity = 'transparent';
+Config.defaultProps.closeButtonBackgroundOpacity = 'transparent';
+
 const HeaderConfig = mergeComponentMetadata('Header', Header);
 
 const items = [];
@@ -217,15 +220,13 @@ select(
 	'backButtonBackgroundOpacity',
 	_Panels,
 	['opaque', 'transparent'],
-	Config,
-	'transparent'
+	Config
 );
 select(
 	'closeButtonBackgroundOpacity',
 	_Panels,
 	['opaque', 'transparent'],
-	Config,
-	'transparent'
+	Config
 );
 boolean('noAnimation', _Panels, Panels, false);
 boolean('noBackButton', _Panels, Panels, false);

--- a/samples/sampler/stories/default/ProgressBar.js
+++ b/samples/sampler/stories/default/ProgressBar.js
@@ -1,10 +1,10 @@
-import ProgressBar, {ProgressBarTooltip} from '@enact/sandstone/ProgressBar';
+import ProgressBar, {ProgressBarBase, ProgressBarTooltip} from '@enact/sandstone/ProgressBar';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, range, select} from '@enact/storybook-utils/addons/controls';
 
 import css from './ProgressBar.module.less';
 
-const ProgressBarConfig = mergeComponentMetadata('ProgressBar', ProgressBar);
+const ProgressBarConfig = mergeComponentMetadata('ProgressBar', ProgressBarBase);
 const ProgressBarTooltipConfig = mergeComponentMetadata('ProgressBarTooltip', ProgressBarTooltip);
 ProgressBar.displayName = 'ProgressBar';
 ProgressBarTooltip.displayName = 'ProgressBarTooltip';
@@ -68,8 +68,7 @@ select(
 	'orientation',
 	_ProgressBar,
 	['horizontal', 'vertical', 'radial'],
-	ProgressBarConfig,
-	'horizontal'
+	ProgressBarConfig
 );
 range(
 	'progress',

--- a/samples/sampler/stories/default/ProgressButton.js
+++ b/samples/sampler/stories/default/ProgressButton.js
@@ -27,7 +27,7 @@ const prop = {
 	},
 	color: ['', 'red', 'green', 'yellow', 'blue'],
 	icons: ['', ...iconNames],
-	minWidth: {'undefined/null (automatic)': '', 'true (enforce)': true, 'false (ignore)': 'false'},
+	minWidth: {'undefined/null (automatic)': '', 'true (enforce)': 'true', 'false (ignore)': 'false'},
 	size: ['', 'small', 'large']
 };
 
@@ -71,7 +71,7 @@ boolean('showProgress', _ProgressButton, Config);
 select('backgroundOpacity', _ProgressButton, prop.backgroundOpacity, Config);
 select('color', _ProgressButton, prop.color, Config);
 select('icon', _ProgressButton, prop.icons, Config);
-select('minWidth', _ProgressButton, prop.minWidth, Config);
+select('minWidth', _ProgressButton, prop.minWidth, Config, '');
 range('progress', _ProgressButton, Config, {min: 0, max: 1, step: 0.01}, 0.4);
 select('size', _ProgressButton, prop.size, Config);
 text('children', _ProgressButton, Config, 'Update');

--- a/samples/sampler/stories/default/QuickGuidePanels.js
+++ b/samples/sampler/stories/default/QuickGuidePanels.js
@@ -2,11 +2,14 @@ import Button from '@enact/sandstone/Button';
 import {Panel} from '@enact/sandstone/Panels';
 import Popup from '@enact/sandstone/Popup';
 import SwitchItem from '@enact/sandstone/SwitchItem';
-import QuickGuidePanels from '@enact/sandstone/QuickGuidePanels';
+import {QuickGuidePanels, QuickGuidePanelsBase} from '@enact/sandstone/QuickGuidePanels';
 import {action} from '@enact/storybook-utils/addons/actions';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {number, select} from '@enact/storybook-utils/addons/controls';
 
 import css from './QuickGuidePanels.module.less';
+
+const Config = mergeComponentMetadata('QuickGuidePanels', QuickGuidePanelsBase);
 
 QuickGuidePanels.displayName = 'QuickGuidePanels';
 
@@ -87,8 +90,8 @@ export const _QuickGuidePanels = (args) => {
 };
 
 number('current', _QuickGuidePanels, 0);
-select('nextButtonVisibility', _QuickGuidePanels, propOptions.buttonVisibility, 'auto');
-select('prevButtonVisibility', _QuickGuidePanels, propOptions.buttonVisibility, 'auto');
+select('nextButtonVisibility', _QuickGuidePanels, propOptions.buttonVisibility, Config);
+select('prevButtonVisibility', _QuickGuidePanels, propOptions.buttonVisibility, Config);
 number('total', _QuickGuidePanels, 0);
 
 _QuickGuidePanels.storyName = 'QuickGuidePanels';

--- a/samples/sampler/stories/default/RangePicker.js
+++ b/samples/sampler/stories/default/RangePicker.js
@@ -58,7 +58,7 @@ select('incrementIcon', _RangePicker, ['', ...incrementIcons], Config);
 boolean('inlineTitle', _RangePicker, Config);
 boolean('joined', _RangePicker, Config);
 boolean('noAnimation', _RangePicker, Config);
-select('orientation', _RangePicker, prop.orientation, Config, 'horizontal');
+select('orientation', _RangePicker, prop.orientation, Config);
 number('step', _RangePicker, Config, 5);
 text('title', _RangePicker, Config);
 select('width', _RangePicker, prop.width, Config, 'small');

--- a/samples/sampler/stories/default/Slider.js
+++ b/samples/sampler/stories/default/Slider.js
@@ -77,7 +77,7 @@ number('knobStep', _Slider, SliderConfig);
 number('max', _Slider, SliderConfig, 10);
 number('min', _Slider, SliderConfig, 0);
 boolean('noFill', _Slider, SliderConfig);
-select('orientation', _Slider, ['horizontal', 'vertical'], SliderConfig, 'horizontal');
+select('orientation', _Slider, ['horizontal', 'vertical'], SliderConfig);
 range(
 	'progressAnchor',
 	_Slider,

--- a/samples/sampler/stories/default/Spinner.js
+++ b/samples/sampler/stories/default/Spinner.js
@@ -7,6 +7,7 @@ import UiSpinner, {SpinnerBase as UiSpinnerBase} from '@enact/ui/Spinner';
 
 Spinner.displayName = 'Spinner';
 const Config = mergeComponentMetadata('Spinner', UiSpinnerBase, UiSpinner, SpinnerBase, Spinner);
+Config.defaultProps.blockClickOn = 'null';
 
 export default {
 	title: 'Sandstone/Spinner',
@@ -78,7 +79,7 @@ export const _Spinner = (args) => (
 	</div>
 );
 
-select('blockClickOn', _Spinner, [null, 'container', 'screen'], Config);
+select('blockClickOn', _Spinner, ['null', 'container', 'screen'], Config);
 boolean('centered', _Spinner, Config);
 boolean('paused', _Spinner, Config);
 boolean('scrim', _Spinner, Config);

--- a/samples/sampler/stories/default/TooltipDecorator.js
+++ b/samples/sampler/stories/default/TooltipDecorator.js
@@ -6,6 +6,7 @@ import {boolean, number, select, text} from '@enact/storybook-utils/addons/contr
 import iconNames from '../helper/icons';
 
 const Config = mergeComponentMetadata('TooltipDecorator', TooltipBase, Tooltip, TooltipDecorator);
+Config.defaultProps.tooltipType = 'balloon';
 const TooltipButton = TooltipDecorator({tooltipDestinationProp: 'decoration'}, Button);
 
 const prop = {
@@ -59,7 +60,7 @@ boolean('tooltipMarquee', _TooltipDecorator, Config);
 select('tooltipPosition', _TooltipDecorator, prop.tooltipPosition, Config, prop.tooltipPosition[0]);
 boolean('tooltipRelative', _TooltipDecorator, Config);
 text('tooltipText', _TooltipDecorator, Config, 'tooltip!');
-select('tooltipType', _TooltipDecorator, prop.tooltipType, Config, prop.tooltipType[0]);
+select('tooltipType', _TooltipDecorator, prop.tooltipType, Config);
 number('tooltipWidth', _TooltipDecorator, Config);
 text('children', _TooltipDecorator, Config, 'click me');
 

--- a/samples/sampler/stories/qa/ContextualPopupDecorator.js
+++ b/samples/sampler/stories/qa/ContextualPopupDecorator.js
@@ -1,5 +1,5 @@
 import Button from '@enact/sandstone/Button';
-import {ContextualPopupDecorator} from '@enact/sandstone/ContextualPopupDecorator';
+import {ContextualPopup, ContextualPopupDecorator} from '@enact/sandstone/ContextualPopupDecorator';
 import Heading from '@enact/sandstone/Heading';
 import Slider from '@enact/sandstone/Slider';
 import {select} from '@enact/storybook-utils/addons/controls';
@@ -8,7 +8,8 @@ import ri from '@enact/ui/resolution';
 import {Component} from 'react';
 
 const ContextualButton = ContextualPopupDecorator(Button);
-const Config = mergeComponentMetadata('ContextualButton', ContextualButton);
+const Config = mergeComponentMetadata('ContextualPopupDecorator', ContextualPopup, ContextualPopupDecorator);
+Config.defaultProps.spotlightRestrict = 'self-first';
 ContextualButton.displayName = 'ContextualButton';
 
 const buttonMargin = () => ({margin: ri.scaleToRem(24)});
@@ -118,8 +119,7 @@ select(
 		'right top',
 		'right bottom'
 	],
-	Config,
-	'below'
+	Config
 );
 select(
 	'spotlightRestrict',
@@ -256,8 +256,7 @@ select(
 		'right top',
 		'right bottom'
 	],
-	Config,
-	'below center'
+	Config
 );
 select(
 	'spotlightRestrict',

--- a/samples/sampler/stories/qa/Input_Number_Fullscreen.js
+++ b/samples/sampler/stories/qa/Input_Number_Fullscreen.js
@@ -1,12 +1,11 @@
-import Input, {InputBase} from '@enact/sandstone/Input';
+import Input, {InputBase, InputPopupBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 
 import {buttons, propOptions, inputData} from './common/Input_Common';
 
 Input.displayName = 'Input';
-const Config = mergeComponentMetadata('Input', InputBase, Input);
-
+const Config = mergeComponentMetadata('Input', InputPopupBase, InputBase, Input);
 export default {
 	title: 'Sandstone/Input/Number/Fullscreen',
 	component: 'InputField'

--- a/samples/sampler/stories/qa/Input_Number_Overlay.js
+++ b/samples/sampler/stories/qa/Input_Number_Overlay.js
@@ -1,11 +1,11 @@
-import Input, {InputBase} from '@enact/sandstone/Input';
+import Input, {InputBase, InputPopupBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 
 import {buttons, propOptions, inputData} from './common/Input_Common';
 
 Input.displayName = 'Input';
-const Config = mergeComponentMetadata('Input', InputBase, Input);
+const Config = mergeComponentMetadata('Input', InputPopupBase, InputBase, Input);
 
 export default {
 	title: 'Sandstone/Input/Number/Overlay',

--- a/samples/sampler/stories/qa/Input_Text_Fullscreen.js
+++ b/samples/sampler/stories/qa/Input_Text_Fullscreen.js
@@ -1,11 +1,11 @@
-import Input, {InputBase} from '@enact/sandstone/Input';
+import Input, {InputBase, InputPopupBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 
 import {propOptions, inputData} from './common/Input_Common';
 
 Input.displayName = 'Input';
-const Config = mergeComponentMetadata('Input', InputBase, Input);
+const Config = mergeComponentMetadata('Input', InputPopupBase, InputBase, Input);
 
 export default {
 	title: 'Sandstone/Input/Text/Fullscreen',

--- a/samples/sampler/stories/qa/Input_Text_Overlay.js
+++ b/samples/sampler/stories/qa/Input_Text_Overlay.js
@@ -1,11 +1,11 @@
-import Input, {InputBase} from '@enact/sandstone/Input';
+import Input, {InputBase, InputPopupBase} from '@enact/sandstone/Input';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 
 import {propOptions, inputData} from './common/Input_Common';
 
 Input.displayName = 'Input';
-const Config = mergeComponentMetadata('Input', InputBase, Input);
+const Config = mergeComponentMetadata('Input', InputPopupBase, InputBase, Input);
 
 export default {
 	title: 'Sandstone/Input/Text/Overlay',

--- a/samples/sampler/stories/qa/Item.js
+++ b/samples/sampler/stories/qa/Item.js
@@ -1,9 +1,11 @@
 import Button from '@enact/sandstone/Button';
 import Heading from '@enact/sandstone/Heading';
 import Icon from '@enact/sandstone/Icon';
-import Item from '@enact/sandstone/Item';
+import Item, {ItemBase} from '@enact/sandstone/Item';
 import Scroller from '@enact/sandstone/Scroller';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
+import UiItem, {ItemBase as UiItemBase} from '@enact/ui/Item';
 import {Row} from '@enact/ui/Layout';
 import {scale} from '@enact/ui/resolution';
 import {useCallback, useState} from 'react';
@@ -13,6 +15,8 @@ import icons from '../helper/icons';
 import Section from './components/KitchenSinkSection';
 
 import css from './Item.module.less';
+
+const Config = mergeComponentMetadata('Item', UiItemBase, UiItem, ItemBase, Item);
 
 const iconNames = ['', ...icons];
 
@@ -51,8 +55,8 @@ export const WithLongText = (args) => (
 	</Item>
 );
 
-boolean('disabled', WithLongText, Item);
-text('Children', WithLongText, Item, inputData.longText);
+boolean('disabled', WithLongText, Config);
+text('Children', WithLongText, Config, inputData.longText);
 
 WithLongText.storyName = 'with long text';
 
@@ -62,8 +66,8 @@ export const WithTallCharacters = (args) => (
 	</Item>
 );
 
-boolean('disabled', WithTallCharacters, Item);
-select('value', WithTallCharacters, inputData.tallText, Item, inputData.tallText[2]);
+boolean('disabled', WithTallCharacters, Config);
+select('value', WithTallCharacters, inputData.tallText, Config, inputData.tallText[2]);
 
 WithTallCharacters.storyName = 'with tall characters';
 
@@ -73,8 +77,8 @@ export const WithExtraSpaces = (args) => (
 	</Item>
 );
 
-boolean('disabled', WithExtraSpaces, Item);
-text('Children', WithExtraSpaces, Item, inputData.extraSpaceText);
+boolean('disabled', WithExtraSpaces, Config);
+text('Children', WithExtraSpaces, Config, inputData.extraSpaceText);
 
 WithExtraSpaces.storyName = 'with extra spaces';
 
@@ -107,13 +111,13 @@ export const SampleForSpotabilityTest = (args) => (
 	</div>
 );
 
-text('Spottable Text', SampleForSpotabilityTest, Item, inputData.normalText);
-text('Disabled Text', SampleForSpotabilityTest, Item, inputData.disabledText);
-select('size', SampleForSpotabilityTest, ['small', 'large'], Item, 'large');
-select('iconBefore', SampleForSpotabilityTest, iconNames, Item, 'plus');
-text('Text with iconBefore', SampleForSpotabilityTest, Item, 'Item with text that is spottable with an icon (at the start of the string)');
-text('Text with iconAfter', SampleForSpotabilityTest, Item, 'Item with text that is spottable with an icon(at the end of the string)');
-select('iconAfter', SampleForSpotabilityTest, iconNames, Item, 'arrowhookright');
+text('Spottable Text', SampleForSpotabilityTest, Config, inputData.normalText);
+text('Disabled Text', SampleForSpotabilityTest, Config, inputData.disabledText);
+select('size', SampleForSpotabilityTest, ['small', 'large'], Config);
+select('iconBefore', SampleForSpotabilityTest, iconNames, Config, 'plus');
+text('Text with iconBefore', SampleForSpotabilityTest, Config, 'Item with text that is spottable with an icon (at the start of the string)');
+text('Text with iconAfter', SampleForSpotabilityTest, Config, 'Item with text that is spottable with an icon(at the end of the string)');
+select('iconAfter', SampleForSpotabilityTest, iconNames, Config, 'arrowhookright');
 
 SampleForSpotabilityTest.storyName = 'sample for spotability test';
 
@@ -156,12 +160,12 @@ export const WithDifferentTextLength = (args) => (
 	</Scroller>
 );
 
-boolean('disabled', WithDifferentTextLength, Item);
-boolean('inline', WithDifferentTextLength, Item);
-text('label', WithDifferentTextLength, Item, inputData.shortLabel);
-text('children2', WithDifferentTextLength, Item, inputData.longChildren);
-text('label2', WithDifferentTextLength, Item, inputData.longLabel);
-text('children', WithDifferentTextLength, Item, inputData.shortChildren);
+boolean('disabled', WithDifferentTextLength, Config);
+boolean('inline', WithDifferentTextLength, Config);
+text('label', WithDifferentTextLength, Config, inputData.shortLabel);
+text('children2', WithDifferentTextLength, Config, inputData.longChildren);
+text('label2', WithDifferentTextLength, Config, inputData.longLabel);
+text('children', WithDifferentTextLength, Config, inputData.shortChildren);
 
 WithDifferentTextLength.storyName = 'with different text length';
 
@@ -177,10 +181,10 @@ export const WithSpotlightDisabled = (args) => (
 	</div>
 );
 
-boolean('spotlightDisabled', WithSpotlightDisabled, Item, true);
-select('marqueeOn', WithSpotlightDisabled, ['render', 'hover'], Item, 'render');
-text('label', WithSpotlightDisabled, Item, inputData.shortLabel);
-text('children', WithSpotlightDisabled, Item, inputData.mediumChildren);
+boolean('spotlightDisabled', WithSpotlightDisabled, Config, true);
+select('marqueeOn', WithSpotlightDisabled, ['render', 'hover'], Config, 'render');
+text('label', WithSpotlightDisabled, Config, inputData.shortLabel);
+text('children', WithSpotlightDisabled, Config, inputData.mediumChildren);
 
 WithSpotlightDisabled.storyName = 'with spotlightDisabled';
 
@@ -262,8 +266,8 @@ export const WithCustomStyle = (args) => (
 	</Item>
 );
 
-text('label', WithCustomStyle, Item, inputData.shortLabel);
-text('children', WithCustomStyle, Item, inputData.shortChildren);
+text('label', WithCustomStyle, Config, inputData.shortLabel);
+text('children', WithCustomStyle, Config, inputData.shortChildren);
 
 WithCustomStyle.storyName = 'with custom style';
 

--- a/samples/sampler/stories/qa/Spinner.js
+++ b/samples/sampler/stories/qa/Spinner.js
@@ -1,12 +1,16 @@
 import Button from '@enact/sandstone/Button';
 import {InputField} from '@enact/sandstone/Input';
-import Spinner from '@enact/sandstone/Spinner';
+import Spinner, {SpinnerBase} from '@enact/sandstone/Spinner';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select, text} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
+import UiSpinner, {SpinnerBase as UiSpinnerBase} from '@enact/ui/Spinner';
 import {Component} from 'react';
 
 Spinner.displayName = 'Spinner';
+const Config = mergeComponentMetadata('Spinner', UiSpinnerBase, UiSpinner, SpinnerBase, Spinner);
+Config.defaultProps.blockClickOn = 'null';
 
 // Set up some defaults for info and controls
 const prop = {
@@ -80,11 +84,11 @@ export const WithLongContent = (args) => (
 	</div>
 );
 
-boolean('transparent', WithLongContent, Spinner, false);
-boolean('centered', WithLongContent, Spinner, false);
-select('blockClickOn', WithLongContent, [null, 'container', 'screen'], Spinner);
-boolean('scrim', WithLongContent, Spinner, true);
-text('content', WithLongContent, Spinner, prop.longText);
+boolean('transparent', WithLongContent, Config, false);
+boolean('centered', WithLongContent, Config, false);
+select('blockClickOn', WithLongContent, ['null', 'container', 'screen'], Config);
+boolean('scrim', WithLongContent, Config, true);
+text('content', WithLongContent, Config, prop.longText);
 
 WithLongContent.storyName = 'with long content';
 
@@ -115,11 +119,11 @@ export const BlockingClickEvents = (args) => (
 	</div>
 );
 
-boolean('transparent', BlockingClickEvents, Spinner, false);
-boolean('centered', BlockingClickEvents, Spinner, false);
-select('blockClickOn', BlockingClickEvents, [null, 'container', 'screen'], Spinner);
-boolean('scrim', BlockingClickEvents, Spinner, true);
-text('content', BlockingClickEvents, Spinner);
+boolean('transparent', BlockingClickEvents, Config, false);
+boolean('centered', BlockingClickEvents, Config, false);
+select('blockClickOn', BlockingClickEvents, [null, 'container', 'screen'], Config);
+boolean('scrim', BlockingClickEvents, Config, true);
+text('content', BlockingClickEvents, Config);
 
 BlockingClickEvents.storyName = 'blocking click events';
 

--- a/samples/sampler/stories/qa/TabLayout.js
+++ b/samples/sampler/stories/qa/TabLayout.js
@@ -143,7 +143,7 @@ export const WithVariableNumberOfTabs = (args) => {
 };
 
 range('Number of Tabs', WithVariableNumberOfTabs, {groupId: 'TabLayout'}, {min: 0, max: 20, step: 1}, 3);
-select('orientation', WithVariableNumberOfTabs, ['vertical', 'horizontal'], TabLayout, 'vertical');
+select('orientation', WithVariableNumberOfTabs, ['vertical', 'horizontal'], Config, 'vertical');
 
 WithVariableNumberOfTabs.storyName = 'With variable number of tabs';
 WithVariableNumberOfTabs.parameters = {
@@ -224,7 +224,7 @@ export const WithTabsWithoutIcons = (args) => {
 };
 
 range('Number of Tabs', WithTabsWithoutIcons, {groupId: 'TabLayout'}, {min: 0, max: 20, step: 1}, 3);
-select('orientation', WithTabsWithoutIcons, ['vertical', 'horizontal'], TabLayout, 'vertical');
+select('orientation', WithTabsWithoutIcons, ['vertical', 'horizontal'], Config, 'vertical');
 
 WithTabsWithoutIcons.storyName = 'With tabs without icons';
 WithTabsWithoutIcons.parameters = {
@@ -310,7 +310,7 @@ export const WithDisabledTabs = (args) => {
 };
 
 range('Number of Tabs', WithDisabledTabs, {groupId: 'TabLayout'}, {min: 0, max: 20, step: 1}, 3);
-select('orientation', WithDisabledTabs, ['vertical', 'horizontal'], TabLayout, 'vertical');
+select('orientation', WithDisabledTabs, ['vertical', 'horizontal'], Config, 'vertical');
 
 WithDisabledTabs.storyName = 'With disabled tabs';
 WithDisabledTabs.parameters = {
@@ -391,7 +391,7 @@ export const WithAllDisabledTabs = (args) => {
 };
 
 range('Number of Tabs', WithAllDisabledTabs, {groupId: 'TabLayout'}, {min: 0, max: 20, step: 1}, 3);
-select('orientation', WithAllDisabledTabs, ['vertical', 'horizontal'], TabLayout, 'vertical');
+select('orientation', WithAllDisabledTabs, ['vertical', 'horizontal'], Config, 'vertical');
 
 WithAllDisabledTabs.storyName = 'With all disabled tabs';
 WithAllDisabledTabs.parameters = {


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some default props in sampler is being misused or omitted 'Default'.
So we need to default props in sampler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix default props in sampler as per the docs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-789

### Comments
