### PR TITLE
Fixed qa-a11y view to scroll properly

### DIFF
--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -153,7 +153,7 @@ const AppBase = ({className, rtl, updateLocale, ...rest}) => {
 	return (
 		<div className={classnames(className, debugAriaClass)}>
 			<Layout {...rest} className={appCss.layout}>
-				<Cell component={Menu} id="menu" size="20%" spotlightId="menu">
+				<Cell component={Menu} id="menu" size="15%" spotlightId="menu">
 					<div className={appCss.jumpToView}>Jump To View: {jumpToView}</div>
 					{views.map((view, i) => (
 						<Item

--- a/samples/qa-a11y/src/App/App.module.less
+++ b/samples/qa-a11y/src/App/App.module.less
@@ -1,3 +1,5 @@
+@import "~@enact/sandstone/styles/mixins.less";
+
 body {
 	position: fixed;
 	overflow: hidden;
@@ -23,6 +25,7 @@ h2 {
 .navItem {
 	height: 42px;
 	margin: 0;
+	.padding-start-end(6px, 0);
 
 	& > div {
 		pointer-events: none;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In qa-a11y sample, in Scroller view, in RTL locale, horizontal scroller did not go back to start after a left-right move

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Adjusted qa-a11y layout 


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I could not identify any sandstone/Scroller cause of this issue

### Links
[//]: # (Related issues, references)
NXT-618

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com