### PR TITLE
NXT-608: Fixed contextualPopup to spot content after state update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 
 ### Fixed
 
+- `sandstone/ContextualPopupDecorator` to focus content with timeout when popup opens
 - `sandstone/QuickGuidePanels` navigation buttons position
 - `sandstone/Scroller` to prevent the native scrolling behavior caused by keydown events only when a popup is open
 

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -667,7 +667,10 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.updateLeaveFor(current);
 			this.setState({
 				activator: current
-			}, () => this.spotPopupContent());
+			});
+			setTimeout(() => {
+				this.spotPopupContent();
+			});
 		};
 
 		handleClose = () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In Dropdown, scrolling happened after the selected item got focused, on dropdown open

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed contextualPopup to spot content after a timeout, so it allows any marquee to cancel, but also to prevent scrolling after spot contextual popup content


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-608

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com