### PR TITLE
WRR-30554: Fixed Scroller to prevent the native scrolling behavior caused by keydown events only when a popup is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ### Fixed
 
 - `sandstone/QuickGuidePanels` navigation buttons position
+- `sandstone/Scroller` to prevent the native scrolling behavior caused by keydown events only when a popup is open
 
 ## [2.9.13] - 2025-04-24
 

--- a/samples/sampler/stories/qa/Scroller.js
+++ b/samples/sampler/stories/qa/Scroller.js
@@ -1316,3 +1316,14 @@ export const WithFixedPopupPanels = () => {
 };
 
 WithFixedPopupPanels.storyName = 'With FixedPopupPanels';
+
+export const WithInputField = () => {
+	return (
+		<Scroller>
+			<InputField autoFocus />
+			<div style={{height: ri.scaleToRem(2400)}} />
+		</Scroller>
+	);
+};
+
+WithInputField.storyName = 'With InputField';

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -271,7 +271,7 @@ const useThemeScroll = (props, instances) => {
 	}
 
 	function preventScroll (ev) {
-		if (Spotlight.isPaused() && getDirection(ev.keyCode)) {
+		if (Spotlight.isPaused() && Spotlight.getPausedInstance() === 'Popup' && getDirection(ev.keyCode)) {
 			ev.preventDefault();
 			ev.stopPropagation();
 		}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller was blocking onKeyDown event when an element had Spotlight paused

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed Scroller to prevent the native scrolling behavior caused by keydown events only when a popup is open

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-30554

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)